### PR TITLE
Change some of the logging message to `DEBUG`  in `kedro-telemetry`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Kedro-Plugins
 ---
 
-First-party plugins maintained by the Kedro team. 
+First-party plugins maintained by the Kedro team.
 
 The Kedro team maintains the following official Kedro plugins:
 
 * [Kedro-Airflow](https://github.com/kedro-org/kedro-plugins/tree/main/kedro-airflow): Allows users to easily deploy Kedro pipelines as [Apache Airflow](https://github.com/apache/airflow) DAGs.
-  
+
 * [Kedro-Docker](https://github.com/kedro-org/kedro-plugins/tree/main/kedro-docker): Simplifies the process of running a Kedro project within a Docker container.
-  
+
 * [Kedro-Telemetry](https://github.com/kedro-org/kedro-plugins/tree/main/kedro-telemetry): Gathers anonymised usage analytics to help drive future development of Kedro. ***Data will only be collected if consent is given.***

--- a/kedro-telemetry/RELEASE.md
+++ b/kedro-telemetry/RELEASE.md
@@ -2,6 +2,7 @@
 
 ## Bug fixes and other changes
 * `kedro telemetry` raising errors will no longer stop `kedro` running pipelines.
+* Lowered some of the log level to `DEBUG`, so they will not be shown by default.
 
 # Release 0.2.0
 

--- a/kedro-telemetry/kedro_telemetry/plugin.py
+++ b/kedro-telemetry/kedro_telemetry/plugin.py
@@ -54,14 +54,13 @@ class KedroTelemetryCLIHooks:
 
             consent = _check_for_telemetry_consent(project_metadata.project_path)
             if not consent:
-                click.secho(
+                logger.debug(
                     "Kedro-Telemetry is installed, but you have opted out of "
                     "sharing usage analytics so none will be collected.",
-                    fg="green",
                 )
                 return
 
-            logger.info("You have opted into product usage analytics.")
+            logger.debug("You have opted into product usage analytics.")
 
             try:
                 hashed_computer_name = hashlib.sha512(
@@ -201,6 +200,10 @@ def _confirm_consent(telemetry_file_path: Path) -> bool:
                 yaml.dump({"consent": True}, telemetry_file)
                 click.secho("You have opted into product usage analytics.", fg="green")
                 return True
+            click.secho(
+                "You have opted out of product usage analytics, so none will be collected.",
+                fg="green",
+            )
             yaml.dump({"consent": False}, telemetry_file)
             return False
     except Exception as exc:  # pylint: disable=broad-except


### PR DESCRIPTION
Signed-off-by: noklam <nok.lam.chan@quantumblack.com>

## Description
<!-- Why was this PR created? -->
> There's two problems with how kedro-telemetry does logging at the moment:
> 
> 1. [Sometimes it uses `click.secho`](https://github.com/kedro-org/kedro-plugins/blob/main/kedro-telemetry/kedro_telemetry/plugin.py#L57) and [sometimes it uses logging](https://github.com/kedro-org/kedro-plugins/blob/main/kedro-telemetry/kedro_telemetry/plugin.py#L64). This is inconsistent.
> 2. Due to changes in [Improve logging setup in Kedro [parent issue] kedro#1461](https://github.com/kedro-org/kedro/issues/1461), as it stands, no kedro-telemetry logging message that is < WARNING will display now.
> 
> For point 1, technically speaking I think both these message should use `logging.debug` (not info) rather than `click.echo`. Since by default these messages should not show to a user (confirmed by @yetudada in sprint planning) then setting them to use `logging.debug` will make them disappear.
> 
> So all that should be needed here is modifying L64 and L57 to both use `logging.debug`, check that the messages disappear when you do `kedro run`, and update any tests affected.
> 
> Note, as per discussion in [kedro-org/kedro#1546](https://github.com/kedro-org/kedro/pull/1546), at the moment there's no way for a user to change whether or not the kedro-telemetry messages are shown by altering project-side logging.yml because `before_command_run` hooks are run before that logging configuration is set up. This is fine for now.



## Development notes
<!-- What have you changed, and how has this been tested? -->
* Update the logging level to `debug`.
* Add a logging so the message should be shown when the user opt in/out for the first time.

Below are the screenshot for the user journey when they do `kedro run` for the 1st time.
| Opt-in      | Opt-out | 
| :---        |    :----:   | 
| ![image](https://user-images.githubusercontent.com/18221871/170032189-28bc2cdf-28a9-4914-9dac-105eefc232ac.png)     | ![image](https://user-images.githubusercontent.com/18221871/170032286-7600bdf6-70f1-494a-89ca-ea930c1a25f4.png)       | 



## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
