### PR TITLE
Remove deprecated `tests_require` from `setup.py` in Kedro-Airflow

### DIFF
--- a/kedro-airflow/setup.py
+++ b/kedro-airflow/setup.py
@@ -16,12 +16,7 @@ with open(path.join(here, package_name, "__init__.py"), encoding="utf-8") as f:
 with open("requirements.txt", "r", encoding="utf-8") as f:
     requires = [x.strip() for x in f if x.strip()]
 
-# get test dependencies and installs
-with open("test_requirements.txt", "r", encoding="utf-8") as f:
-    test_requires = [x.strip() for x in f if x.strip() and not x.startswith("-r")]
-
-
-# Get the long description from the README file
+# get the long description from the README file
 with open(path.join(here, "README.md"), encoding="utf-8") as f:
     readme = f.read()
 
@@ -35,7 +30,6 @@ setup(
     author="Kedro",
     python_requires=">=3.7, <3.11",
     install_requires=requires,
-    tests_require=test_requires,
     license="Apache Software License (Apache 2.0)",
     packages=["kedro_airflow"],
     package_data={"kedro_airflow": ["kedro_airflow/airflow_dag_template.j2"]},


### PR DESCRIPTION
## Description
See issue #53 

## Development notes
I have removed tests_require from setup.py

## Checklist

- [NA] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [NA] Updated the documentation to reflect the code changes
- [NA] Added a description of this change in the relevant `RELEASE.md` file
- [NA] Added tests to cover my changes
