### PR TITLE
Prevent Telemetry breaking Kedro when no write permissions

### DIFF
--- a/kedro-telemetry/RELEASE.md
+++ b/kedro-telemetry/RELEASE.md
@@ -1,7 +1,10 @@
 # Release 0.2.0
+
+## Bug fixes and other changes
 * Add compatibility with `kedro` 0.18.0
 * Add compatibility with Python 3.9 and 3.10
 * Remove compatibility with Python 3.6
+* `kedro telemetry` raising errors will no longer stop `kedro` running pipelines. 
 
 # Release 0.1.4
 

--- a/kedro-telemetry/RELEASE.md
+++ b/kedro-telemetry/RELEASE.md
@@ -4,7 +4,7 @@
 * Add compatibility with `kedro` 0.18.0
 * Add compatibility with Python 3.9 and 3.10
 * Remove compatibility with Python 3.6
-* `kedro telemetry` raising errors will no longer stop `kedro` running pipelines. 
+* `kedro telemetry` raising errors will no longer stop `kedro` running pipelines.
 
 # Release 0.1.4
 

--- a/kedro-telemetry/RELEASE.md
+++ b/kedro-telemetry/RELEASE.md
@@ -1,10 +1,14 @@
+# Release 0.2.1
+
+## Bug fixes and other changes
+* `kedro telemetry` raising errors will no longer stop `kedro` running pipelines.
+
 # Release 0.2.0
 
 ## Bug fixes and other changes
 * Add compatibility with `kedro` 0.18.0
 * Add compatibility with Python 3.9 and 3.10
 * Remove compatibility with Python 3.6
-* `kedro telemetry` raising errors will no longer stop `kedro` running pipelines.
 
 # Release 0.1.4
 

--- a/kedro-telemetry/kedro_telemetry/plugin.py
+++ b/kedro-telemetry/kedro_telemetry/plugin.py
@@ -180,21 +180,28 @@ def _is_valid_syntax(telemetry: Any) -> bool:
 
 
 def _confirm_consent(telemetry_file_path: Path) -> bool:
-    with telemetry_file_path.open("w") as telemetry_file:
-        confirm_msg = (
-            "As an open-source project, we collect usage analytics. \n"
-            "We cannot see nor store information contained in "
-            "a Kedro project. \nYou can find out more by reading our "
-            "privacy notice: \n"
-            "https://github.com/kedro-org/kedro-plugins/tree/main/kedro-telemetry#privacy-notice \n"
-            "Do you opt into usage analytics? "
+    try:
+        with telemetry_file_path.open("w") as telemetry_file:
+            confirm_msg = (
+                "As an open-source project, we collect usage analytics. \n"
+                "We cannot see nor store information contained in "
+                "a Kedro project. \nYou can find out more by reading our "
+                "privacy notice: \n"
+                "https://github.com/kedro-org/kedro-plugins/tree/main/kedro-telemetry#privacy-notice \n"
+                "Do you opt into usage analytics? "
+            )
+            if click.confirm(confirm_msg):
+                yaml.dump({"consent": True}, telemetry_file)
+                click.secho("You have opted into product usage analytics.", fg="green")
+                return True
+            yaml.dump({"consent": False}, telemetry_file)
+            return False
+    except Exception as exc:
+        logger.warning(
+            "Failed to confirm consent.",
+            "Exception: %s",
+            exc,
         )
-        if click.confirm(confirm_msg):
-            yaml.dump({"consent": True}, telemetry_file)
-            click.secho("You have opted into product usage analytics.", fg="green")
-            return True
-        yaml.dump({"consent": False}, telemetry_file)
-        return False
 
 
 cli_hooks = KedroTelemetryCLIHooks()

--- a/kedro-telemetry/kedro_telemetry/plugin.py
+++ b/kedro-telemetry/kedro_telemetry/plugin.py
@@ -17,6 +17,7 @@ import yaml
 from kedro.framework.cli.cli import KedroCLI
 from kedro.framework.cli.hooks import cli_hook_impl
 from kedro.framework.startup import ProjectMetadata
+
 from kedro_telemetry import __version__ as telemetry_version
 from kedro_telemetry.masking import _get_cli_structure, _mask_kedro_cli
 
@@ -204,8 +205,7 @@ def _confirm_consent(telemetry_file_path: Path) -> bool:
             return False
     except Exception as exc:  # pylint: disable=broad-except
         logger.warning(
-            "Failed to confirm consent. Exception: %s",
-            exc,
+            "Failed to confirm consent. Exception: %s", exc,
         )
         return False
 

--- a/kedro-telemetry/kedro_telemetry/plugin.py
+++ b/kedro-telemetry/kedro_telemetry/plugin.py
@@ -17,7 +17,6 @@ import yaml
 from kedro.framework.cli.cli import KedroCLI
 from kedro.framework.cli.hooks import cli_hook_impl
 from kedro.framework.startup import ProjectMetadata
-
 from kedro_telemetry import __version__ as telemetry_version
 from kedro_telemetry.masking import _get_cli_structure, _mask_kedro_cli
 
@@ -205,7 +204,8 @@ def _confirm_consent(telemetry_file_path: Path) -> bool:
             return False
     except Exception as exc:  # pylint: disable=broad-except
         logger.warning(
-            "Failed to confirm consent. Exception: %s", exc,
+            "Failed to confirm consent. Exception: %s",
+            exc,
         )
         return False
 

--- a/kedro-telemetry/kedro_telemetry/plugin.py
+++ b/kedro-telemetry/kedro_telemetry/plugin.py
@@ -91,7 +91,7 @@ class KedroTelemetryCLIHooks:
                 identity=hashed_computer_name.hexdigest(),
                 properties=generic_properties,
             )
