### PR TITLE
Expand telemetry to better understand size of kedro projects in the wild

### DIFF
--- a/kedro-telemetry/RELEASE.md
+++ b/kedro-telemetry/RELEASE.md
@@ -1,3 +1,7 @@
+# Release 0.2.3
+## Bug fixes and other changes
+* Expanding to track numbers of datasets, nodes, pipelines to better understand the size of kedro project.
+
 # Release 0.2.2
 
 ## Bug fixes and other changes

--- a/kedro-telemetry/RELEASE.md
+++ b/kedro-telemetry/RELEASE.md
@@ -1,11 +1,8 @@
-# Release 0.2.3
-## Bug fixes and other changes
-* Expanding to track numbers of datasets, nodes, pipelines to better understand the size of kedro project.
-
 # Release 0.2.2
 
 ## Bug fixes and other changes
 * Changed the value associated with the `identity` key in the call to heap's /track endpoint from hashed computer name to hashed username.
+* Expanding to track numbers of datasets, nodes, pipelines to better understand the size of kedro project.
 
 # Release 0.2.1
 

--- a/kedro-telemetry/kedro_telemetry/plugin.py
+++ b/kedro-telemetry/kedro_telemetry/plugin.py
@@ -115,7 +115,7 @@ class KedroTelemetryCLIHooks:
             )
 
 
-class KedroTelemetryHooks:  # pylint: disable=too-few-public-methods
+class KedroTelemetryProjectHooks:  # pylint: disable=too-few-public-methods
     """Hook to send proejct statistics data to Heap"""
 
     project_properties = PROJECT_PROPERTIES if PROJECT_PROPERTIES else {}
@@ -125,7 +125,7 @@ class KedroTelemetryHooks:  # pylint: disable=too-few-public-methods
         """Hook implementation to send proejct statistics data to Heap"""
 
         catalog = context.catalog
-        default_pipeline = pipelines.get("__default__")
+        default_pipeline = pipelines.get("__default__")  # __default__
         hashed_username = _get_hashed_username()
 
         if not self.project_properties:  # `KedroSession.run` without invoking CLI
@@ -186,17 +186,10 @@ def _format_project_statistics_data(
 ):
     """Add project staitsitcs to send to Heap."""
     project_statistics_properties = properties.copy()
-    # Initialize default value
-    project_statistics_properties["number_of_datasets"] = 0
-    project_statistics_properties["number_of_nodes"] = 0
-    project_statistics_properties["number_of_pipelines"] = 0
-
-    # Assign the project statistics
     project_statistics_properties["number_of_datasets"] = len(
         catalog.datasets.__dict__.keys()
     )
-    if default_pipeline:
-        project_statistics_properties["number_of_nodes"] = len(default_pipeline.nodes)
+    project_statistics_properties["number_of_nodes"] = len(default_pipeline.nodes) if default_pipeline else None
     project_statistics_properties["number_of_pipelines"] = len(project_pipelines.keys())
     return project_statistics_properties
 
@@ -287,4 +280,4 @@ def _confirm_consent(telemetry_file_path: Path) -> bool:
 
 
 cli_hooks = KedroTelemetryCLIHooks()
-project_telemetry_hooks = KedroTelemetryHooks()
+project_hooks = KedroTelemetryProjectHooks()

--- a/kedro-telemetry/kedro_telemetry/plugin.py
+++ b/kedro-telemetry/kedro_telemetry/plugin.py
@@ -17,6 +17,7 @@ import yaml
 from kedro.framework.cli.cli import KedroCLI
 from kedro.framework.cli.hooks import cli_hook_impl
 from kedro.framework.hooks import hook_impl
+from kedro.framework.project import pipelines
 from kedro.framework.startup import ProjectMetadata
 from kedro.io.data_catalog import DataCatalog
 from kedro.pipeline import Pipeline
@@ -117,7 +118,6 @@ class KedroTelemetryCLIHooks:
 class KedroTelemetryHooks:
     @hook_impl
     def after_context_created(self, context):
