### PR TITLE
Update airflow tests to latests `pandas-iris`

### DIFF
--- a/kedro-airflow/README.md
+++ b/kedro-airflow/README.md
@@ -1,4 +1,4 @@
-# Kedro-Airflow
+# Kedro-Airflow!
 
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Python Version](https://img.shields.io/badge/python-3.7%20%7C%203.8%20%7C%203.9%20%7C%203.10-blue.svg)](https://pypi.org/project/kedro-airflow/)

--- a/kedro-airflow/README.md
+++ b/kedro-airflow/README.md
@@ -1,4 +1,4 @@
-# Kedro-Airflow!
+# Kedro-Airflow
 
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Python Version](https://img.shields.io/badge/python-3.7%20%7C%203.8%20%7C%203.9%20%7C%203.10-blue.svg)](https://pypi.org/project/kedro-airflow/)

--- a/kedro-airflow/features/airflow.feature
+++ b/kedro-airflow/features/airflow.feature
@@ -11,10 +11,9 @@ Feature: Airflow
     And I have executed the kedro command "airflow create -t ../airflow/dags/"
     When I execute the airflow command "tasks list project-dummy"
     Then I should get a successful exit code
-    And I should get a message including "predict"
-    And I should get a message including "report"
     And I should get a message including "split"
-    And I should get a message including "train"
+    And I should get a message including "make-predictions"
+    And I should get a message including "report-accuracy"
 
   Scenario: Run Airflow task locally with latest Kedro
     Given I have installed kedro version "latest"
@@ -25,4 +24,4 @@ Feature: Airflow
     And I have installed the kedro project package
     When I execute the airflow command "tasks test project-dummy split 2016-06-01T00:00:00+00:00"
     Then I should get a successful exit code
-    And I should get a message including "Loading data from `params:"
+    And I should get a message including "Loading data from `parameters"


### PR DESCRIPTION
## Description
The `pandas-iris` starter was simplified a while back, but we didn't update the tests for `kedro-airflow` that uses the starter.

## Development notes


## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