-        except Exception as exc: # pylint: disable=broad-except
+        except Exception as exc:  # pylint: disable=broad-except
             logger.warning(
                 "Something went wrong in hook implementation to send command run data to Heap. "
                 "Exception: %s",
@@ -205,8 +205,7 @@ def _confirm_consent(telemetry_file_path: Path) -> bool:
             return False
     except Exception as exc:  # pylint: disable=broad-except
         logger.warning(
-            "Failed to confirm consent. Exception: %s",
-            exc,
+            "Failed to confirm consent. Exception: %s", exc,
         )
         return False
 

--- a/kedro-telemetry/kedro_telemetry/plugin.py
+++ b/kedro-telemetry/kedro_telemetry/plugin.py
@@ -187,7 +187,8 @@ def _confirm_consent(telemetry_file_path: Path) -> bool:
                 "We cannot see nor store information contained in "
                 "a Kedro project. \nYou can find out more by reading our "
                 "privacy notice: \n"
-                "https://github.com/kedro-org/kedro-plugins/tree/main/kedro-telemetry#privacy-notice \n"
+                "https://github.com/kedro-org/kedro-plugins/tree/main/kedro-telemetry#"
+                "privacy-notice \n"
                 "Do you opt into usage analytics? "
             )
             if click.confirm(confirm_msg):
@@ -196,12 +197,12 @@ def _confirm_consent(telemetry_file_path: Path) -> bool:
                 return True
             yaml.dump({"consent": False}, telemetry_file)
             return False
-    except Exception as exc:
+    except Exception as exc:  # pylint: disable=broad-except
         logger.warning(
-            "Failed to confirm consent.",
-            "Exception: %s",
+            "Failed to confirm consent. Exception: %s",
             exc,
         )
+        return False
 
 
 cli_hooks = KedroTelemetryCLIHooks()

--- a/kedro-telemetry/kedro_telemetry/plugin.py
+++ b/kedro-telemetry/kedro_telemetry/plugin.py
@@ -205,7 +205,7 @@ def _confirm_consent(telemetry_file_path: Path) -> bool:
             return False
     except Exception as exc:  # pylint: disable=broad-except
         logger.warning(
-            "Failed to confirm consent. Exception: %s",
+            "Failed to confirm consent. No data was sent to Heap. Exception: %s",
             exc,
         )
         return False

--- a/kedro-telemetry/kedro_telemetry/plugin.py
+++ b/kedro-telemetry/kedro_telemetry/plugin.py
@@ -17,6 +17,7 @@ import yaml
 from kedro.framework.cli.cli import KedroCLI
 from kedro.framework.cli.hooks import cli_hook_impl
 from kedro.framework.startup import ProjectMetadata
+
 from kedro_telemetry import __version__ as telemetry_version
 from kedro_telemetry.masking import _get_cli_structure, _mask_kedro_cli
 

--- a/kedro-telemetry/tests/test_masking.py
+++ b/kedro-telemetry/tests/test_masking.py
@@ -9,6 +9,7 @@ import pytest
 from kedro import __version__ as kedro_version
 from kedro.framework.cli.cli import KedroCLI, cli
 from kedro.framework.startup import ProjectMetadata