-        from kedro.framework.project import pipelines
 
         catalog = context.catalog
         default_pipeline = pipelines.get("__default__")
@@ -171,10 +171,17 @@ def _format_project_statistics_data(
 ):
     """Add project staitsitcs to send to Heap."""
     project_statistics_properties = properties.copy()
+    # Initialize default value
+    project_statistics_properties["number_of_datasets"] = 0
+    project_statistics_properties["number_of_nodes"] = 0
+    project_statistics_properties["number_of_pipelines"] = 0
+
+    #
     project_statistics_properties["number_of_datasets"] = len(
         catalog.datasets.__dict__.keys()
     )
-    project_statistics_properties["number_of_nodes"] = len(default_pipeline.nodes)
+    if default_pipeline:
+        project_statistics_properties["number_of_nodes"] = len(default_pipeline.nodes)
     project_statistics_properties["number_of_pipelines"] = len(pipelines.keys())
     return project_statistics_properties
 

--- a/kedro-telemetry/kedro_telemetry/plugin.py
+++ b/kedro-telemetry/kedro_telemetry/plugin.py
@@ -115,9 +115,12 @@ class KedroTelemetryCLIHooks:
             )
 
 
-class KedroTelemetryHooks:
+class KedroTelemetryHooks:  # pylint: disable=too-few-public-methods
+    """Hook to send proejct statistics data to Heap"""
+
     @hook_impl
     def after_context_created(self, context):
+        """Hook implementation to send proejct statistics data to Heap"""
 
         catalog = context.catalog
         default_pipeline = pipelines.get("__default__")
@@ -167,7 +170,10 @@ def _format_user_cli_data(
 
 
 def _format_project_statistics_data(
-    properties: dict, catalog: DataCatalog, default_pipeline: Pipeline, pipelines: dict
+    properties: dict,
+    catalog: DataCatalog,
+    default_pipeline: Pipeline,
+    project_pipelines: dict,
 ):
     """Add project staitsitcs to send to Heap."""
     project_statistics_properties = properties.copy()
@@ -182,7 +188,7 @@ def _format_project_statistics_data(
     )
     if default_pipeline:
         project_statistics_properties["number_of_nodes"] = len(default_pipeline.nodes)
-    project_statistics_properties["number_of_pipelines"] = len(pipelines.keys())
+    project_statistics_properties["number_of_pipelines"] = len(project_pipelines.keys())
     return project_statistics_properties
 
 

--- a/kedro-telemetry/kedro_telemetry/plugin.py
+++ b/kedro-telemetry/kedro_telemetry/plugin.py
@@ -49,25 +49,6 @@ except Exception as exc:  # pylint: disable=broad-except
     HASHED_USERNAME = ""
 
 
-class TelemetryHooks:
-    @hook_impl
-    def after_context_created(self, context):
-        from kedro.framework.project import pipelines
-
-        catalog = context.catalog
-        default_pipeline = pipelines.get("__default__")
-
-        project_statistics_properties = _format_project_statistics_data(
-            PROJECT_PROPERTIES, catalog, default_pipeline, pipelines
-        )
-
-        _send_heap_event(
-            event_name="Kedro Project Statistics",
-            identity=HASHED_USERNAME,
-            properties=project_statistics_properties,
-        )
-
-
 class KedroTelemetryCLIHooks:
     """Hook to send CLI command data to Heap"""
 
@@ -126,6 +107,25 @@ class KedroTelemetryCLIHooks:
                 "Exception: %s",
                 exc,
             )
