### PR TITLE
Prepare `kedro-telemetry` for release

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -55,7 +55,7 @@ commands:
           name: Install kedro and test requirements
           command: |
             cd <<parameters.plugin>>
-            pip install git+https://github.com/kedro-org/kedro@develop
+            pip install git+https://github.com/kedro-org/kedro@main
             pip install -r test_requirements.txt
       - run:
           name: Install pre-commit hooks
@@ -106,7 +106,7 @@ commands:
             conda activate kedro_plugins
             cd <<parameters.plugin>>
             python -m pip install -U pip setuptools wheel
-            pip install git+https://github.com/kedro-org/kedro@develop
+            pip install git+https://github.com/kedro-org/kedro@main
             pip install -r test_requirements.txt -U
       - run:
           name: Pip freeze

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -200,12 +200,12 @@ workflows:
           plugin: "kedro-telemetry"
           matrix:
             parameters:
-              python_version: ["3.6", "3.7", "3.8"]
+              python_version: ["3.7", "3.8", "3.9", "3.10"]
       - win_unit_tests:
           plugin: "kedro-telemetry"
           matrix:
             parameters:
-              python_version: ["3.6", "3.7", "3.8"]
+              python_version: ["3.7", "3.8", "3.9", "3.10"]
       - lint:
           plugin: "kedro-telemetry"
   # when pipeline parameter, run-build-kedro-docker is true, the

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -106,7 +106,7 @@ commands:
             conda activate kedro_plugins
             cd <<parameters.plugin>>
             python -m pip install -U pip setuptools wheel
-            pip install git+https://github.com/kedro-org/kedro@main
+            pip install git+https://github.com/kedro-org/kedro@develop
             pip install -r test_requirements.txt -U
       - run:
           name: Pip freeze

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -55,7 +55,7 @@ commands:
           name: Install kedro and test requirements
           command: |
             cd <<parameters.plugin>>
-            pip install git+https://github.com/kedro-org/kedro@main
+            pip install git+https://github.com/kedro-org/kedro@develop
             pip install -r test_requirements.txt
       - run:
           name: Install pre-commit hooks

--- a/kedro-telemetry/requirements.txt
+++ b/kedro-telemetry/requirements.txt
@@ -1,3 +1,3 @@
-kedro~=0.17.3
+git+https://github.com/kedro-org/kedro.git@develop#egg=kedro
 PyYAML>=4.2, <6.0
 requests~=2.25.1

--- a/kedro-telemetry/setup.py
+++ b/kedro-telemetry/setup.py
@@ -28,7 +28,7 @@ setup(
     long_description_content_type="text/markdown",
     url="https://github.com/kedro-org/kedro-plugins/tree/main/kedro-telemetry",
     author="Kedro",
-    python_requires=">=3.6, <3.9",
+    python_requires=">=3.7, <3.11",
     install_requires=requires,
     license="Apache Software License (Apache 2.0)",
     packages=["kedro_telemetry"],

--- a/kedro-telemetry/test_requirements.txt
+++ b/kedro-telemetry/test_requirements.txt
@@ -4,7 +4,6 @@ black~=22.0
 flake8
 isort>=4.3.21, <5.0
 pre-commit>=1.17.0, <2.0
-psutil
 pylint>=2.5.2, <3.0
 pytest
 pytest-cov

--- a/kedro-telemetry/test_requirements.txt
+++ b/kedro-telemetry/test_requirements.txt
@@ -4,7 +4,7 @@ black~=22.0
 flake8
 isort>=4.3.21, <5.0
 pre-commit>=1.17.0, <2.0
-psutil==5.6.6
+psutil
 pylint>=2.5.2, <3.0
 pytest
 pytest-cov

--- a/kedro-telemetry/test_requirements.txt
+++ b/kedro-telemetry/test_requirements.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 bandit>=1.6.2, <2.0
-black==v19.10.b0
+black~=22.0
 flake8
 isort>=4.3.21, <5.0
 pre-commit>=1.17.0, <2.0

--- a/kedro-telemetry/tests/test_masking.py
+++ b/kedro-telemetry/tests/test_masking.py
@@ -25,7 +25,6 @@ DEFAULT_KEDRO_COMMANDS = [
     "build-docs",
     "build-reqs",
     "catalog",
-    "install",
     "ipython",
     "jupyter",
     "lint",


### PR DESCRIPTION
## Description
First step to preparing `kedro-telemetry` for release when Kedro `0.18.0` is released. 

## Development notes

Temporarily pinned to use kedro from develop to make sure everything works. Will revert this and point to kedro 0.18.0 when it's released. 
- [X]  Add compatibility with python 3.9 + 3.10
- [X]  Remove support for python 3.6

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