+
 from kedro_telemetry.masking import (
     MASK,
     _get_cli_structure,

--- a/kedro-telemetry/tests/test_masking.py
+++ b/kedro-telemetry/tests/test_masking.py
@@ -9,7 +9,6 @@ import pytest
 from kedro import __version__ as kedro_version
 from kedro.framework.cli.cli import KedroCLI, cli
 from kedro.framework.startup import ProjectMetadata
-
 from kedro_telemetry.masking import (
     MASK,
     _get_cli_structure,

--- a/kedro-telemetry/tests/test_plugin.py
+++ b/kedro-telemetry/tests/test_plugin.py
@@ -207,7 +207,8 @@ class TestKedroTelemetryCLIHooks:
         command_args = ["--version"]
         
         telemetry_hook.before_command_run(fake_metadata, command_args)
-        msg = "Something went wrong in hook implementation to send command run data to Heap. Exception:"
+        msg = "Something went wrong in hook implementation to send command run data to" \
+              " Heap. Exception:"
         assert msg in caplog.messages[-1]
         mocked_heap_call.assert_called()
 

--- a/kedro-telemetry/tests/test_plugin.py
+++ b/kedro-telemetry/tests/test_plugin.py
@@ -196,7 +196,7 @@ class TestKedroTelemetryCLIHooks:
         ]
         assert mocked_heap_call.call_args_list == expected_calls
 
-    def test_before_command_run_heap_call_error(self, mocker, fake_metadata):
+    def test_before_command_run_heap_call_error(self, mocker, fake_metadata, caplog):
         mocker.patch(
             "kedro_telemetry.plugin._check_for_telemetry_consent", return_value=True
         )
@@ -205,8 +205,10 @@ class TestKedroTelemetryCLIHooks:
         )
         telemetry_hook = KedroTelemetryCLIHooks()
         command_args = ["--version"]
-
+        
         telemetry_hook.before_command_run(fake_metadata, command_args)
+        msg = "Something went wrong in hook implementation to send command run data to Heap. Exception:"
+        assert msg in caplog.messages[-1]
         mocked_heap_call.assert_called()
 
     def test_check_for_telemetry_consent_given(self, mocker, fake_metadata):
@@ -276,9 +278,13 @@ class TestKedroTelemetryCLIHooks:
         assert _check_for_telemetry_consent(fake_metadata.project_path)
         mock_create_file.assert_called_once_with(telemetry_file_path)
 
-    def test_confirm_consent_yaml_dump_error(self, mocker, fake_metadata):
+    def test_confirm_consent_yaml_dump_error(self, mocker, fake_metadata, caplog):
         Path(fake_metadata.project_path, "conf").mkdir(parents=True)
         telemetry_file_path = fake_metadata.project_path / ".telemetry"
         mocker.patch("yaml.dump", side_effect=Exception)
 
         assert not _confirm_consent(telemetry_file_path)
+
+        msg = "Failed to confirm consent. No data was sent to Heap. Exception: " \
+              "pytest: reading from stdin while output is captured!  Consider using `-s`."
+        assert msg in caplog.messages[-1]

--- a/kedro-telemetry/tests/test_plugin.py
+++ b/kedro-telemetry/tests/test_plugin.py
@@ -6,13 +6,14 @@ import requests
 import yaml
 from kedro import __version__ as kedro_version
 from kedro.framework.startup import ProjectMetadata
+from pytest import fixture
+
 from kedro_telemetry import __version__ as telemetry_version
 from kedro_telemetry.plugin import (
     KedroTelemetryCLIHooks,
     _check_for_telemetry_consent,
     _confirm_consent,
 )
-from pytest import fixture
 
 REPO_NAME = "dummy_project"
 PACKAGE_NAME = "dummy_package"

--- a/kedro-telemetry/tests/test_plugin.py
+++ b/kedro-telemetry/tests/test_plugin.py
@@ -205,10 +205,12 @@ class TestKedroTelemetryCLIHooks:
         )
         telemetry_hook = KedroTelemetryCLIHooks()
         command_args = ["--version"]
-        
+
         telemetry_hook.before_command_run(fake_metadata, command_args)
-        msg = "Something went wrong in hook implementation to send command run data to" \
-              " Heap. Exception:"
+        msg = (
+            "Something went wrong in hook implementation to send command run data to"
+            " Heap. Exception:"
+        )
         assert msg in caplog.messages[-1]
         mocked_heap_call.assert_called()
 
@@ -286,6 +288,8 @@ class TestKedroTelemetryCLIHooks:
 
         assert not _confirm_consent(telemetry_file_path)
 
-        msg = "Failed to confirm consent. No data was sent to Heap. Exception: " \
-              "pytest: reading from stdin while output is captured!  Consider using `-s`."
+        msg = (
+            "Failed to confirm consent. No data was sent to Heap. Exception: "
+            "pytest: reading from stdin while output is captured!  Consider using `-s`."
+        )
         assert msg in caplog.messages[-1]

--- a/kedro-telemetry/tests/test_plugin.py
+++ b/kedro-telemetry/tests/test_plugin.py
@@ -6,14 +6,13 @@ import requests
 import yaml
 from kedro import __version__ as kedro_version
 from kedro.framework.startup import ProjectMetadata
