### PR TITLE
Create a new package `kedro-datasets` as part of `kedro-plugins`

### DIFF
--- a/kedro-datasets/.gitignore
+++ b/kedro-datasets/.gitignore
@@ -1,0 +1,147 @@
+# CMake
+cmake-build-debug/
+
+## File-based project format:
+*.iws
+
+## Plugin-specific files:
+
+# IntelliJ
+.idea/
+*.iml
+out/
+
+### macOS
+*.DS_Store
+.AppleDouble
+.LSOverride
+.Trashes
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+### Python template
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+.static_storage/
+.media/
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+
+# Visual Studio Code
+.vscode/
+# end to end tests assets
+kedro.db
+
+# Vim
+*~
+.*.swo
+.*.swp
+
+.pytest_cache/
+kedro/html
+docs/tmp-build-artifacts
+docs/build

--- a/kedro-datasets/README.md
+++ b/kedro-datasets/README.md
@@ -1,0 +1,16 @@
+# Kedro-Airflow
+
+[![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![Python Version](https://img.shields.io/badge/python-3.7%20%7C%203.8%20%7C%203.9%20%7C%203.10-blue.svg)](https://pypi.org/project/kedro-datasets/)
+[![PyPI Version](https://badge.fury.io/py/kedro-datasets.svg)](https://pypi.org/project/kedro-datasets/)
+[![Code Style: Black](https://img.shields.io/badge/code%20style-black-black.svg)](https://github.com/ambv/black)
+
+
+## Installation
+
+`kedro-datasets` is a Python plugin. To install it:
+
+```bash
+pip install kedro-datasets
+```
+

--- a/kedro-datasets/RELEASE.md
+++ b/kedro-datasets/RELEASE.md
@@ -1,0 +1,14 @@
+
+## Thanks for supporting contributions
+
+## Major features and improvements
+
+
+# Release 0.1.0:
+
+The initial release of `kedro-datasets`.
+
+## Thanks to our main contributors
+
+
+We are also grateful to everyone who advised and supported us, filed issues or helped resolve them, asked and answered questions and were part of inspiring discussions.

--- a/kedro-datasets/kedro_datasets/__init__.py
+++ b/kedro-datasets/kedro_datasets/__init__.py
@@ -1,0 +1,1 @@
+"""Kedro plugin to support Kedro's DataCatalog"""

--- a/kedro-datasets/setup.cfg
+++ b/kedro-datasets/setup.cfg
@@ -1,0 +1,10 @@
+[metadata]
+description-file=README.md
+
+[tool:pytest]
+addopts=--cov-report xml:coverage.xml
+        --cov-report term-missing
+        --cov kedro_airflow
+        --cov tests
+        --no-cov-on-fail
+        -ra

--- a/kedro-datasets/setup.py
+++ b/kedro-datasets/setup.py
@@ -1,0 +1,47 @@
+import re
+from codecs import open
+from os import path
+
+from setuptools import setup
+
+name = "kedro-airflow"
+here = path.abspath(path.dirname(__file__))
+
+# get package version
+package_name = name.replace("-", "_")
+with open(path.join(here, package_name, "__init__.py"), encoding="utf-8") as f:
+    version = re.search(r'__version__ = ["\']([^"\']+)', f.read()).group(1)
+
+# get the dependencies and installs
+with open("requirements.txt", "r", encoding="utf-8") as f:
+    requires = [x.strip() for x in f if x.strip()]
+
+# get test dependencies and installs
+with open("test_requirements.txt", "r", encoding="utf-8") as f:
+    test_requires = [x.strip() for x in f if x.strip() and not x.startswith("-r")]
+
+
+# Get the long description from the README file
+with open(path.join(here, "README.md"), encoding="utf-8") as f:
+    readme = f.read()
+
+setup(
+    name=name,
+    version=version,
+    description="Kedro-Datasets is the core plugin that support Kedro's DataCatalog",
+    long_description=readme,
+    long_description_content_type="text/markdown",
+    url="https://github.com/kedro-org/kedro-plugins/tree/main/kedro-datasets",
+    author="Kedro",
+    python_requires=">=3.7, <3.11",
+    install_requires=requires,
+    tests_require=test_requires,
+    license="Apache Software License (Apache 2.0)",
+    packages=["kedro_datasets"],
+    # package_data={"kedro_airflow": ["kedro_airflow/airflow_dag_template.j2"]},
+    # include_package_data=True,
+    # zip_safe=False,
+    # entry_points={
+        # "kedro.project_commands": ["airflow = kedro_airflow.plugin:commands"]
+    # },
+)


### PR DESCRIPTION
Signed-off-by: Nok Chan <nok.lam.chan@quantumblack.com>

## Description
<!-- Why was this PR created? -->
The full issues describe this https://github.com/kedro-org/kedro/issues/1492 

> Currently Kedro as a framework and kedro.extras.datasets are one package and this has caused a number of issues:
> * Kedro Framework was held back adding support for Python 3.9/3.10 by breaking changes in the datasets dependencies
> * Adding support for newer versions of the datasets was held back by the need for more conservative versioning of the framework
>  * The difference of breaking change velocity between the Framework (more stable) and the datasets (less stable) meant a painful accounting of what was new in 0.18 and what was merely a change in a dataset

This is the initial attempt to setup the `kedro-datasets` plugins package, which will enable subsequent related works and allow us to migrate all datasets code to this new package.


## Development notes
<!-- What have you changed, and how has this been tested? -->
- [ ] Create the new package in `kedro-plugins`
- [ ] Copy all datasets to the new `kedro-datasets` package including the relevant `extras_require=`
https://github.com/kedro-org/kedro/blob/1b1558952c059eea5636d9ccf9a883f9cf4ef643/setup.py#L107-L148
- [ ] Move all dataset tests to `kedro-datasets`

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
