### PR TITLE
[KED-3080] Remove click requirement

### DIFF
--- a/kedro-telemetry/requirements.txt
+++ b/kedro-telemetry/requirements.txt
@@ -1,4 +1,3 @@
-click<8.0
 kedro~=0.17.3
 PyYAML>=4.2, <6.0
 requests~=2.25.1

--- a/kedro-telemetry/tests/test_masking.py
+++ b/kedro-telemetry/tests/test_masking.py
@@ -29,6 +29,7 @@ DEFAULT_KEDRO_COMMANDS = [
     "ipython",
     "jupyter",
     "lint",
+    "micropkg",
     "new",
     "package",
     "pipeline",


### PR DESCRIPTION
## Development Notes

_Related to https://github.com/kedro-org/kedro/pull/1260_

`kedro-telemetry` has had an explicit dependency on `click`, which means that if we were to update `click` version on `kedro` now, users wouldn't be able to install `kedro-telemetry` due to a dependency clash. Deleting this so that we rely on whatever `click` version `kedro` is using.

I believe this, including a fix for https://github.com/kedro-org/kedro/issues/1249, would be best included in an upcoming release so we're in a good position for 0.18.

## Testing

_I tested to make sure `click==8.x` still works with telemetry._

Created new conda env where I `pip installed .` kedro from branch above and kedro-telemetry from this branch. Double-checked that `click` was newer version:

```
pip freeze | grep click
```

resulting in:
```
click==8.0.4
```

Running kedro commands in a new project (within the new env) works smoothly. 

Checked Heap data to make sure masking is still working as usual and data is flowing through. Found events sent to dev env on 21st of Feb, and grouping by package name gives the same sha as the name of the package I created for testing. 
![Screenshot 2022-02-22 at 13 38 35](https://user-images.githubusercontent.com/6642900/155143583-a066dbd7-59c3-4fc5-9c0c-5b3620823aca.png)

Filtering on specific command gives the following options (each with at least one event, as I ran all these yesterday)
![Screenshot 2022-02-22 at 13 35 22](https://user-images.githubusercontent.com/6642900/155143476-4f13cfbd-6e28-40e2-bc15-2fdb6b6a8132.png)