-from pytest import fixture
-
 from kedro_telemetry import __version__ as telemetry_version
 from kedro_telemetry.plugin import (
     KedroTelemetryCLIHooks,
     _check_for_telemetry_consent,
     _confirm_consent,
 )
+from pytest import fixture
 
 REPO_NAME = "dummy_project"
 PACKAGE_NAME = "dummy_package"

--- a/kedro-telemetry/tests/test_plugin.py
+++ b/kedro-telemetry/tests/test_plugin.py
@@ -9,7 +9,7 @@ from kedro.framework.startup import ProjectMetadata
 from pytest import fixture
 
 from kedro_telemetry import __version__ as telemetry_version
-from kedro_telemetry.plugin import KedroTelemetryCLIHooks, _check_for_telemetry_consent
+from kedro_telemetry.plugin import KedroTelemetryCLIHooks, _check_for_telemetry_consent, _confirm_consent
 
 REPO_NAME = "dummy_project"
 PACKAGE_NAME = "dummy_package"
@@ -192,6 +192,18 @@ class TestKedroTelemetryCLIHooks:
         ]
         assert mocked_heap_call.call_args_list == expected_calls
 
+    def test_before_command_run_heap_call_error(self, mocker, fake_metadata, caplog):
+        mocker.patch(
+            "kedro_telemetry.plugin._check_for_telemetry_consent", return_value=True
+        )
+        mocked_heap_call = mocker.patch("kedro_telemetry.plugin._send_heap_event", side_effect=Exception)
+        telemetry_hook = KedroTelemetryCLIHooks()
+        command_args = ["--version"]
+
+        telemetry_hook.before_command_run(fake_metadata, command_args)
+        mocked_heap_call.assert_called()
+
+
     def test_check_for_telemetry_consent_given(self, mocker, fake_metadata):
         Path(fake_metadata.project_path, "conf").mkdir(parents=True)
         telemetry_file_path = fake_metadata.project_path / ".telemetry"
@@ -258,3 +270,10 @@ class TestKedroTelemetryCLIHooks:
 
         assert _check_for_telemetry_consent(fake_metadata.project_path)
         mock_create_file.assert_called_once_with(telemetry_file_path)
+
+    def test_confirm_consent_yaml_dump_error(self, mocker, fake_metadata):
+        Path(fake_metadata.project_path, "conf").mkdir(parents=True)
+        telemetry_file_path = fake_metadata.project_path / ".telemetry"
+        mocker.patch("yaml.dump", side_effect=Exception)
+
+        assert not _confirm_consent(telemetry_file_path)

--- a/kedro-telemetry/tests/test_plugin.py
+++ b/kedro-telemetry/tests/test_plugin.py
@@ -9,7 +9,11 @@ from kedro.framework.startup import ProjectMetadata
 from pytest import fixture
 
 from kedro_telemetry import __version__ as telemetry_version
-from kedro_telemetry.plugin import KedroTelemetryCLIHooks, _check_for_telemetry_consent, _confirm_consent
+from kedro_telemetry.plugin import (
+    KedroTelemetryCLIHooks,
+    _check_for_telemetry_consent,
+    _confirm_consent,
+)
 
 REPO_NAME = "dummy_project"
 PACKAGE_NAME = "dummy_package"
@@ -192,17 +196,18 @@ class TestKedroTelemetryCLIHooks:
         ]
         assert mocked_heap_call.call_args_list == expected_calls
 
-    def test_before_command_run_heap_call_error(self, mocker, fake_metadata, caplog):
+    def test_before_command_run_heap_call_error(self, mocker, fake_metadata):
         mocker.patch(
             "kedro_telemetry.plugin._check_for_telemetry_consent", return_value=True
         )
-        mocked_heap_call = mocker.patch("kedro_telemetry.plugin._send_heap_event", side_effect=Exception)
+        mocked_heap_call = mocker.patch(
+            "kedro_telemetry.plugin._send_heap_event", side_effect=Exception
+        )
         telemetry_hook = KedroTelemetryCLIHooks()
         command_args = ["--version"]
 
         telemetry_hook.before_command_run(fake_metadata, command_args)
         mocked_heap_call.assert_called()
-
 
     def test_check_for_telemetry_consent_given(self, mocker, fake_metadata):
         Path(fake_metadata.project_path, "conf").mkdir(parents=True)


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->

Related issue: https://github.com/kedro-org/kedro-plugins/issues/11

When having no write access in a project, running any kedro command will raise an error with kedro-telemetry which then stops kedro from running everything. A broken kedro-telemetry shouldn't prevent users from using kedro.

## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
