### PR TITLE
Fix connection error issue in telemetry

### DIFF
--- a/kedro-telemetry/kedro_telemetry/plugin.py
+++ b/kedro-telemetry/kedro_telemetry/plugin.py
@@ -155,10 +155,10 @@ def _send_heap_event(
                 resp.status_code,
                 resp.reason,
             )
-    except requests.exceptions.RequestException as e:
+    except requests.exceptions.RequestException as exc:
         logger.warning(
             "Failed to send data to Heap. Exception of type '%s' was raised.",
-            type(e).__name__,
+            type(exc).__name__,
         )
 
 

--- a/kedro-telemetry/kedro_telemetry/plugin.py
+++ b/kedro-telemetry/kedro_telemetry/plugin.py
@@ -145,13 +145,19 @@ def _send_heap_event(
         "properties": properties or {},
     }
 
-    resp = requests.post(url=HEAP_ENDPOINT, headers=HEAP_HEADERS, data=json.dumps(data))
-    if resp.status_code != 200:
+    try:
+        resp = requests.post(url=HEAP_ENDPOINT, headers=HEAP_HEADERS, data=json.dumps(data))
+        if resp.status_code != 200:
+            logger.warning(
+                "Failed to send data to Heap. Response code returned: %s, Response reason: %s",
+                resp.status_code,
+                resp.reason,
+            )
+    except requests.exceptions.RequestException as e:
         logger.warning(
-            "Failed to send data to Heap. Response code returned: %s, Response reason: %s",
-            resp.status_code,
-            resp.reason,
+            "Failed to send data to Heap. Exception of type '%s' raised.", type(e)
         )
+        
 
 
 def _check_for_telemetry_consent(project_path: Path) -> bool:

--- a/kedro-telemetry/kedro_telemetry/plugin.py
+++ b/kedro-telemetry/kedro_telemetry/plugin.py
@@ -146,7 +146,9 @@ def _send_heap_event(
     }
 
     try:
-        resp = requests.post(url=HEAP_ENDPOINT, headers=HEAP_HEADERS, data=json.dumps(data))
+        resp = requests.post(
+            url=HEAP_ENDPOINT, headers=HEAP_HEADERS, data=json.dumps(data)
+        )
         if resp.status_code != 200:
             logger.warning(
                 "Failed to send data to Heap. Response code returned: %s, Response reason: %s",
@@ -155,9 +157,9 @@ def _send_heap_event(
             )
     except requests.exceptions.RequestException as e:
         logger.warning(
-            "Failed to send data to Heap. Exception of type '%s' raised.", type(e)
+            "Failed to send data to Heap. Exception of type '%s' was raised.",
+            type(e).__name__,
         )
-        
 
 
 def _check_for_telemetry_consent(project_path: Path) -> bool:

--- a/kedro-telemetry/tests/test_masking.py
+++ b/kedro-telemetry/tests/test_masking.py
@@ -29,6 +29,7 @@ DEFAULT_KEDRO_COMMANDS = [
     "ipython",
     "jupyter",
     "lint",
+    "micropkg",
     "new",
     "package",
     "pipeline",

--- a/kedro-telemetry/tests/test_plugin.py
+++ b/kedro-telemetry/tests/test_plugin.py
@@ -2,7 +2,6 @@ import socket
 import sys
 from pathlib import Path
 
-import pytest
 import requests
 import yaml
 from kedro import __version__ as kedro_version

--- a/kedro-telemetry/tests/test_plugin.py
+++ b/kedro-telemetry/tests/test_plugin.py
@@ -136,6 +136,19 @@ class TestKedroTelemetryCLIHooks:
 
         mocked_heap_call.assert_not_called()
 
+     def test_before_command_rin_connection_error(self, mocker, fake_metadata):
+        mocker.patch(
+            "kedro_telemetry.plugin._check_for_telemetry_consent", return_value=True
+        )
+        telemetry_hook = KedroTelemetryCLIHooks()
+        command_args = ["--version"]
+        mocker.patch("requests.post", side_effect=requests.exceptions.ConnectionError)
+        
+        telemetry_hook.before_command_run(fake_metadata, command_args)
+
+        #assert exception
+    
+
     def test_before_command_run_anonymous(self, mocker, fake_metadata):
         mocker.patch(
             "kedro_telemetry.plugin._check_for_telemetry_consent", return_value=True


### PR DESCRIPTION
Two related GH issues:

https://github.com/kedro-org/kedro/issues/1289
https://github.com/kedro-org/kedro/issues/1249

Today - if consent provided, but the user has no access to the internet  an error is raised. This PR introduces a small exception handler that simply raises warnings whenever a `requests.exceptions.RequestException` base exception is raised.
