### PR TITLE
Update machine image to ubuntu 20.04

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -120,8 +120,7 @@ jobs:
       plugin:
         type: string
     machine:
-      # Don't use 2018 image: https://discuss.circleci.com/t/24639/18
-      image: circleci/classic:201711-01
+      image: ubuntu-2004:202201-02
       docker_layer_caching: true
     steps:
       - setup:
@@ -138,8 +137,7 @@ jobs:
       plugin:
         type: string
     machine:
-      # Don't use 2018 image: https://discuss.circleci.com/t/24639/18
-      image: circleci/classic:201711-01
+      image: ubuntu-2004:202201-02
       docker_layer_caching: true
     steps:
       - setup:
@@ -154,8 +152,7 @@ jobs:
       plugin:
         type: string
     machine:
-      # Don't use 2018 image: https://discuss.circleci.com/t/24639/18
-      image: circleci/classic:201711-01
+      image: ubuntu-2004:202201-02
       docker_layer_caching: true
     steps:
       - setup:


### PR DESCRIPTION
Signed-off-by: Merel Theisen <merel.theisen@quantumblack.com>

## Description
The machine image we're using to run these builds on CCI will be removed on the 31st of May.

## Development notes
https://circleci.com/docs/2.0/images/linux-vm/14.04-to-20.04-migration/

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
