### PR TITLE
Prepare `kedro-docker` for release

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -55,7 +55,7 @@ commands:
           name: Install kedro and test requirements
           command: |
             cd <<parameters.plugin>>
-            pip install git+https://github.com/kedro-org/kedro@develop
+            pip install git+https://github.com/kedro-org/kedro@main
             pip install -r test_requirements.txt
       - run:
           name: Install pre-commit hooks
@@ -106,7 +106,7 @@ commands:
             conda activate kedro_plugins
             cd <<parameters.plugin>>
             python -m pip install -U pip setuptools wheel
-            pip install git+https://github.com/kedro-org/kedro@develop
+            pip install git+https://github.com/kedro-org/kedro@main
             pip install -r test_requirements.txt -U
       - run:
           name: Pip freeze

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -55,7 +55,7 @@ commands:
           name: Install kedro and test requirements
           command: |
             cd <<parameters.plugin>>
-            pip install git+https://github.com/kedro-org/kedro@main
+            pip install git+https://github.com/kedro-org/kedro@develop
             pip install -r test_requirements.txt
       - run:
           name: Install pre-commit hooks
@@ -106,7 +106,7 @@ commands:
             conda activate kedro_plugins
             cd <<parameters.plugin>>
             python -m pip install -U pip setuptools wheel
-            pip install git+https://github.com/kedro-org/kedro@main
+            pip install git+https://github.com/kedro-org/kedro@develop
             pip install -r test_requirements.txt -U
       - run:
           name: Pip freeze
@@ -217,17 +217,17 @@ workflows:
           plugin: "kedro-docker"
           matrix:
             parameters:
-              python_version: ["3.6", "3.7", "3.8"]
+              python_version: ["3.7", "3.8", "3.9", "3.10"]
       - e2e_tests:
           plugin: "kedro-docker"
           matrix:
             parameters:
-              python_version: ["3.6", "3.7", "3.8"]
+              python_version: ["3.7", "3.8", "3.9", "3.10"]
       - win_unit_tests:
           plugin: "kedro-docker"
           matrix:
             parameters:
-              python_version: ["3.6", "3.7", "3.8"]
+              python_version: ["3.7", "3.8", "3.9", "3.10"]
       - lint:
           plugin: "kedro-docker"
   # when pipeline parameter, run-build-kedro-airflow is true, the

--- a/kedro-docker/features/docker.feature
+++ b/kedro-docker/features/docker.feature
@@ -3,7 +3,7 @@
 Feature: Docker commands in new projects
   Background:
     Given I have prepared a config file
-    And I run a non-interactive kedro new with starter
+    And I run a non-interactive kedro new
     And I have fixed logs write permission
     And I have installed the project dependencies
     And I have removed old docker image of test project

--- a/kedro-docker/features/docker.feature
+++ b/kedro-docker/features/docker.feature
@@ -58,7 +58,7 @@ Feature: Docker commands in new projects
 
   Scenario: Execute docker run in parallel mode
     Given I have executed the kedro command "docker build"
-    When I execute the kedro command "docker run --parallel"
+    When I execute the kedro command "docker run --runner=ParallelRunner"
     Then I should get a successful exit code
     And I should get a message including "kedro.runner.parallel_runner - INFO - Pipeline execution completed successfully"
 

--- a/kedro-docker/features/docker.feature
+++ b/kedro-docker/features/docker.feature
@@ -5,7 +5,7 @@ Feature: Docker commands in new projects
     Given I have prepared a config file
     And I run a non-interactive kedro new with starter
     And I have fixed logs write permission
-    And I have executed the kedro command "install"
+    And I have installed the project dependencies
     And I have removed old docker image of test project
 
   Scenario: Execute docker init

--- a/kedro-docker/features/docker.feature
+++ b/kedro-docker/features/docker.feature
@@ -3,7 +3,7 @@
 Feature: Docker commands in new projects
   Background:
     Given I have prepared a config file
-    And I run a non-interactive kedro new
+    And I run a non-interactive kedro new with starter
     And I have fixed logs write permission
     And I have installed the project dependencies
     And I have removed old docker image of test project

--- a/kedro-docker/features/docker.feature
+++ b/kedro-docker/features/docker.feature
@@ -118,7 +118,7 @@ Feature: Docker commands in new projects
     When I execute the kedro command "docker ipython"
     Then I should see messages from docker ipython startup including "An enhanced Interactive Python"
     And  I should see messages from docker ipython startup including "INFO - ** Kedro project project-dummy"
-    And  I should see messages from docker ipython startup including "Starting a Kedro session with the following variables in scope"
+    And  I should see messages from docker ipython startup including "Defined global variable `context`, `session`, `catalog` and `pipelines`"
 
   Scenario: Execute docker run target without building image
     When I execute the kedro command "docker run"