+
+
+class KedroTelemetryHooks:
+    @hook_impl
+    def after_context_created(self, context):
+        from kedro.framework.project import pipelines
+
+        catalog = context.catalog
+        default_pipeline = pipelines.get("__default__")
+
+        project_statistics_properties = _format_project_statistics_data(
+            PROJECT_PROPERTIES, catalog, default_pipeline, pipelines
+        )
+
+        _send_heap_event(
+            event_name="Kedro Project Statistics",
+            identity=HASHED_USERNAME,
+            properties=project_statistics_properties,
+        )
 
 
 def _prepare_project_properties(
@@ -260,4 +260,4 @@ def _confirm_consent(telemetry_file_path: Path) -> bool:
 
 
 cli_hooks = KedroTelemetryCLIHooks()
-project_telemetry_hooks = TelemetryHooks()
+project_telemetry_hooks = KedroTelemetryHooks()

--- a/kedro-telemetry/kedro_telemetry/plugin.py
+++ b/kedro-telemetry/kedro_telemetry/plugin.py
@@ -182,7 +182,7 @@ def _format_project_statistics_data(
     project_statistics_properties["number_of_nodes"] = 0
     project_statistics_properties["number_of_pipelines"] = 0
 
-    #
+    # Assign the project statistics
     project_statistics_properties["number_of_datasets"] = len(
         catalog.datasets.__dict__.keys()
     )

--- a/kedro-telemetry/kedro_telemetry/plugin.py
+++ b/kedro-telemetry/kedro_telemetry/plugin.py
@@ -112,7 +112,7 @@ class KedroTelemetryCLIHooks:
 
 
 class KedroTelemetryProjectHooks:  # pylint: disable=too-few-public-methods
-    """Hook to send proejct statistics data to Heap"""
+    """Hook to send project statistics data to Heap"""
 
     @hook_impl
     def after_context_created(self, context):

--- a/kedro-telemetry/kedro_telemetry/plugin.py
+++ b/kedro-telemetry/kedro_telemetry/plugin.py
@@ -116,7 +116,7 @@ class KedroTelemetryProjectHooks:  # pylint: disable=too-few-public-methods
 
     @hook_impl
     def after_context_created(self, context):
-        """Hook implementation to send proejct statistics data to Heap"""
+        """Hook implementation to send project statistics data to Heap"""
 
         catalog = context.catalog
         default_pipeline = pipelines.get("__default__")  # __default__

--- a/kedro-telemetry/setup.py
+++ b/kedro-telemetry/setup.py
@@ -35,6 +35,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     entry_points={
-        "kedro.cli_hooks": ["kedro-telemetry = kedro_telemetry.plugin:cli_hooks"]
+        "kedro.cli_hooks": ["kedro-telemetry = kedro_telemetry.plugin:cli_hooks"],
+        "kedro.hooks": ["kedro-telemetry = kedro_telemetry.plugin:project_telemetry_hooks"]
     },
 )

--- a/kedro-telemetry/setup.py
+++ b/kedro-telemetry/setup.py
@@ -36,6 +36,6 @@ setup(
     zip_safe=False,
     entry_points={
         "kedro.cli_hooks": ["kedro-telemetry = kedro_telemetry.plugin:cli_hooks"],
-        "kedro.hooks": ["kedro-telemetry = kedro_telemetry.plugin:project_telemetry_hooks"]
+        "kedro.hooks": ["kedro-telemetry = kedro_telemetry.plugin:project_hooks"]
     },
 )

--- a/kedro-telemetry/tests/test_plugin.py
+++ b/kedro-telemetry/tests/test_plugin.py
@@ -14,7 +14,7 @@ from pytest import fixture
 from kedro_telemetry import __version__ as TELEMETRY_VERSION
 from kedro_telemetry.plugin import (
     KedroTelemetryCLIHooks,
-    KedroTelemetryHooks,
+    KedroTelemetryProjectHooks,
     _check_for_telemetry_consent,
     _confirm_consent,
 )
@@ -355,7 +355,7 @@ class TestKedroTelemetryHooks:
         )
 
         # Without CLI invoked - i.e. `session.run` in Jupyter/IPython
