### PR TITLE
Implement fix for failing test for loading CSVDataSet from S3 bucket

### DIFF
--- a/kedro-datasets/pyproject.toml
+++ b/kedro-datasets/pyproject.toml
@@ -33,7 +33,7 @@ min-public-methods = 1
 [tool.coverage.report]
 fail_under = 100
 show_missing = true
-omit = ["tests/*", "kedro_datasets/datasets/holoviews/*"]
+omit = ["tests/*", "kedro_datasets/holoviews/*"]
 exclude_lines = ["pragma: no cover", "raise NotImplementedError"]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
Signed-off-by: Jannic Holzer <jannic.holzer@quantumblack.com>

## Description
Resolves #67

## Development notes
Discovered that the source of the bug is another bug in moto (tested with moto==4.0.8, moto==3.0.4). Changing order of tests, so that TestCSVDataSetS3::test_load_and_confirm runs before TestCSVDataSet::test_protocol_usage avoids encountering the bug.

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