--- a/kedro-docker/features/steps/cli_steps.py
+++ b/kedro-docker/features/steps/cli_steps.py
@@ -176,6 +176,20 @@ def exec_kedro_command(context, command):
         print(res.stderr)
         assert False
 
+@given("I have installed the project dependencies")
+def pip_install_dependencies(context):
+    """Install project dependencies using pip."""
+    reqs_path = "src/requirements.txt"
+    res = run(
+        [context.pip, "install", "-r", reqs_path],
+        env=context.env,
+        cwd=str(context.root_project_dir),
+    )
+
+    if res.returncode != OK_EXIT_CODE:
+        print(res.stdout)
+        print(res.stderr)
+        assert False
 
 @given("I have removed old docker image of test project")
 def remove_old_docker_images(context):

--- a/kedro-docker/features/steps/cli_steps.py
+++ b/kedro-docker/features/steps/cli_steps.py
@@ -180,7 +180,7 @@ def exec_kedro_command(context, command):
 @given("I have installed the project dependencies")
 def pip_install_dependencies(context):
     """Install project dependencies using pip."""
-    reqs_path = "src/requirements.txt"
+    reqs_path = Path("src", "requirements.txt")
     res = run(
         [context.pip, "install", "-r", reqs_path],
         env=context.env,

--- a/kedro-docker/features/steps/cli_steps.py
+++ b/kedro-docker/features/steps/cli_steps.py
@@ -182,7 +182,7 @@ def pip_install_dependencies(context):
     """Install project dependencies using pip."""
     reqs_path = Path("src", "requirements.txt")
     res = run(
-        [context.pip, "install", "-r", reqs_path],
+        [context.pip, "install", "-r", str(reqs_path)],
         env=context.env,
         cwd=str(context.root_project_dir),
     )

--- a/kedro-docker/features/steps/cli_steps.py
+++ b/kedro-docker/features/steps/cli_steps.py
@@ -176,6 +176,7 @@ def exec_kedro_command(context, command):
         print(res.stderr)
         assert False
 
+
 @given("I have installed the project dependencies")
 def pip_install_dependencies(context):
     """Install project dependencies using pip."""
@@ -190,6 +191,7 @@ def pip_install_dependencies(context):
         print(res.stdout)
         print(res.stderr)
         assert False
+
 
 @given("I have removed old docker image of test project")
 def remove_old_docker_images(context):

--- a/kedro-docker/features/steps/cli_steps.py
+++ b/kedro-docker/features/steps/cli_steps.py
@@ -140,7 +140,7 @@ def modify_write_permission(context):
     journal_dir.chmod(0o777)
 
 
-@given("I run a non-interactive kedro new with starter")
+@given("I run a non-interactive kedro new")
 def create_project_from_config_file(context):
     """Behave step to run kedro new
     given the config I previously created.
@@ -151,8 +151,6 @@ def create_project_from_config_file(context):
             "new",
             "-c",
             str(context.config_file),
-            "--starter",
-            "pandas-iris",
         ],
         env=context.env,
         cwd=str(context.temp_dir),

--- a/kedro-docker/features/steps/cli_steps.py
+++ b/kedro-docker/features/steps/cli_steps.py
@@ -178,9 +178,9 @@ def exec_kedro_command(context, command):
 @given("I have installed the project dependencies")
 def pip_install_dependencies(context):
     """Install project dependencies using pip."""
-    reqs_path = "src/requirements.txt"
+    reqs_path = Path("src", "requirements.txt")
     res = run(
-        [context.pip, "install", "-r", reqs_path],
+        [context.pip, "install", "-r", str(reqs_path)],
         env=context.env,
         cwd=str(context.root_project_dir),
     )

--- a/kedro-docker/features/steps/cli_steps.py
+++ b/kedro-docker/features/steps/cli_steps.py
@@ -180,9 +180,9 @@ def exec_kedro_command(context, command):
 @given("I have installed the project dependencies")
 def pip_install_dependencies(context):
     """Install project dependencies using pip."""
-    reqs_path = Path("src", "requirements.txt")
+    reqs_path = "src/requirements.txt"
     res = run(
-        [context.pip, "install", "-r", str(reqs_path)],
+        [context.pip, "install", "-r", reqs_path],
         env=context.env,
         cwd=str(context.root_project_dir),
     )

--- a/kedro-docker/features/steps/cli_steps.py
+++ b/kedro-docker/features/steps/cli_steps.py
@@ -140,7 +140,7 @@ def modify_write_permission(context):
     journal_dir.chmod(0o777)
 
 
-@given("I run a non-interactive kedro new")
+@given("I run a non-interactive kedro new with starter")
 def create_project_from_config_file(context):
     """Behave step to run kedro new
     given the config I previously created.
@@ -151,6 +151,8 @@ def create_project_from_config_file(context):
             "new",
             "-c",
             str(context.config_file),
+            "--starter",
+            "pandas-iris",
         ],
         env=context.env,
         cwd=str(context.temp_dir),