-        telemetry_hook = KedroTelemetryHooks()
+        telemetry_hook = KedroTelemetryProjectHooks()
         telemetry_hook.after_context_created(fake_context)
 
         project_properties = {
@@ -410,7 +410,7 @@ class TestKedroTelemetryHooks:
         telemetry_cli_hook.before_command_run(fake_metadata, command_args)
 
         # Follow by project run
-        telemetry_hook = KedroTelemetryHooks()
+        telemetry_hook = KedroTelemetryProjectHooks()
         telemetry_hook.after_context_created(fake_context)
 
         project_properties = {

--- a/kedro-telemetry/tests/test_plugin.py
+++ b/kedro-telemetry/tests/test_plugin.py
@@ -307,7 +307,7 @@ def identity(arg):
 
 
 class TestKedroTelemetryHooks:
-    def test_after_context_created(self, mocker, fake_context, fake_metadata):
+    def test_after_context_created_with_kedro_run(self, mocker, fake_context, fake_metadata):
         mock_default_pipeline = pipeline(
             [
                 node(identity, ["input"], ["intermediate"], name="node0"),
@@ -334,11 +334,15 @@ class TestKedroTelemetryHooks:
         )
 
         mocked_heap_call = mocker.patch("kedro_telemetry.plugin._send_heap_event")
+        # CLI run first
         telemetry_cli_hook = KedroTelemetryCLIHooks()
         command_args = ["--version"]
         telemetry_cli_hook.before_command_run(fake_metadata, command_args)
+
+        # Follow by project run
         telemetry_hook = KedroTelemetryHooks()
         telemetry_hook.after_context_created(fake_context)
+
         project_properties = {
             "username": "hashed_username",
             "package_name": "digested",

--- a/kedro-telemetry/tests/test_plugin.py
+++ b/kedro-telemetry/tests/test_plugin.py
@@ -317,7 +317,7 @@ class TestKedroTelemetryCLIHooks:
     def test_confirm_consent_yaml_dump_error(self, mocker, fake_metadata, caplog):
         Path(fake_metadata.project_path, "conf").mkdir(parents=True)
         telemetry_file_path = fake_metadata.project_path / ".telemetry"
-        mocker.patch("yaml.dump", side_effect=Exception)
+        mocker.patch("yaml.dump", side_efyfect=Exception)
 
         assert not _confirm_consent(telemetry_file_path)
 
@@ -351,7 +351,7 @@ class TestKedroTelemetryHooks:
         )
         mocked_heap_call = mocker.patch("kedro_telemetry.plugin._send_heap_event")
         mocker.patch(
-            "kedro_telemetry.plugin.bootstrap_project", return_value=fake_metadata
+            "kedro_telemetry.plugin._get_project_metadata", return_value=fake_metadata
         )
 
         # Without CLI invoked - i.e. `session.run` in Jupyter/IPython
@@ -404,6 +404,9 @@ class TestKedroTelemetryHooks:
             return_value="hashed_username",
         )
         mocked_heap_call = mocker.patch("kedro_telemetry.plugin._send_heap_event")
+        mocker.patch(
+            "kedro_telemetry.plugin._get_project_metadata", return_value=fake_metadata
+        )
         # CLI run first
         telemetry_cli_hook = KedroTelemetryCLIHooks()
         command_args = ["--version"]

--- a/kedro-telemetry/tests/test_plugin.py
+++ b/kedro-telemetry/tests/test_plugin.py
@@ -8,7 +8,6 @@ from kedro.framework.project import pipelines
 from kedro.framework.startup import ProjectMetadata
 from kedro.io import DataCatalog, MemoryDataSet
 from kedro.pipeline import node, pipeline
-from numpy import fix
 from pytest import fixture
 
 from kedro_telemetry import __version__ as TELEMETRY_VERSION

--- a/kedro-telemetry/tests/test_plugin.py
+++ b/kedro-telemetry/tests/test_plugin.py
@@ -361,5 +361,5 @@ class TestKedroTelemetryHooks:
             properties=expected_properties,
         )
 
-        # The first 2 calls are for CLI
-        assert mocked_heap_call.call_args_list[2] == expected_calls
+        # CLI hook makes the first 2 calls, the 3rd one is the Project hook
+        assert mocked_heap_call.call_args_list[2] == expected_call

--- a/kedro-telemetry/tests/test_plugin.py
+++ b/kedro-telemetry/tests/test_plugin.py
@@ -38,37 +38,41 @@ class TestKedroTelemetryCLIHooks:
         mocker.patch(
             "kedro_telemetry.plugin._check_for_telemetry_consent", return_value=True
         )
-        mocked_anon_id = mocker.patch("hashlib.sha512")
-        mocked_anon_id.return_value.hexdigest.return_value = "digested"
+        mocked_anon_id = mocker.patch("kedro_telemetry.plugin._hash")
+        mocked_anon_id.return_value = "digested"
+        mocked_username = mocker.patch(
+            "kedro_telemetry.plugin._get_hashed_username",
+            return_value="hashed_username",
+        )
 
         mocked_heap_call = mocker.patch("kedro_telemetry.plugin._send_heap_event")
         telemetry_hook = KedroTelemetryCLIHooks()
         command_args = ["--version"]
         telemetry_hook.before_command_run(fake_metadata, command_args)
         expected_properties = {
-            "username": "digested",
-            "command": "kedro --version",
+            "username": "hashed_username",
             "package_name": "digested",
             "project_name": "digested",
             "project_version": kedro_version,
             "telemetry_version": TELEMETRY_VERSION,
             "python_version": sys.version,
             "os": sys.platform,
+            "command": "kedro --version",
         }
         generic_properties = {
-            "main_command": "--version",
             **expected_properties,
+            "main_command": "--version",
         }
 
         expected_calls = [
             mocker.call(
                 event_name="Command run: --version",
-                identity="digested",
+                identity="hashed_username",
                 properties=expected_properties,
             ),
             mocker.call(
                 event_name="CLI command",
-                identity="digested",
+                identity="hashed_username",
                 properties=generic_properties,
             ),
         ]
@@ -78,8 +82,8 @@ class TestKedroTelemetryCLIHooks:
         mocker.patch(
             "kedro_telemetry.plugin._check_for_telemetry_consent", return_value=True
         )
-        mocked_anon_id = mocker.patch("hashlib.sha512")
-        mocked_anon_id.return_value.hexdigest.return_value = "digested"
+        mocked_anon_id = mocker.patch("kedro_telemetry.plugin._hash")
+        mocked_anon_id.return_value = "digested"
 
         mocked_heap_call = mocker.patch("kedro_telemetry.plugin._send_heap_event")
         telemetry_hook = KedroTelemetryCLIHooks()
@@ -87,13 +91,13 @@ class TestKedroTelemetryCLIHooks:
         telemetry_hook.before_command_run(fake_metadata, command_args)
         expected_properties = {
             "username": "digested",
-            "command": "kedro",
             "package_name": "digested",
             "project_name": "digested",
             "project_version": kedro_version,
             "telemetry_version": TELEMETRY_VERSION,
             "python_version": sys.version,
             "os": sys.platform,
+            "command": "kedro",
         }
         generic_properties = {
             "main_command": "kedro",
@@ -146,8 +150,8 @@ class TestKedroTelemetryCLIHooks:
         mocker.patch(
             "kedro_telemetry.plugin._check_for_telemetry_consent", return_value=True
         )
-        mocked_anon_id = mocker.patch("hashlib.sha512")
-        mocked_anon_id.return_value.hexdigest.return_value = "digested"
+        mocked_anon_id = mocker.patch("kedro_telemetry.plugin._hash")
+        mocked_anon_id.return_value = "digested"
         mocker.patch("getpass.getuser", side_effect=Exception)
 
         mocked_heap_call = mocker.patch("kedro_telemetry.plugin._send_heap_event")

--- a/kedro-telemetry/tests/test_plugin.py
+++ b/kedro-telemetry/tests/test_plugin.py
@@ -7,7 +7,7 @@ from kedro import __version__ as kedro_version
 from kedro.framework.startup import ProjectMetadata
 from pytest import fixture
 
-from kedro_telemetry import __version__ as telemetry_version
+from kedro_telemetry import __version__ as TELEMETRY_VERSION
 from kedro_telemetry.plugin import (
     KedroTelemetryCLIHooks,
     _check_for_telemetry_consent,
@@ -51,7 +51,7 @@ class TestKedroTelemetryCLIHooks:
             "package_name": "digested",
             "project_name": "digested",
             "project_version": kedro_version,
-            "telemetry_version": telemetry_version,
+            "telemetry_version": TELEMETRY_VERSION,
             "python_version": sys.version,
             "os": sys.platform,
         }
@@ -91,7 +91,7 @@ class TestKedroTelemetryCLIHooks:
             "package_name": "digested",
             "project_name": "digested",
             "project_version": kedro_version,
-            "telemetry_version": telemetry_version,
+            "telemetry_version": TELEMETRY_VERSION,
             "python_version": sys.version,
             "os": sys.platform,
         }
@@ -160,7 +160,7 @@ class TestKedroTelemetryCLIHooks:
             "package_name": "digested",
             "project_name": "digested",
             "project_version": kedro_version,
-            "telemetry_version": telemetry_version,
+            "telemetry_version": TELEMETRY_VERSION,
             "python_version": sys.version,
             "os": sys.platform,
         }


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
See #44, quotes related to the actual tasks related to the scope of this PR.