--- a/kedro-docker/kedro_docker/plugin.py
+++ b/kedro-docker/kedro_docker/plugin.py
@@ -164,14 +164,16 @@ def docker_init(spark):
     type=str,
     default=DEFAULT_BASE_IMAGE,
     show_default=True,
-    help="Base image for Dockerfile.",  # pylint: disable=too-many-arguments
+    help="Base image for Dockerfile.",
 )
 @_make_image_option()
 @_make_docker_args_option(
     help="Optional arguments to be passed to `docker build` command"
 )
 @click.pass_context
-def docker_build(ctx, uid, gid, spark, base_image, image, docker_args):
+def docker_build(
+    ctx, uid, gid, spark, base_image, image, docker_args
+):  # pylint: disable=too-many-arguments
     """Build a Docker image for the project."""
     uid, gid = get_uid_gid(uid, gid)
     project_path = Path.cwd()

--- a/kedro-docker/requirements.txt
+++ b/kedro-docker/requirements.txt
@@ -1,3 +1,3 @@
 anyconfig~=0.10.0 # not directly required, pinned by Snyk to avoid a vulnerability
-git+https://github.com/kedro-org/kedro.git@develop#egg=kedro
+kedro>=0.16.0
 semver~=2.10 # Needs to be at least 2.10.0 to get VersionInfo.match

--- a/kedro-docker/requirements.txt
+++ b/kedro-docker/requirements.txt
@@ -1,3 +1,3 @@
 anyconfig~=0.10.0 # not directly required, pinned by Snyk to avoid a vulnerability
-kedro>=0.16.0
+git+https://github.com/kedro-org/kedro.git@develop#egg=kedro
 semver~=2.10 # Needs to be at least 2.10.0 to get VersionInfo.match

--- a/kedro-docker/setup.py
+++ b/kedro-docker/setup.py
@@ -35,7 +35,7 @@ setup(
     long_description_content_type="text/markdown",
     url="https://github.com/kedro-org/kedro-plugins/tree/main/kedro-docker",
     license="Apache Software License (Apache 2.0)",
-    python_requires=">=3.6, <3.9",
+    python_requires=">=3.7, <3.11",
     install_requires=requires,
     tests_require=test_requires,
     author="Kedro",

--- a/kedro-docker/test_requirements.txt
+++ b/kedro-docker/test_requirements.txt
@@ -7,9 +7,9 @@ flake8>=3.5, <4.0
 pre-commit>=1.17.0, <2.0
 psutil
 pylint>=2.4.4, <3.0
-pytest-cov>=2.7.1, <3.0
-pytest-mock>=1.10.4, <2.0
-pytest>=4.4.2, <5.0
+pytest-cov
+pytest-mock
+pytest
 PyYAML>=5.1, <6.0
 trufflehog>=2.0.99, <3.0
 wheel==0.32.2

--- a/kedro-docker/test_requirements.txt
+++ b/kedro-docker/test_requirements.txt
@@ -1,11 +1,11 @@
 -r requirements.txt
 bandit>=1.6.2, <2.0
 behave>=1.2.6, <2.0
-black==v19.10.b0
+black~=22.0
 docker
 flake8>=3.5, <4.0
 pre-commit>=1.17.0, <2.0
-psutil==5.6.6
+psutil
 pylint>=2.4.4, <3.0
 pytest-cov>=2.7.1, <3.0
 pytest-mock>=1.10.4, <2.0

--- a/kedro-docker/test_requirements.txt
+++ b/kedro-docker/test_requirements.txt
@@ -7,9 +7,9 @@ flake8>=3.5, <4.0
 pre-commit>=1.17.0, <2.0
 psutil
 pylint>=2.4.4, <3.0
+pytest
 pytest-cov
 pytest-mock
-pytest
 PyYAML>=5.1, <6.0
 trufflehog>=2.0.99, <3.0
 wheel==0.32.2


### PR DESCRIPTION
Signed-off-by: Merel Theisen <merel.theisen@quantumblack.com>

## Description
First step to preparing `kedro-docker` for release when Kedro 0.18.0 is released.

## Development notes
- [x] Add compatibility with python 3.9 + 3.10
- [x] Remove support for python 3.6

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