> To work out the size of a Kedro project, probably tracked per username:

- Number of datasets
- Number of nodes
- Number of pipelines

To work out how many team members are on a project, to show that Kedro helps with collaboration:

- Number of projects, identified by project_name
- A count of username per project


> **If possible add:** Size of projects by internal vs external users
> 
> **Nice to have:** Could we figure out what parts of a pipeline are data engineering vs data science specific?

> This issue was discussed as part of a **Technical Design** session:
> 
> * Size should be determined by the number of nodes in the default pipeline and the number of dataset entries in the catalog
> * Currently we use the `before_command_run` hook, but to send the size info to heap we'd also need to either use the `before_pipeline_run` or `after_context_created` hook.
> * To be decided by the person implementing this: inside `kedro-telemetry` would we do a call to the Heap API for every Kedro hook that's called, or do we aggregate the data fetched in the hooks and then send it to Heap in one call?
> 
> 1. Need to implement the size calculation and sending it to heap
> 2. Make a "dashboard" or other view on Heap that shows the Kedro project size


## Development notes
<!-- What have you changed, and how has this been tested? -->

* Number of pipelines
* Number of nodes in the `__default__` pipeline
* Number of datasets


### Setup for HEAP testing environment
* https://confluence.quantumblack.com/display/CAI/Heap+Analytics+for+Kedro-Viz?searchId=ZC01QX5OV

# demo
![image](https://user-images.githubusercontent.com/18221871/193869216-2f7a410b-1065-4eb4-a3fd-2c856892dae1.png)

# How to review?
There are mainly 2 ways that users run a project
* `kedro run`
* Manually create a `KedroSessions` and do `session.run`

The difference is - the first one will always invoke the CLI first, and currently this is the only hook that captures the project metadata. `PROJECT_PROPERTIES` is a global variable that tracks this information. So the order is always CLI hook -> Kedro's run hook.

However, it's also common to skip the CLI (Databricks or any interactive workflow), and I think it's important to capture the statistics for these projects. Without the project metadata, the data on HEAP will be inconsistent, so a manual `bootstrap_project` call is added to retrieve the `metadata`. 

# How to test?
* `kedro new -s pandas-iris` # telemetry
* `cd telemetry`

1. `kedro run`
2. `kedro ipython` - `session.run()`

You should see events on Heap immediately (Better to use Dev environment) - check the `Live Data Feed` page on Heap. If you have trouble with the setup, feel free to DM me I can show you quickly how it's done.

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
