### PR TITLE
Update kedro-datasets to match with `kedro.extras.datasets`

### DIFF
--- a/kedro-datasets/kedro_datasets/api/api_dataset.py
+++ b/kedro-datasets/kedro_datasets/api/api_dataset.py
@@ -4,9 +4,8 @@ It uses the python requests library: https://requests.readthedocs.io/en/latest/
 from typing import Any, Dict, Iterable, List, NoReturn, Union
 
 import requests
-from requests.auth import AuthBase
-
 from kedro.io.core import AbstractDataSet, DataSetError
+from requests.auth import AuthBase
 
 
 class APIDataSet(AbstractDataSet[None, requests.Response]):

--- a/kedro-datasets/kedro_datasets/api/api_dataset.py
+++ b/kedro-datasets/kedro_datasets/api/api_dataset.py
@@ -1,18 +1,39 @@
 """``APIDataSet`` loads the data from HTTP(S) APIs.
 It uses the python requests library: https://requests.readthedocs.io/en/latest/
 """
-from typing import Any, Dict, Iterable, List, Union
+from typing import Any, Dict, Iterable, List, NoReturn, Union
 
 import requests
-from kedro.io.core import AbstractDataSet, DataSetError
 from requests.auth import AuthBase
 
+from kedro.io.core import AbstractDataSet, DataSetError
 
-class APIDataSet(AbstractDataSet):
+
+class APIDataSet(AbstractDataSet[None, requests.Response]):
     """``APIDataSet`` loads the data from HTTP(S) APIs.
     It uses the python requests library: https://requests.readthedocs.io/en/latest/
 
-    Example:
+    Example adding a catalog entry with
+    `YAML API
+    <https://kedro.readthedocs.io/en/stable/data/\
+        data_catalog.html#use-the-data-catalog-with-the-yaml-api>`_:
+
+    .. code-block:: yaml
+
+        >>> usda:
+        >>>   type: api.APIDataSet
+        >>>   url: https://quickstats.nass.usda.gov
+        >>>   params:
+        >>>     key: SOME_TOKEN,
+        >>>     format: JSON,
+        >>>     commodity_desc: CORN,
+        >>>     statisticcat_des: YIELD,
+        >>>     agg_level_desc: STATE,
+        >>>     year: 2000
+        >>>
+
+
+    Example using Python API:
     ::
 
         >>> from kedro_datasets.api import APIDataSet
@@ -108,7 +129,7 @@ class APIDataSet(AbstractDataSet):
     def _load(self) -> requests.Response:
         return self._execute_request()
 
-    def _save(self, data: Any) -> None:
+    def _save(self, data: None) -> NoReturn:
         raise DataSetError(f"{self.__class__.__name__} is a read only data set type")
 
     def _exists(self) -> bool:

--- a/kedro-datasets/kedro_datasets/biosequence/biosequence_dataset.py
+++ b/kedro-datasets/kedro_datasets/biosequence/biosequence_dataset.py
@@ -7,10 +7,11 @@ from typing import Any, Dict, List
 
 import fsspec
 from Bio import SeqIO
+
 from kedro.io.core import AbstractDataSet, get_filepath_str, get_protocol_and_path
 
 
-class BioSequenceDataSet(AbstractDataSet):
+class BioSequenceDataSet(AbstractDataSet[List, List]):
     r"""``BioSequenceDataSet`` loads and saves data to a sequence file.
 
     Example:

--- a/kedro-datasets/kedro_datasets/biosequence/biosequence_dataset.py
+++ b/kedro-datasets/kedro_datasets/biosequence/biosequence_dataset.py
@@ -7,7 +7,6 @@ from typing import Any, Dict, List
 
 import fsspec
 from Bio import SeqIO
-
 from kedro.io.core import AbstractDataSet, get_filepath_str, get_protocol_and_path
 
 

--- a/kedro-datasets/kedro_datasets/dask/parquet_dataset.py
+++ b/kedro-datasets/kedro_datasets/dask/parquet_dataset.py
@@ -6,7 +6,6 @@ from typing import Any, Dict
 
 import dask.dataframe as dd
 import fsspec
-
 from kedro.io.core import AbstractDataSet, get_protocol_and_path
 
 

--- a/kedro-datasets/kedro_datasets/dask/parquet_dataset.py
+++ b/kedro-datasets/kedro_datasets/dask/parquet_dataset.py
@@ -6,15 +6,35 @@ from typing import Any, Dict
 
 import dask.dataframe as dd
 import fsspec
+
 from kedro.io.core import AbstractDataSet, get_protocol_and_path
 
 
-class ParquetDataSet(AbstractDataSet):
+class ParquetDataSet(AbstractDataSet[dd.DataFrame, dd.DataFrame]):
     """``ParquetDataSet`` loads and saves data to parquet file(s). It uses Dask
     remote data services to handle the corresponding load and save operations:
     https://docs.dask.org/en/latest/how-to/connect-to-remote-data.html
 
-        Example (AWS S3):
+        Example adding a catalog entry with
+        `YAML API
+        <https://kedro.readthedocs.io/en/stable/data/\
+            data_catalog.html#use-the-data-catalog-with-the-yaml-api>`_:
+
+        .. code-block:: yaml
+
+        >>> cars:
+        >>>   type: dask.ParquetDataSet
+        >>>   filepath: s3://bucket_name/path/to/folder
+        >>>   save_args:
+        >>>     compression: GZIP
+        >>>   credentials:
+        >>>     client_kwargs:
+        >>>         aws_access_key_id: YOUR_KEY
+        >>>         aws_secret_access_key: YOUR_SECRET
+        >>>
+
+
+        Example using Python API (AWS S3):
         ::
 
             >>> from kedro_datasets.dask import ParquetDataSet

--- a/kedro-datasets/kedro_datasets/email/message_dataset.py
+++ b/kedro-datasets/kedro_datasets/email/message_dataset.py
@@ -11,7 +11,6 @@ from pathlib import PurePosixPath
 from typing import Any, Dict
 
 import fsspec
-
 from kedro.io.core import (
     AbstractVersionedDataSet,
     DataSetError,

--- a/kedro-datasets/kedro_datasets/email/message_dataset.py
+++ b/kedro-datasets/kedro_datasets/email/message_dataset.py
@@ -11,6 +11,7 @@ from pathlib import PurePosixPath
 from typing import Any, Dict
 
 import fsspec
+
 from kedro.io.core import (
     AbstractVersionedDataSet,
     DataSetError,
@@ -21,7 +22,7 @@ from kedro.io.core import (
 
 
 class EmailMessageDataSet(
-    AbstractVersionedDataSet
+    AbstractVersionedDataSet[Message, Message]
 ):  # pylint: disable=too-many-instance-attributes
     """``EmailMessageDataSet`` loads/saves an email message from/to a file
     using an underlying filesystem (e.g.: local, S3, GCS). It uses the
@@ -45,7 +46,6 @@ class EmailMessageDataSet(
         >>> msg["From"] = '"sin studly17"'
         >>> msg["To"] = '"strong bad"'
         >>>
-        >>> # data_set = EmailMessageDataSet(filepath="gcs://bucket/test")
         >>> data_set = EmailMessageDataSet(filepath="test")
         >>> data_set.save(msg)
         >>> reloaded = data_set.load()

--- a/kedro-datasets/kedro_datasets/geopandas/geojson_dataset.py
+++ b/kedro-datasets/kedro_datasets/geopandas/geojson_dataset.py
@@ -8,7 +8,6 @@ from typing import Any, Dict, Union
 
 import fsspec
 import geopandas as gpd
-
 from kedro.io.core import (
     AbstractVersionedDataSet,
     DataSetError,

--- a/kedro-datasets/kedro_datasets/geopandas/geojson_dataset.py
+++ b/kedro-datasets/kedro_datasets/geopandas/geojson_dataset.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, Union
 
 import fsspec
 import geopandas as gpd
+
 from kedro.io.core import (
     AbstractVersionedDataSet,
     DataSetError,
@@ -17,7 +18,11 @@ from kedro.io.core import (
 )
 
 
-class GeoJSONDataSet(AbstractVersionedDataSet):
+class GeoJSONDataSet(
+    AbstractVersionedDataSet[
+        gpd.GeoDataFrame, Union[gpd.GeoDataFrame, Dict[str, gpd.GeoDataFrame]]
+    ]
+):
     """``GeoJSONDataSet`` loads/saves data to a GeoJSON file using an underlying filesystem
     (eg: local, S3, GCS).
     The underlying functionality is supported by geopandas, so it supports all
@@ -32,10 +37,7 @@ class GeoJSONDataSet(AbstractVersionedDataSet):
         >>>
         >>> data = gpd.GeoDataFrame({'col1': [1, 2], 'col2': [4, 5],
         >>>                      'col3': [5, 6]}, geometry=[Point(1,1), Point(2,4)])
-        >>> # data_set = GeoJSONDataSet(filepath="gcs://bucket/test.geojson",
-        >>>                                save_args=None)
-        >>> data_set = GeoJSONDataSet(filepath="test.geojson",
-        >>>                                save_args=None)
+        >>> data_set = GeoJSONDataSet(filepath="test.geojson", save_args=None)
         >>> data_set.save(data)
         >>> reloaded = data_set.load()
         >>>

--- a/kedro-datasets/kedro_datasets/holoviews/holoviews_writer.py
+++ b/kedro-datasets/kedro_datasets/holoviews/holoviews_writer.py
@@ -8,7 +8,6 @@ from typing import Any, Dict, NoReturn, TypeVar
 
 import fsspec
 import holoviews as hv
-
 from kedro.io.core import (
     AbstractVersionedDataSet,
     DataSetError,

--- a/kedro-datasets/kedro_datasets/holoviews/holoviews_writer.py
+++ b/kedro-datasets/kedro_datasets/holoviews/holoviews_writer.py
@@ -4,10 +4,11 @@ filesystem (e.g. local, S3, GCS)."""
 import io
 from copy import deepcopy
 from pathlib import PurePosixPath
-from typing import Any, Dict, TypeVar
+from typing import Any, Dict, NoReturn, TypeVar
 
 import fsspec
 import holoviews as hv
+
 from kedro.io.core import (
     AbstractVersionedDataSet,
     DataSetError,
@@ -20,7 +21,7 @@ from kedro.io.core import (
 HoloViews = TypeVar("HoloViews")
 
 
-class HoloviewsWriter(AbstractVersionedDataSet):
+class HoloviewsWriter(AbstractVersionedDataSet[HoloViews, NoReturn]):
     """``HoloviewsWriter`` saves Holoviews objects to image file(s) in an underlying
     filesystem (e.g. local, S3, GCS).
 
@@ -105,7 +106,7 @@ class HoloviewsWriter(AbstractVersionedDataSet):
             version=self._version,
         )
 
-    def _load(self) -> str:
+    def _load(self) -> NoReturn:
         raise DataSetError(f"Loading not supported for '{self.__class__.__name__}'")
 
     def _save(self, data: HoloViews) -> None:

--- a/kedro-datasets/kedro_datasets/json/json_dataset.py
+++ b/kedro-datasets/kedro_datasets/json/json_dataset.py
@@ -7,6 +7,7 @@ from pathlib import PurePosixPath
 from typing import Any, Dict
 
 import fsspec
+
 from kedro.io.core import (
     AbstractVersionedDataSet,
     DataSetError,
@@ -16,7 +17,7 @@ from kedro.io.core import (
 )
 
 
-class JSONDataSet(AbstractVersionedDataSet):
+class JSONDataSet(AbstractVersionedDataSet[Any, Any]):
     """``JSONDataSet`` loads/saves data from/to a JSON file using an underlying
     filesystem (e.g.: local, S3, GCS). It uses native json to handle the JSON file.
 
@@ -27,8 +28,6 @@ class JSONDataSet(AbstractVersionedDataSet):
         >>> json_dataset:
         >>>   type: json.JSONDataSet
         >>>   filepath: data/01_raw/location.json
-        >>>   load_args:
-        >>>     lines: True
         >>>
         >>> cars:
         >>>   type: json.JSONDataSet
@@ -36,8 +35,6 @@ class JSONDataSet(AbstractVersionedDataSet):
         >>>   fs_args:
         >>>     project: my-project
         >>>   credentials: my_gcp_credentials
-        >>>   load_args:
-        >>>     lines: True
 
     Example using Python API:
     ::
@@ -46,7 +43,6 @@ class JSONDataSet(AbstractVersionedDataSet):
         >>>
         >>> data = {'col1': [1, 2], 'col2': [4, 5], 'col3': [5, 6]}
         >>>
-        >>> # data_set = JSONDataSet(filepath="gcs://bucket/test.json")
         >>> data_set = JSONDataSet(filepath="test.json")
         >>> data_set.save(data)
         >>> reloaded = data_set.load()
@@ -128,13 +124,13 @@ class JSONDataSet(AbstractVersionedDataSet):
             version=self._version,
         )
 
-    def _load(self) -> Dict:
+    def _load(self) -> Any:
         load_path = get_filepath_str(self._get_load_path(), self._protocol)
 
         with self._fs.open(load_path, **self._fs_open_args_load) as fs_file:
             return json.load(fs_file)
 
-    def _save(self, data: Dict) -> None:
+    def _save(self, data: Any) -> None:
         save_path = get_filepath_str(self._get_save_path(), self._protocol)
 
         with self._fs.open(save_path, **self._fs_open_args_save) as fs_file:

--- a/kedro-datasets/kedro_datasets/json/json_dataset.py
+++ b/kedro-datasets/kedro_datasets/json/json_dataset.py
@@ -7,7 +7,6 @@ from pathlib import PurePosixPath
 from typing import Any, Dict
 
 import fsspec
-
 from kedro.io.core import (
     AbstractVersionedDataSet,
     DataSetError,

--- a/kedro-datasets/kedro_datasets/matplotlib/matplotlib_writer.py
+++ b/kedro-datasets/kedro_datasets/matplotlib/matplotlib_writer.py
@@ -4,11 +4,12 @@ files to an underlying filesystem (e.g. local, S3, GCS)."""
 import io
 from copy import deepcopy
 from pathlib import PurePosixPath
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, NoReturn, Union
 from warnings import warn
 
 import fsspec
 import matplotlib.pyplot as plt
+
 from kedro.io.core import (
     AbstractVersionedDataSet,
     DataSetError,
@@ -18,55 +19,91 @@ from kedro.io.core import (
 )
 
 
-class MatplotlibWriter(AbstractVersionedDataSet):
+class MatplotlibWriter(
+    AbstractVersionedDataSet[
+        Union[plt.figure, List[plt.figure], Dict[str, plt.figure]], NoReturn
+    ]
+):
     """``MatplotlibWriter`` saves one or more Matplotlib objects as
     image files to an underlying filesystem (e.g. local, S3, GCS).
 
-    Example:
+    Example adding a catalog entry with the `YAML API
+    <https://kedro.readthedocs.io/en/stable/data/\
+        data_catalog.html#use-the-data-catalog-with-the-yaml-api>`_:
+
+    .. code-block:: yaml
+
+        >>> output_plot:
+        >>>   type: matplotlib.MatplotlibWriter
+        >>>   filepath: data/08_reporting/output_plot.png
+        >>>   save_args:
+        >>>     format: png
+        >>>
+
+    Example using the Python API:
+
     ::
 
         >>> import matplotlib.pyplot as plt
         >>> from kedro_datasets.matplotlib import MatplotlibWriter
         >>>
-        >>> # Saving single plot
         >>> fig = plt.figure()
-        >>> plt.plot([1, 2, 3], [4, 5, 6])
-        >>> single_plot_writer = MatplotlibWriter(
-        >>>     filepath="matplot_lib_single_plot.png"
+        >>> plt.plot([1, 2, 3])
+        >>> plot_writer = MatplotlibWriter(
+        >>>     filepath="data/08_reporting/output_plot.png"
         >>> )
         >>> plt.close()
-        >>> single_plot_writer.save(fig)
+        >>> plot_writer.save(fig)
+
+    Example saving a plot as a PDF file:
+
+    ::
+
+        >>> import matplotlib.pyplot as plt
+        >>> from kedro_datasets.matplotlib import MatplotlibWriter
         >>>
-        >>> # MatplotlibWriter can output other formats as well, such as PDF files.
-        >>> # For this, we need to specify the format:
         >>> fig = plt.figure()
-        >>> plt.plot([1, 2, 3], [4, 5, 6])
-        >>> single_plot_writer = MatplotlibWriter(
-        >>>     filepath="matplot_lib_single_plot.pdf",
+        >>> plt.plot([1, 2, 3])
+        >>> pdf_plot_writer = MatplotlibWriter(
+        >>>     filepath="data/08_reporting/output_plot.pdf",
         >>>     save_args={"format": "pdf"},
         >>> )
         >>> plt.close()
-        >>> single_plot_writer.save(fig)
+        >>> pdf_plot_writer.save(fig)
+
+
+    Example saving multiple plots in a folder, using a dictionary:
+
+    ::
+
+        >>> import matplotlib.pyplot as plt
+        >>> from kedro_datasets.matplotlib import MatplotlibWriter
         >>>
-        >>> # Saving dictionary of plots
         >>> plots_dict = dict()
         >>> for colour in ["blue", "green", "red"]:
-        >>>     plots_dict[colour] = plt.figure()
-        >>>     plt.plot([1, 2, 3], [4, 5, 6], color=colour)
+        >>>     plots_dict[f"{colour}.png"] = plt.figure()
+        >>>     plt.plot([1, 2, 3], color=colour)
+        >>>
         >>> plt.close("all")
         >>> dict_plot_writer = MatplotlibWriter(
-        >>>     filepath="matplotlib_dict"
+        >>>     filepath="data/08_reporting/plots"
         >>> )
         >>> dict_plot_writer.save(plots_dict)
+
+    Example saving multiple plots in a folder, using a list:
+
+    ::
+
+        >>> import matplotlib.pyplot as plt
+        >>> from kedro_datasets.matplotlib import MatplotlibWriter
         >>>
-        >>> # Saving list of plots
         >>> plots_list = []
-        >>> for index in range(5):
+        >>> for i in range(5):
         >>>     plots_list.append(plt.figure())
-        >>>     plt.plot([1,2,3],[4,5,6])
+        >>>     plt.plot([i, i + 1, i + 2])
         >>> plt.close("all")
         >>> list_plot_writer = MatplotlibWriter(
-        >>>     filepath="matplotlib_list"
+        >>>     filepath="data/08_reporting/plots"
         >>> )
         >>> list_plot_writer.save(plots_list)
 
@@ -152,7 +189,7 @@ class MatplotlibWriter(AbstractVersionedDataSet):
             version=self._version,
         )
 
-    def _load(self) -> None:
+    def _load(self) -> NoReturn:
         raise DataSetError(f"Loading not supported for '{self.__class__.__name__}'")
 
     def _save(

--- a/kedro-datasets/kedro_datasets/matplotlib/matplotlib_writer.py
+++ b/kedro-datasets/kedro_datasets/matplotlib/matplotlib_writer.py
@@ -9,7 +9,6 @@ from warnings import warn
 
 import fsspec
 import matplotlib.pyplot as plt
-
 from kedro.io.core import (
     AbstractVersionedDataSet,
     DataSetError,

--- a/kedro-datasets/kedro_datasets/networkx/gml_dataset.py
+++ b/kedro-datasets/kedro_datasets/networkx/gml_dataset.py
@@ -9,6 +9,7 @@ from typing import Any, Dict
 
 import fsspec
 import networkx
+
 from kedro.io.core import (
     AbstractVersionedDataSet,
     Version,
@@ -17,7 +18,7 @@ from kedro.io.core import (
 )
 
 
-class GMLDataSet(AbstractVersionedDataSet):
+class GMLDataSet(AbstractVersionedDataSet[networkx.Graph, networkx.Graph]):
     """``GMLDataSet`` loads and saves graphs to a GML file using an
     underlying filesystem (e.g.: local, S3, GCS). ``NetworkX`` is used to
     create GML data.

--- a/kedro-datasets/kedro_datasets/networkx/gml_dataset.py
+++ b/kedro-datasets/kedro_datasets/networkx/gml_dataset.py
@@ -9,7 +9,6 @@ from typing import Any, Dict
 
 import fsspec
 import networkx
-
 from kedro.io.core import (
     AbstractVersionedDataSet,
     Version,

--- a/kedro-datasets/kedro_datasets/networkx/graphml_dataset.py
+++ b/kedro-datasets/kedro_datasets/networkx/graphml_dataset.py
@@ -8,6 +8,7 @@ from typing import Any, Dict
 
 import fsspec
 import networkx
+
 from kedro.io.core import (
     AbstractVersionedDataSet,
     Version,
@@ -16,7 +17,7 @@ from kedro.io.core import (
 )
 
 
-class GraphMLDataSet(AbstractVersionedDataSet):
+class GraphMLDataSet(AbstractVersionedDataSet[networkx.Graph, networkx.Graph]):
     """``GraphMLDataSet`` loads and saves graphs to a GraphML file using an
     underlying filesystem (e.g.: local, S3, GCS). ``NetworkX`` is used to
     create GraphML data.
@@ -107,8 +108,7 @@ class GraphMLDataSet(AbstractVersionedDataSet):
     def _load(self) -> networkx.Graph:
         load_path = get_filepath_str(self._get_load_path(), self._protocol)
         with self._fs.open(load_path, **self._fs_open_args_load) as fs_file:
-            data = networkx.read_graphml(fs_file, **self._load_args)
-        return data
+            return networkx.read_graphml(fs_file, **self._load_args)
 
     def _save(self, data: networkx.Graph) -> None:
         save_path = get_filepath_str(self._get_save_path(), self._protocol)

--- a/kedro-datasets/kedro_datasets/networkx/graphml_dataset.py
+++ b/kedro-datasets/kedro_datasets/networkx/graphml_dataset.py
@@ -8,7 +8,6 @@ from typing import Any, Dict
 
 import fsspec
 import networkx
-
 from kedro.io.core import (
     AbstractVersionedDataSet,
     Version,

--- a/kedro-datasets/kedro_datasets/networkx/json_dataset.py
+++ b/kedro-datasets/kedro_datasets/networkx/json_dataset.py
@@ -9,7 +9,6 @@ from typing import Any, Dict
 
 import fsspec
 import networkx
-
 from kedro.io.core import (
     AbstractVersionedDataSet,
     Version,

--- a/kedro-datasets/kedro_datasets/networkx/json_dataset.py
+++ b/kedro-datasets/kedro_datasets/networkx/json_dataset.py
@@ -9,6 +9,7 @@ from typing import Any, Dict
 
 import fsspec
 import networkx
+
 from kedro.io.core import (
     AbstractVersionedDataSet,
     Version,
@@ -17,7 +18,7 @@ from kedro.io.core import (
 )
 
 
-class JSONDataSet(AbstractVersionedDataSet):
+class JSONDataSet(AbstractVersionedDataSet[networkx.Graph, networkx.Graph]):
     """NetworkX ``JSONDataSet`` loads and saves graphs to a JSON file using an
     underlying filesystem (e.g.: local, S3, GCS). ``NetworkX`` is used to
     create JSON data.

--- a/kedro-datasets/kedro_datasets/pandas/csv_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/csv_dataset.py
@@ -9,6 +9,7 @@ from typing import Any, Dict
 
 import fsspec
 import pandas as pd
+
 from kedro.io.core import (
     PROTOCOL_DELIMITER,
     AbstractVersionedDataSet,
@@ -21,14 +22,14 @@ from kedro.io.core import (
 logger = logging.getLogger(__name__)
 
 
-class CSVDataSet(AbstractVersionedDataSet):
+class CSVDataSet(AbstractVersionedDataSet[pd.DataFrame, pd.DataFrame]):
     """``CSVDataSet`` loads/saves data from/to a CSV file using an underlying
     filesystem (e.g.: local, S3, GCS). It uses pandas to handle the CSV file.
 
     Example adding a catalog entry with
     `YAML API
     <https://kedro.readthedocs.io/en/stable/data/\
-        data_catalog.html#using-the-data-catalog-with-the-yaml-api>`_:
+        data_catalog.html#use-the-data-catalog-with-the-yaml-api>`_:
 
     .. code-block:: yaml
 
@@ -47,8 +48,6 @@ class CSVDataSet(AbstractVersionedDataSet):
         >>>   type: pandas.CSVDataSet
         >>>   filepath: s3://your_bucket/data/02_intermediate/company/motorbikes.csv
         >>>   credentials: dev_s3
-        >>>
-
 
     Example using Python API:
     ::
@@ -59,7 +58,6 @@ class CSVDataSet(AbstractVersionedDataSet):
         >>> data = pd.DataFrame({'col1': [1, 2], 'col2': [4, 5],
         >>>                      'col3': [5, 6]})
         >>>
-        >>> # data_set = CSVDataSet(filepath="gcs://bucket/test.csv")
         >>> data_set = CSVDataSet(filepath="test.csv")
         >>> data_set.save(data)
         >>> reloaded = data_set.load()

--- a/kedro-datasets/kedro_datasets/pandas/csv_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/csv_dataset.py
@@ -9,7 +9,6 @@ from typing import Any, Dict
 
 import fsspec
 import pandas as pd
-
 from kedro.io.core import (
     PROTOCOL_DELIMITER,
     AbstractVersionedDataSet,

--- a/kedro-datasets/kedro_datasets/pandas/excel_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/excel_dataset.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, Union
 
 import fsspec
 import pandas as pd
+
 from kedro.io.core import (
     PROTOCOL_DELIMITER,
     AbstractVersionedDataSet,
@@ -21,7 +22,12 @@ from kedro.io.core import (
 logger = logging.getLogger(__name__)
 
 
-class ExcelDataSet(AbstractVersionedDataSet):
+class ExcelDataSet(
+    AbstractVersionedDataSet[
+        Union[pd.DataFrame, Dict[str, pd.DataFrame]],
+        Union[pd.DataFrame, Dict[str, pd.DataFrame]],
+    ]
+):
     """``ExcelDataSet`` loads/saves data from/to a Excel file using an underlying
     filesystem (e.g.: local, S3, GCS). It uses pandas to handle the Excel file.
 
@@ -53,11 +59,40 @@ class ExcelDataSet(AbstractVersionedDataSet):
         >>> data = pd.DataFrame({'col1': [1, 2], 'col2': [4, 5],
         >>>                      'col3': [5, 6]})
         >>>
-        >>> # data_set = ExcelDataSet(filepath="gcs://bucket/test.xlsx")
         >>> data_set = ExcelDataSet(filepath="test.xlsx")
         >>> data_set.save(data)
         >>> reloaded = data_set.load()
         >>> assert data.equals(reloaded)
+
+    Note: To save a multi-sheet Excel file, no special ``save_args`` are required.
+    Instead, return a dictionary of ``Dict[str, pd.DataFrame]`` where the string
+    keys are your sheet names.
+
+    Example adding a catalog entry for multi-sheet Excel file with the ``YAML API``:
+
+    .. code-block:: yaml
+
+        >>> trains:
+        >>>   type: pandas.ExcelDataSet
+        >>>   filepath: data/02_intermediate/company/trains.xlsx
+        >>>   load_args:
+        >>>     sheet_name: [Sheet1, Sheet2, Sheet3]
+
+    Example multi-sheet Excel file using Python API:
+    ::
+
+        >>> from kedro_datasets.pandas import ExcelDataSet
+        >>> import pandas as pd
+        >>>
+        >>> dataframe = pd.DataFrame({'col1': [1, 2], 'col2': [4, 5],
+        >>>                      'col3': [5, 6]})
+        >>> another_dataframe = pd.DataFrame({"x": [10, 20], "y": ["hello", "world"]})
+        >>> multiframe = {"Sheet1": dataframe, "Sheet2": another_dataframe}
+        >>> data_set = ExcelDataSet(filepath="test.xlsx", load_args = {"sheet_name": None})
+        >>> data_set.save(multiframe)
+        >>> reloaded = data_set.load()
+        >>> assert multiframe["Sheet1"].equals(reloaded["Sheet1"])
+        >>> assert multiframe["Sheet2"].equals(reloaded["Sheet2"])
 
     """
 
@@ -83,7 +118,7 @@ class ExcelDataSet(AbstractVersionedDataSet):
                 `s3://`. If prefix is not provided, `file` protocol (local filesystem) will be used.
                 The prefix should be any protocol supported by ``fsspec``.
                 Note: `http(s)` doesn't support versioning.
-            engine: The engine used to write to excel files. The default
+            engine: The engine used to write to Excel files. The default
                 engine is 'openpyxl'.
             load_args: Pandas options for loading Excel files.
                 Here you can find all available arguments:

--- a/kedro-datasets/kedro_datasets/pandas/excel_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/excel_dataset.py
@@ -9,7 +9,6 @@ from typing import Any, Dict, Union
 
 import fsspec
 import pandas as pd
-
 from kedro.io.core import (
     PROTOCOL_DELIMITER,
     AbstractVersionedDataSet,

--- a/kedro-datasets/kedro_datasets/pandas/feather_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/feather_dataset.py
@@ -10,7 +10,6 @@ from typing import Any, Dict
 
 import fsspec
 import pandas as pd
-
 from kedro.io.core import (
     PROTOCOL_DELIMITER,
     AbstractVersionedDataSet,

--- a/kedro-datasets/kedro_datasets/pandas/feather_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/feather_dataset.py
@@ -10,6 +10,7 @@ from typing import Any, Dict
 
 import fsspec
 import pandas as pd
+
 from kedro.io.core import (
     PROTOCOL_DELIMITER,
     AbstractVersionedDataSet,
@@ -21,13 +22,34 @@ from kedro.io.core import (
 logger = logging.getLogger(__name__)
 
 
-class FeatherDataSet(AbstractVersionedDataSet):
+class FeatherDataSet(AbstractVersionedDataSet[pd.DataFrame, pd.DataFrame]):
     """``FeatherDataSet`` loads and saves data to a feather file using an
     underlying filesystem (e.g.: local, S3, GCS). The underlying functionality
     is supported by pandas, so it supports all allowed pandas options
     for loading and saving csv files.
 
-    Example:
+    Example adding a catalog entry with
+    `YAML API
+    <https://kedro.readthedocs.io/en/stable/data/\
+        data_catalog.html#use-the-data-catalog-with-the-yaml-api>`_:
+
+    .. code-block:: yaml
+
+        >>> cars:
+        >>>   type: pandas.FeatherDataSet
+        >>>   filepath: data/01_raw/company/cars.feather
+        >>>   load_args:
+        >>>     columns: ['col1', 'col2', 'col3']
+        >>>     use_threads: True
+        >>>
+        >>> motorbikes:
+        >>>   type: pandas.FeatherDataSet
+        >>>   filepath: s3://your_bucket/data/02_intermediate/company/motorbikes.feather
+        >>>   credentials: dev_s3
+        >>>
+
+
+    Example using Python API:
     ::
 
         >>> from kedro_datasets.pandas import FeatherDataSet
@@ -36,7 +58,6 @@ class FeatherDataSet(AbstractVersionedDataSet):
         >>> data = pd.DataFrame({'col1': [1, 2], 'col2': [4, 5],
         >>>                      'col3': [5, 6]})
         >>>
-        >>> # data_set = FeatherDataSet(filepath="gcs://bucket/test.feather")
         >>> data_set = FeatherDataSet(filepath="test.feather")
         >>>
         >>> data_set.save(data)

--- a/kedro-datasets/kedro_datasets/pandas/gbq_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/gbq_dataset.py
@@ -11,7 +11,6 @@ import pandas as pd
 from google.cloud import bigquery
 from google.cloud.exceptions import NotFound
 from google.oauth2.credentials import Credentials
-
 from kedro.io.core import (
     AbstractDataSet,
     DataSetError,

--- a/kedro-datasets/kedro_datasets/pandas/gbq_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/gbq_dataset.py
@@ -4,13 +4,14 @@ to read and write from/to BigQuery table.
 
 import copy
 from pathlib import PurePosixPath
-from typing import Any, Dict, Union
+from typing import Any, Dict, NoReturn, Union
 
 import fsspec
 import pandas as pd
 from google.cloud import bigquery
 from google.cloud.exceptions import NotFound
 from google.oauth2.credentials import Credentials
+
 from kedro.io.core import (
     AbstractDataSet,
     DataSetError,
@@ -20,13 +21,13 @@ from kedro.io.core import (
 )
 
 
-class GBQTableDataSet(AbstractDataSet):
+class GBQTableDataSet(AbstractDataSet[None, pd.DataFrame]):
     """``GBQTableDataSet`` loads and saves data from/to Google BigQuery.
     It uses pandas-gbq to read and write from/to BigQuery table.
 
     Example adding a catalog entry with
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
-        data_catalog.html#using-the-data-catalog-with-the-yaml-api>`_:
+        data_catalog.html#use-the-data-catalog-with-the-yaml-api>`_:
 
     .. code-block:: yaml
 
@@ -170,7 +171,7 @@ class GBQTableDataSet(AbstractDataSet):
             )
 
 
-class GBQQueryDataSet(AbstractDataSet):
+class GBQQueryDataSet(AbstractDataSet[None, pd.DataFrame]):
     """``GBQQueryDataSet`` loads data from a provided SQL query from Google
     BigQuery. It uses ``pandas.read_gbq`` which itself uses ``pandas-gbq``
     internally to read from BigQuery table. Therefore it supports all allowed
@@ -305,5 +306,5 @@ class GBQQueryDataSet(AbstractDataSet):
             **load_args,
         )
 
-    def _save(self, data: pd.DataFrame) -> None:
+    def _save(self, data: None) -> NoReturn:
         raise DataSetError("'save' is not supported on GBQQueryDataSet")

--- a/kedro-datasets/kedro_datasets/pandas/generic_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/generic_dataset.py
@@ -8,7 +8,6 @@ from typing import Any, Dict
 
 import fsspec
 import pandas as pd
-
 from kedro.io.core import (
     AbstractVersionedDataSet,
     DataSetError,

--- a/kedro-datasets/kedro_datasets/pandas/generic_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/generic_dataset.py
@@ -8,6 +8,7 @@ from typing import Any, Dict
 
 import fsspec
 import pandas as pd
+
 from kedro.io.core import (
     AbstractVersionedDataSet,
     DataSetError,
@@ -28,14 +29,14 @@ NON_FILE_SYSTEM_TARGETS = [
 ]
 
 
-class GenericDataSet(AbstractVersionedDataSet):
+class GenericDataSet(AbstractVersionedDataSet[pd.DataFrame, pd.DataFrame]):
     """`pandas.GenericDataSet` loads/saves data from/to a data file using an underlying
     filesystem (e.g.: local, S3, GCS). It uses pandas to dynamically select the
     appropriate type of read/write target on a best effort basis.
 
     Example using `YAML API
     <https://kedro.readthedocs.io/en/stable/data/\
-        data_catalog.html#using-the-data-catalog-with-the-yaml-api>`_:
+        data_catalog.html#use-the-data-catalog-with-the-yaml-api>`_:
 
     .. code-block:: yaml
 
@@ -72,7 +73,6 @@ class GenericDataSet(AbstractVersionedDataSet):
         >>> data = pd.DataFrame({'col1': [1, 2], 'col2': [4, 5],
         >>>                      'col3': [5, 6]})
         >>>
-        >>> # data_set = GenericDataSet(filepath="s3://test.csv", file_format='csv')
         >>> data_set = GenericDataSet(filepath="test.csv", file_format='csv')
         >>> data_set.save(data)
         >>> reloaded = data_set.load()
@@ -179,7 +179,7 @@ class GenericDataSet(AbstractVersionedDataSet):
                 f"does not support a filepath target/source."
             )
 
-    def _load(self) -> Any:
+    def _load(self) -> pd.DataFrame:
 
         self._ensure_file_system_target()
 

--- a/kedro-datasets/kedro_datasets/pandas/hdf_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/hdf_dataset.py
@@ -8,7 +8,6 @@ from typing import Any, Dict
 
 import fsspec
 import pandas as pd
-
 from kedro.io.core import (
     AbstractVersionedDataSet,
     DataSetError,

--- a/kedro-datasets/kedro_datasets/pandas/hdf_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/hdf_dataset.py
@@ -8,6 +8,7 @@ from typing import Any, Dict
 
 import fsspec
 import pandas as pd
+
 from kedro.io.core import (
     AbstractVersionedDataSet,
     DataSetError,
@@ -19,13 +20,13 @@ from kedro.io.core import (
 HDFSTORE_DRIVER = "H5FD_CORE"
 
 
-class HDFDataSet(AbstractVersionedDataSet):
+class HDFDataSet(AbstractVersionedDataSet[pd.DataFrame, pd.DataFrame]):
     """``HDFDataSet`` loads/saves data from/to a hdf file using an underlying
     filesystem (e.g. local, S3, GCS). It uses pandas.HDFStore to handle the hdf file.
 
     Example adding a catalog entry with
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
-        data_catalog.html#using-the-data-catalog-with-the-yaml-api>`_:
+        data_catalog.html#use-the-data-catalog-with-the-yaml-api>`_:
 
     .. code-block:: yaml
 
@@ -44,7 +45,6 @@ class HDFDataSet(AbstractVersionedDataSet):
         >>> data = pd.DataFrame({'col1': [1, 2], 'col2': [4, 5],
         >>>                      'col3': [5, 6]})
         >>>
-        >>> # data_set = HDFDataSet(filepath="gcs://bucket/test.hdf", key='data')
         >>> data_set = HDFDataSet(filepath="test.h5", key='data')
         >>> data_set.save(data)
         >>> reloaded = data_set.load()

--- a/kedro-datasets/kedro_datasets/pandas/json_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/json_dataset.py
@@ -9,6 +9,7 @@ from typing import Any, Dict
 
 import fsspec
 import pandas as pd
+
 from kedro.io.core import (
     PROTOCOL_DELIMITER,
     AbstractVersionedDataSet,
@@ -21,13 +22,13 @@ from kedro.io.core import (
 logger = logging.getLogger(__name__)
 
 
-class JSONDataSet(AbstractVersionedDataSet):
+class JSONDataSet(AbstractVersionedDataSet[pd.DataFrame, pd.DataFrame]):
     """``JSONDataSet`` loads/saves data from/to a JSON file using an underlying
     filesystem (e.g.: local, S3, GCS). It uses pandas to handle the json file.
 
     Example adding a catalog entry with
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
-        data_catalog.html#using-the-data-catalog-with-the-yaml-api>`_:
+        data_catalog.html#use-the-data-catalog-with-the-yaml-api>`_:
 
     .. code-block:: yaml
 
@@ -51,7 +52,6 @@ class JSONDataSet(AbstractVersionedDataSet):
         >>> data = pd.DataFrame({'col1': [1, 2], 'col2': [4, 5],
         >>>                      'col3': [5, 6]})
         >>>
-        >>> # data_set = JSONDataSet(filepath="gcs://bucket/test.json")
         >>> data_set = JSONDataSet(filepath="test.json")
         >>> data_set.save(data)
         >>> reloaded = data_set.load()
@@ -140,7 +140,7 @@ class JSONDataSet(AbstractVersionedDataSet):
             version=self._version,
         )
 
-    def _load(self) -> Any:
+    def _load(self) -> pd.DataFrame:
         load_path = str(self._get_load_path())
         if self._protocol == "file":
             # file:// protocol seems to misbehave on Windows

--- a/kedro-datasets/kedro_datasets/pandas/json_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/json_dataset.py
@@ -9,7 +9,6 @@ from typing import Any, Dict
 
 import fsspec
 import pandas as pd
-
 from kedro.io.core import (
     PROTOCOL_DELIMITER,
     AbstractVersionedDataSet,

--- a/kedro-datasets/kedro_datasets/pandas/parquet_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/parquet_dataset.py
@@ -10,6 +10,7 @@ from typing import Any, Dict
 import fsspec
 import pandas as pd
 import pyarrow.parquet as pq
+
 from kedro.io.core import (
     PROTOCOL_DELIMITER,
     AbstractVersionedDataSet,
@@ -22,13 +23,13 @@ from kedro.io.core import (
 logger = logging.getLogger(__name__)
 
 
-class ParquetDataSet(AbstractVersionedDataSet):
+class ParquetDataSet(AbstractVersionedDataSet[pd.DataFrame, pd.DataFrame]):
     """``ParquetDataSet`` loads/saves data from/to a Parquet file using an underlying
     filesystem (e.g.: local, S3, GCS). It uses pandas to handle the Parquet file.
 
     Example adding a catalog entry with
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
-        data_catalog.html#using-the-data-catalog-with-the-yaml-api>`_:
+        data_catalog.html#use-the-data-catalog-with-the-yaml-api>`_:
 
     .. code-block:: yaml
 
@@ -63,7 +64,6 @@ class ParquetDataSet(AbstractVersionedDataSet):
         >>> data = pd.DataFrame({'col1': [1, 2], 'col2': [4, 5],
         >>>                      'col3': [5, 6]})
         >>>
-        >>> # data_set = ParquetDataSet(filepath="gcs://bucket/test.parquet")
         >>> data_set = ParquetDataSet(filepath="test.parquet")
         >>> data_set.save(data)
         >>> reloaded = data_set.load()
@@ -197,7 +197,7 @@ class ParquetDataSet(AbstractVersionedDataSet):
         if "partition_cols" in self._save_args:
             raise DataSetError(
                 f"{self.__class__.__name__} does not support save argument "
-                f"'partition_cols'. Please use 'kedro_datasets.io.PartitionedDataSet' instead."
+                f"'partition_cols'. Please use 'kedro.io.PartitionedDataSet' instead."
             )
 
         bytes_buffer = BytesIO()

--- a/kedro-datasets/kedro_datasets/pandas/parquet_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/parquet_dataset.py
@@ -10,7 +10,6 @@ from typing import Any, Dict
 import fsspec
 import pandas as pd
 import pyarrow.parquet as pq
-
 from kedro.io.core import (
     PROTOCOL_DELIMITER,
     AbstractVersionedDataSet,

--- a/kedro-datasets/kedro_datasets/pandas/sql_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/sql_dataset.py
@@ -16,8 +16,6 @@ from kedro.io.core import (
     get_filepath_str,
     get_protocol_and_path,
 )
-from sqlalchemy import create_engine
-from sqlalchemy.exc import NoSuchModuleError
 
 __all__ = ["SQLTableDataSet", "SQLQueryDataSet"]
 

--- a/kedro-datasets/kedro_datasets/pandas/sql_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/sql_dataset.py
@@ -7,15 +7,14 @@ from typing import Any, Dict, NoReturn, Optional
 
 import fsspec
 import pandas as pd
-from sqlalchemy import create_engine
-from sqlalchemy.exc import NoSuchModuleError
-
 from kedro.io.core import (
     AbstractDataSet,
     DataSetError,
     get_filepath_str,
     get_protocol_and_path,
 )
+from sqlalchemy import create_engine
+from sqlalchemy.exc import NoSuchModuleError
 
 __all__ = ["SQLTableDataSet", "SQLQueryDataSet"]
 

--- a/kedro-datasets/kedro_datasets/pandas/sql_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/sql_dataset.py
@@ -3,10 +3,13 @@
 import copy
 import re
 from pathlib import PurePosixPath
-from typing import Any, Dict, Optional
+from typing import Any, Dict, NoReturn, Optional
 
 import fsspec
 import pandas as pd
+from sqlalchemy import create_engine
+from sqlalchemy.exc import NoSuchModuleError
+
 from kedro.io.core import (
     AbstractDataSet,
     DataSetError,
@@ -86,7 +89,7 @@ def _get_sql_alchemy_missing_error() -> DataSetError:
     )
 
 
-class SQLTableDataSet(AbstractDataSet):
+class SQLTableDataSet(AbstractDataSet[pd.DataFrame, pd.DataFrame]):
     """``SQLTableDataSet`` loads data from a SQL table and saves a pandas
     dataframe to a table. It uses ``pandas.DataFrame`` internally,
     so it supports all allowed pandas options on ``read_sql_table`` and
@@ -103,7 +106,7 @@ class SQLTableDataSet(AbstractDataSet):
 
     Example adding a catalog entry with
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
-        data_catalog.html#using-the-data-catalog-with-the-yaml-api>`_:
+        data_catalog.html#use-the-data-catalog-with-the-yaml-api>`_:
 
     .. code-block:: yaml
 
@@ -256,7 +259,7 @@ class SQLTableDataSet(AbstractDataSet):
         return exists
 
 
-class SQLQueryDataSet(AbstractDataSet):
+class SQLQueryDataSet(AbstractDataSet[None, pd.DataFrame]):
     """``SQLQueryDataSet`` loads data from a provided SQL query. It
     uses ``pandas.DataFrame`` internally, so it supports all allowed
     pandas options on ``read_sql_query``. Since Pandas uses SQLAlchemy behind
@@ -272,7 +275,7 @@ class SQLQueryDataSet(AbstractDataSet):
 
     Example adding a catalog entry with
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
-        data_catalog.html#using-the-data-catalog-with-the-yaml-api>`_:
+        data_catalog.html#use-the-data-catalog-with-the-yaml-api>`_:
 
     .. code-block:: yaml
 
@@ -428,5 +431,5 @@ class SQLQueryDataSet(AbstractDataSet):
 
         return pd.read_sql_query(con=engine, **load_args)
 
-    def _save(self, data: pd.DataFrame) -> None:
+    def _save(self, data: None) -> NoReturn:
         raise DataSetError("'save' is not supported on SQLQueryDataSet")

--- a/kedro-datasets/kedro_datasets/pandas/xml_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/xml_dataset.py
@@ -9,6 +9,7 @@ from typing import Any, Dict
 
 import fsspec
 import pandas as pd
+
 from kedro.io.core import (
     PROTOCOL_DELIMITER,
     AbstractVersionedDataSet,
@@ -21,7 +22,7 @@ from kedro.io.core import (
 logger = logging.getLogger(__name__)
 
 
-class XMLDataSet(AbstractVersionedDataSet):
+class XMLDataSet(AbstractVersionedDataSet[pd.DataFrame, pd.DataFrame]):
     """``XMLDataSet`` loads/saves data from/to a XML file using an underlying
     filesystem (e.g.: local, S3, GCS). It uses pandas to handle the XML file.
 
@@ -34,7 +35,6 @@ class XMLDataSet(AbstractVersionedDataSet):
         >>> data = pd.DataFrame({'col1': [1, 2], 'col2': [4, 5],
         >>>                      'col3': [5, 6]})
         >>>
-        >>> # data_set = XMLDataSet(filepath="gcs://bucket/test.xml")
         >>> data_set = XMLDataSet(filepath="test.xml")
         >>> data_set.save(data)
         >>> reloaded = data_set.load()

--- a/kedro-datasets/kedro_datasets/pandas/xml_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/xml_dataset.py
@@ -9,7 +9,6 @@ from typing import Any, Dict
 
 import fsspec
 import pandas as pd
-
 from kedro.io.core import (
     PROTOCOL_DELIMITER,
     AbstractVersionedDataSet,

--- a/kedro-datasets/kedro_datasets/pickle/pickle_dataset.py
+++ b/kedro-datasets/kedro_datasets/pickle/pickle_dataset.py
@@ -9,6 +9,7 @@ from pathlib import PurePosixPath
 from typing import Any, Dict
 
 import fsspec
+
 from kedro.io.core import (
     AbstractVersionedDataSet,
     DataSetError,
@@ -18,7 +19,7 @@ from kedro.io.core import (
 )
 
 
-class PickleDataSet(AbstractVersionedDataSet):
+class PickleDataSet(AbstractVersionedDataSet[Any, Any]):
     """``PickleDataSet`` loads/saves data from/to a Pickle file using an underlying
     filesystem (e.g.: local, S3, GCS). The underlying functionality is supported by
     the specified backend library passed in (defaults to the ``pickle`` library), so it
@@ -26,7 +27,7 @@ class PickleDataSet(AbstractVersionedDataSet):
 
     Example adding a catalog entry with
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
-        data_catalog.html#using-the-data-catalog-with-the-yaml-api>`_:
+        data_catalog.html#use-the-data-catalog-with-the-yaml-api>`_:
 
     .. code-block:: yaml
 
@@ -41,9 +42,7 @@ class PickleDataSet(AbstractVersionedDataSet):
         >>>   backend: joblib
         >>>   credentials: s3_credentials
         >>>   save_args:
-        >>>     compression: lz4
-        >>>   load_args:
-        >>>     compression: lz4
+        >>>     compress: lz4
 
     Example using Python API:
     ::
@@ -54,13 +53,11 @@ class PickleDataSet(AbstractVersionedDataSet):
         >>> data = pd.DataFrame({'col1': [1, 2], 'col2': [4, 5],
         >>>                      'col3': [5, 6]})
         >>>
-        >>> # data_set = PickleDataSet(filepath="gcs://bucket/test.pkl")
         >>> data_set = PickleDataSet(filepath="test.pkl", backend="pickle")
         >>> data_set.save(data)
         >>> reloaded = data_set.load()
         >>> assert data.equals(reloaded)
         >>>
-        >>> # Add "compress_pickle[lz4]" to requirements.txt
         >>> data_set = PickleDataSet(filepath="test.pickle.lz4",
         >>>                          backend="compress_pickle",
         >>>                          load_args={"compression":"lz4"},

--- a/kedro-datasets/kedro_datasets/pickle/pickle_dataset.py
+++ b/kedro-datasets/kedro_datasets/pickle/pickle_dataset.py
@@ -9,7 +9,6 @@ from pathlib import PurePosixPath
 from typing import Any, Dict
 
 import fsspec
-
 from kedro.io.core import (
     AbstractVersionedDataSet,
     DataSetError,

--- a/kedro-datasets/kedro_datasets/pillow/image_dataset.py
+++ b/kedro-datasets/kedro_datasets/pillow/image_dataset.py
@@ -6,8 +6,6 @@ from pathlib import PurePosixPath
 from typing import Any, Dict
 
 import fsspec
-from PIL import Image
-
 from kedro.io.core import (
     AbstractVersionedDataSet,
     DataSetError,
@@ -15,6 +13,7 @@ from kedro.io.core import (
     get_filepath_str,
     get_protocol_and_path,
 )
+from PIL import Image
 
 
 class ImageDataSet(AbstractVersionedDataSet[Image.Image, Image.Image]):

--- a/kedro-datasets/kedro_datasets/pillow/image_dataset.py
+++ b/kedro-datasets/kedro_datasets/pillow/image_dataset.py
@@ -6,6 +6,8 @@ from pathlib import PurePosixPath
 from typing import Any, Dict
 
 import fsspec
+from PIL import Image
+
 from kedro.io.core import (
     AbstractVersionedDataSet,
     DataSetError,
@@ -13,10 +15,9 @@ from kedro.io.core import (
     get_filepath_str,
     get_protocol_and_path,
 )
-from PIL import Image
 
 
-class ImageDataSet(AbstractVersionedDataSet):
+class ImageDataSet(AbstractVersionedDataSet[Image.Image, Image.Image]):
     """``ImageDataSet`` loads/saves image data as `numpy` from an underlying
     filesystem (e.g.: local, S3, GCS). It uses Pillow to handle image file.
 
@@ -25,7 +26,6 @@ class ImageDataSet(AbstractVersionedDataSet):
 
         >>> from kedro_datasets.pillow import ImageDataSet
         >>>
-        >>> # data_set = ImageDataSet(filepath="gcs://bucket/test.png")
         >>> data_set = ImageDataSet(filepath="test.png")
         >>> image = data_set.load()
         >>> image.show()
@@ -106,13 +106,13 @@ class ImageDataSet(AbstractVersionedDataSet):
             version=self._version,
         )
 
-    def _load(self) -> Image:
+    def _load(self) -> Image.Image:
         load_path = get_filepath_str(self._get_load_path(), self._protocol)
 
         with self._fs.open(load_path, **self._fs_open_args_load) as fs_file:
             return Image.open(fs_file).copy()
 
-    def _save(self, data: Image) -> None:
+    def _save(self, data: Image.Image) -> None:
         save_path = get_filepath_str(self._get_save_path(), self._protocol)
 
         with self._fs.open(save_path, **self._fs_open_args_save) as fs_file:

--- a/kedro-datasets/kedro_datasets/plotly/json_dataset.py
+++ b/kedro-datasets/kedro_datasets/plotly/json_dataset.py
@@ -7,14 +7,13 @@ from typing import Any, Dict, Union
 
 import fsspec
 import plotly.io as pio
-from plotly import graph_objects as go
-
 from kedro.io.core import (
     AbstractVersionedDataSet,
     Version,
     get_filepath_str,
     get_protocol_and_path,
 )
+from plotly import graph_objects as go
 
 
 class JSONDataSet(

--- a/kedro-datasets/kedro_datasets/plotly/json_dataset.py
+++ b/kedro-datasets/kedro_datasets/plotly/json_dataset.py
@@ -7,16 +7,19 @@ from typing import Any, Dict, Union
 
 import fsspec
 import plotly.io as pio
+from plotly import graph_objects as go
+
 from kedro.io.core import (
     AbstractVersionedDataSet,
     Version,
     get_filepath_str,
     get_protocol_and_path,
 )
-from plotly import graph_objects as go
 
 
-class JSONDataSet(AbstractVersionedDataSet):
+class JSONDataSet(
+    AbstractVersionedDataSet[go.Figure, Union[go.Figure, go.FigureWidget]]
+):
     """``JSONDataSet`` loads/saves a plotly figure from/to a JSON file using an
     underlying filesystem (e.g.: local, S3, GCS).
 

--- a/kedro-datasets/kedro_datasets/plotly/plotly_dataset.py
+++ b/kedro-datasets/kedro_datasets/plotly/plotly_dataset.py
@@ -7,8 +7,9 @@ from typing import Any, Dict
 
 import pandas as pd
 import plotly.express as px
-from kedro.io.core import Version
 from plotly import graph_objects as go
+
+from kedro.io.core import Version
 
 from .json_dataset import JSONDataSet
 
@@ -22,21 +23,22 @@ class PlotlyDataSet(JSONDataSet):
     the JSON file directly from a pandas DataFrame through ``plotly_args``.
 
     Example configuration for a PlotlyDataSet in the catalog:
-    ::
+
+    .. code-block:: yaml
 
         >>> bar_plot:
-        >>>     type: plotly.PlotlyDataSet
-        >>>     filepath: data/08_reporting/bar_plot.json
-        >>>     plotly_args:
-        >>>         type: bar
-        >>>         fig:
-        >>>             x: features
-        >>>             y: importance
-        >>>             orientation: h
-        >>>         layout:
-        >>>             xaxis_title: x
-        >>>             yaxis_title: y
-        >>>             title: Test
+        >>>   type: plotly.PlotlyDataSet
+        >>>   filepath: data/08_reporting/bar_plot.json
+        >>>   plotly_args:
+        >>>     type: bar
+        >>>     fig:
+        >>>         x: features
+        >>>         y: importance
+        >>>         orientation: h
+        >>>     layout:
+        >>>         xaxis_title: x
+        >>>         yaxis_title: y
+        >>>         title: Title
     """
 
     # pylint: disable=too-many-arguments

--- a/kedro-datasets/kedro_datasets/plotly/plotly_dataset.py
+++ b/kedro-datasets/kedro_datasets/plotly/plotly_dataset.py
@@ -7,9 +7,8 @@ from typing import Any, Dict
 
 import pandas as pd
 import plotly.express as px
-from plotly import graph_objects as go
-
 from kedro.io.core import Version
+from plotly import graph_objects as go
 
 from .json_dataset import JSONDataSet
 

--- a/kedro-datasets/kedro_datasets/redis/redis_dataset.py
+++ b/kedro-datasets/kedro_datasets/redis/redis_dataset.py
@@ -8,7 +8,6 @@ from copy import deepcopy
 from typing import Any, Dict
 
 import redis
-
 from kedro.io.core import AbstractDataSet, DataSetError
 
 

--- a/kedro-datasets/kedro_datasets/redis/redis_dataset.py
+++ b/kedro-datasets/kedro_datasets/redis/redis_dataset.py
@@ -8,10 +8,11 @@ from copy import deepcopy
 from typing import Any, Dict
 
 import redis
+
 from kedro.io.core import AbstractDataSet, DataSetError
 
 
-class PickleDataSet(AbstractDataSet):
+class PickleDataSet(AbstractDataSet[Any, Any]):
     """``PickleDataSet`` loads/saves data from/to a Redis database. The
     underlying functionality is supported by the redis library, so it supports
     all allowed options for instantiating the redis app ``from_url`` and setting
@@ -19,7 +20,7 @@ class PickleDataSet(AbstractDataSet):
 
     Example adding a catalog entry with
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
-        data_catalog.html#using-the-data-catalog-with-the-yaml-api>`_:
+        data_catalog.html#use-the-data-catalog-with-the-yaml-api>`_:
 
     .. code-block:: yaml
 
@@ -42,6 +43,7 @@ class PickleDataSet(AbstractDataSet):
     ::
 
         >>> from kedro_datasets.redis import PickleDataSet
+        >>> import pandas as pd
         >>>
         >>> data = pd.DataFrame({'col1': [1, 2], 'col2': [4, 5],
         >>>                       'col3': [5, 6]})

--- a/kedro-datasets/kedro_datasets/spark/deltatable_dataset.py
+++ b/kedro-datasets/kedro_datasets/spark/deltatable_dataset.py
@@ -2,22 +2,25 @@
 ``delta-spark``
 """
 from pathlib import PurePosixPath
-from typing import Any
+from typing import NoReturn
 
 from delta.tables import DeltaTable
-from kedro.io.core import AbstractDataSet, DataSetError
 from pyspark.sql import SparkSession
 from pyspark.sql.utils import AnalysisException
 
-from kedro_datasets.spark.spark_dataset import _split_filepath, _strip_dbfs_prefix
+from kedro_datasets.spark.spark_dataset import (
+    _split_filepath,
+    _strip_dbfs_prefix,
+)
+from kedro.io.core import AbstractDataSet, DataSetError
 
 
-class DeltaTableDataSet(AbstractDataSet):
+class DeltaTableDataSet(AbstractDataSet[None, DeltaTable]):
     """``DeltaTableDataSet`` loads data into DeltaTable objects.
 
         Example adding a catalog entry with
         `YAML API <https://kedro.readthedocs.io/en/stable/05_data/\
-            01_data_catalog.html#using-the-data-catalog-with-the-yaml-api>`_:
+            01_data_catalog.html#use-the-data-catalog-with-the-yaml-api>`_:
 
         .. code-block:: yaml
 
@@ -82,7 +85,7 @@ class DeltaTableDataSet(AbstractDataSet):
         load_path = self._fs_prefix + str(self._filepath)
         return DeltaTable.forPath(self._get_spark(), load_path)
 
-    def _save(self, data: Any) -> None:
+    def _save(self, data: None) -> NoReturn:
         raise DataSetError(f"{self.__class__.__name__} is a read only dataset type")
 
     def _exists(self) -> bool:

--- a/kedro-datasets/kedro_datasets/spark/deltatable_dataset.py
+++ b/kedro-datasets/kedro_datasets/spark/deltatable_dataset.py
@@ -5,14 +5,11 @@ from pathlib import PurePosixPath
 from typing import NoReturn
 
 from delta.tables import DeltaTable
+from kedro.io.core import AbstractDataSet, DataSetError
 from pyspark.sql import SparkSession
 from pyspark.sql.utils import AnalysisException
 
-from kedro_datasets.spark.spark_dataset import (
-    _split_filepath,
-    _strip_dbfs_prefix,
-)
-from kedro.io.core import AbstractDataSet, DataSetError
+from kedro_datasets.spark.spark_dataset import _split_filepath, _strip_dbfs_prefix
 
 
 class DeltaTableDataSet(AbstractDataSet[None, DeltaTable]):

--- a/kedro-datasets/kedro_datasets/spark/spark_dataset.py
+++ b/kedro-datasets/kedro_datasets/spark/spark_dataset.py
@@ -11,6 +11,11 @@ from warnings import warn
 
 import fsspec
 from hdfs import HdfsError, InsecureClient
+from pyspark.sql import DataFrame, SparkSession
+from pyspark.sql.types import StructType
+from pyspark.sql.utils import AnalysisException
+from s3fs import S3FileSystem
+
 from kedro.io.core import (
     AbstractVersionedDataSet,
     DataSetError,
@@ -18,10 +23,6 @@ from kedro.io.core import (
     get_filepath_str,
     get_protocol_and_path,
 )
-from pyspark.sql import DataFrame, SparkSession
-from pyspark.sql.types import StructType
-from pyspark.sql.utils import AnalysisException
-from s3fs import S3FileSystem
 
 
 def _parse_glob_pattern(pattern: str) -> str:
@@ -156,12 +157,12 @@ class KedroHdfsInsecureClient(InsecureClient):
         return sorted(matched)
 
 
-class SparkDataSet(AbstractVersionedDataSet):
+class SparkDataSet(AbstractVersionedDataSet[DataFrame, DataFrame]):
     """``SparkDataSet`` loads and saves Spark dataframes.
 
     Example adding a catalog entry with
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
-        data_catalog.html#using-the-data-catalog-with-the-yaml-api>`_:
+        data_catalog.html#use-the-data-catalog-with-the-yaml-api>`_:
 
     .. code-block:: yaml
 

--- a/kedro-datasets/kedro_datasets/spark/spark_dataset.py
+++ b/kedro-datasets/kedro_datasets/spark/spark_dataset.py
@@ -11,11 +11,6 @@ from warnings import warn
 
 import fsspec
 from hdfs import HdfsError, InsecureClient
-from pyspark.sql import DataFrame, SparkSession
-from pyspark.sql.types import StructType
-from pyspark.sql.utils import AnalysisException
-from s3fs import S3FileSystem
-
 from kedro.io.core import (
     AbstractVersionedDataSet,
     DataSetError,
@@ -23,6 +18,10 @@ from kedro.io.core import (
     get_filepath_str,
     get_protocol_and_path,
 )
+from pyspark.sql import DataFrame, SparkSession
+from pyspark.sql.types import StructType
+from pyspark.sql.utils import AnalysisException
+from s3fs import S3FileSystem
 
 
 def _parse_glob_pattern(pattern: str) -> str:

--- a/kedro-datasets/kedro_datasets/spark/spark_hive_dataset.py
+++ b/kedro-datasets/kedro_datasets/spark/spark_hive_dataset.py
@@ -5,13 +5,14 @@ import pickle
 from copy import deepcopy
 from typing import Any, Dict, List
 
-from kedro.io.core import AbstractDataSet, DataSetError
 from pyspark.sql import DataFrame, SparkSession, Window
 from pyspark.sql.functions import col, lit, row_number
 
+from kedro.io.core import AbstractDataSet, DataSetError
+
 
 # pylint:disable=too-many-instance-attributes
-class SparkHiveDataSet(AbstractDataSet):
+class SparkHiveDataSet(AbstractDataSet[DataFrame, DataFrame]):
     """``SparkHiveDataSet`` loads and saves Spark dataframes stored on Hive.
     This data set also handles some incompatible file types such as using partitioned parquet on
     hive which will not normally allow upserts to existing data without a complete replacement
@@ -26,7 +27,7 @@ class SparkHiveDataSet(AbstractDataSet):
 
     Example adding a catalog entry with
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
-        data_catalog.html#using-the-data-catalog-with-the-yaml-api>`_:
+        data_catalog.html#use-the-data-catalog-with-the-yaml-api>`_:
 
     .. code-block:: yaml
 
@@ -113,7 +114,7 @@ class SparkHiveDataSet(AbstractDataSet):
         self._save_args = deepcopy(self.DEFAULT_SAVE_ARGS)
         if save_args is not None:
             self._save_args.update(save_args)
-        self._format = self._save_args.get("format") or "hive"
+        self._format = self._save_args.pop("format", None) or "hive"
         self._eager_checkpoint = self._save_args.pop("eager_checkpoint", None) or True
 
     def _describe(self) -> Dict[str, Any]:

--- a/kedro-datasets/kedro_datasets/spark/spark_hive_dataset.py
+++ b/kedro-datasets/kedro_datasets/spark/spark_hive_dataset.py
@@ -5,10 +5,9 @@ import pickle
 from copy import deepcopy
 from typing import Any, Dict, List
 
+from kedro.io.core import AbstractDataSet, DataSetError
 from pyspark.sql import DataFrame, SparkSession, Window
 from pyspark.sql.functions import col, lit, row_number
-
-from kedro.io.core import AbstractDataSet, DataSetError
 
 
 # pylint:disable=too-many-instance-attributes

--- a/kedro-datasets/kedro_datasets/spark/spark_jdbc_dataset.py
+++ b/kedro-datasets/kedro_datasets/spark/spark_jdbc_dataset.py
@@ -3,9 +3,8 @@
 from copy import deepcopy
 from typing import Any, Dict
 
-from pyspark.sql import DataFrame, SparkSession
-
 from kedro.io.core import AbstractDataSet, DataSetError
+from pyspark.sql import DataFrame, SparkSession
 
 __all__ = ["SparkJDBCDataSet"]
 

--- a/kedro-datasets/kedro_datasets/spark/spark_jdbc_dataset.py
+++ b/kedro-datasets/kedro_datasets/spark/spark_jdbc_dataset.py
@@ -3,13 +3,14 @@
 from copy import deepcopy
 from typing import Any, Dict
 
-from kedro.io.core import AbstractDataSet, DataSetError
 from pyspark.sql import DataFrame, SparkSession
+
+from kedro.io.core import AbstractDataSet, DataSetError
 
 __all__ = ["SparkJDBCDataSet"]
 
 
-class SparkJDBCDataSet(AbstractDataSet):
+class SparkJDBCDataSet(AbstractDataSet[DataFrame, DataFrame]):
     """``SparkJDBCDataSet`` loads data from a database table accessible
     via JDBC URL url and connection properties and saves the content of
     a PySpark DataFrame to an external database table via JDBC.  It uses
@@ -19,7 +20,7 @@ class SparkJDBCDataSet(AbstractDataSet):
 
     Example adding a catalog entry with
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
-        data_catalog.html#using-the-data-catalog-with-the-yaml-api>`_:
+        data_catalog.html#use-the-data-catalog-with-the-yaml-api>`_:
 
     .. code-block:: yaml
 

--- a/kedro-datasets/kedro_datasets/tensorflow/tensorflow_model_dataset.py
+++ b/kedro-datasets/kedro_datasets/tensorflow/tensorflow_model_dataset.py
@@ -8,7 +8,6 @@ from typing import Any, Dict
 
 import fsspec
 import tensorflow as tf
-
 from kedro.io.core import (
     AbstractVersionedDataSet,
     DataSetError,

--- a/kedro-datasets/kedro_datasets/tensorflow/tensorflow_model_dataset.py
+++ b/kedro-datasets/kedro_datasets/tensorflow/tensorflow_model_dataset.py
@@ -3,11 +3,12 @@ TensorFlow models.
 """
 import copy
 import tempfile
-from pathlib import Path, PurePath, PurePosixPath
+from pathlib import PurePath, PurePosixPath
 from typing import Any, Dict
 
 import fsspec
 import tensorflow as tf
+
 from kedro.io.core import (
     AbstractVersionedDataSet,
     DataSetError,
@@ -19,19 +20,33 @@ from kedro.io.core import (
 TEMPORARY_H5_FILE = "tmp_tensorflow_model.h5"
 
 
-class TensorFlowModelDataset(AbstractVersionedDataSet):
+class TensorFlowModelDataset(AbstractVersionedDataSet[tf.keras.Model, tf.keras.Model]):
     """``TensorflowModelDataset`` loads and saves TensorFlow models.
     The underlying functionality is supported by, and passes input arguments through to,
     TensorFlow 2.X load_model and save_model methods.
 
-    Example:
+    .. code-block:: yaml
+
+        >>> tensorflow_model:
+        >>>   type: tensorflow.TensorFlowModelDataset
+        >>>   filepath: data/06_models/tensorflow_model.h5
+        >>>   load_args:
+        >>>     compile: False
+        >>>   save_args:
+        >>>     overwrite: True
+        >>>     include_optimizer: False
+        >>>   credentials: tf_creds
+        >>>
+
+
+    Example using Python API:
     ::
 
         >>> from kedro_datasets.tensorflow import TensorFlowModelDataset
         >>> import tensorflow as tf
         >>> import numpy as np
         >>>
-        >>> data_set = TensorFlowModelDataset("saved_model_path")
+        >>> data_set = TensorFlowModelDataset("data/06_models/tensorflow_model.h5")
         >>> model = tf.keras.Model()
         >>> predictions = model.predict([...])
         >>>
@@ -117,14 +132,16 @@ class TensorFlowModelDataset(AbstractVersionedDataSet):
                 self._fs.get(load_path, path, recursive=True)
 
             # Pass the local temporary directory/file path to keras.load_model
-            return tf.keras.models.load_model(path, **self._load_args)
+            device_name = self._load_args.pop("tf_device", None)
+            if device_name:
+                with tf.device(device_name):
+                    model = tf.keras.models.load_model(path, **self._load_args)
+            else:
+                model = tf.keras.models.load_model(path, **self._load_args)
+            return model
 
     def _save(self, data: tf.keras.Model) -> None:
         save_path = get_filepath_str(self._get_save_path(), self._protocol)
-
-        # Make sure all intermediate directories are created.
-        save_dir = Path(save_path).parent
-        save_dir.mkdir(parents=True, exist_ok=True)
 
         with tempfile.TemporaryDirectory(prefix=self._tmp_prefix) as path:
             if self._is_h5:
@@ -137,6 +154,8 @@ class TensorFlowModelDataset(AbstractVersionedDataSet):
             if self._is_h5:
                 self._fs.copy(path, save_path)
             else:
+                if self._fs.exists(save_path):
+                    self._fs.rm(save_path, recursive=True)
                 self._fs.put(path, save_path, recursive=True)
 
     def _exists(self) -> bool:

--- a/kedro-datasets/kedro_datasets/text/text_dataset.py
+++ b/kedro-datasets/kedro_datasets/text/text_dataset.py
@@ -6,6 +6,7 @@ from pathlib import PurePosixPath
 from typing import Any, Dict
 
 import fsspec
+
 from kedro.io.core import (
     AbstractVersionedDataSet,
     DataSetError,
@@ -15,7 +16,7 @@ from kedro.io.core import (
 )
 
 
-class TextDataSet(AbstractVersionedDataSet):
+class TextDataSet(AbstractVersionedDataSet[str, str]):
     """``TextDataSet`` loads/saves data from/to a text file using an underlying
     filesystem (e.g.: local, S3, GCS)
 
@@ -26,7 +27,6 @@ class TextDataSet(AbstractVersionedDataSet):
         >>>
         >>> string_to_write = "This will go in a file."
         >>>
-        >>> # data_set = TextDataSet(filepath="gcs://bucket/test.md")
         >>> data_set = TextDataSet(filepath="test.md")
         >>> data_set.save(string_to_write)
         >>> reloaded = data_set.load()

--- a/kedro-datasets/kedro_datasets/text/text_dataset.py
+++ b/kedro-datasets/kedro_datasets/text/text_dataset.py
@@ -6,7 +6,6 @@ from pathlib import PurePosixPath
 from typing import Any, Dict
 
 import fsspec
-
 from kedro.io.core import (
     AbstractVersionedDataSet,
     DataSetError,

--- a/kedro-datasets/kedro_datasets/tracking/json_dataset.py
+++ b/kedro-datasets/kedro_datasets/tracking/json_dataset.py
@@ -4,8 +4,9 @@ The ``JSONDataSet`` is part of Kedro Experiment Tracking. The dataset is version
 """
 from typing import NoReturn
 
-from kedro_datasets.json import JSONDataSet as JDS
 from kedro.io.core import DataSetError
+
+from kedro_datasets.json import JSONDataSet as JDS
 
 
 class JSONDataSet(JDS):

--- a/kedro-datasets/kedro_datasets/tracking/json_dataset.py
+++ b/kedro-datasets/kedro_datasets/tracking/json_dataset.py
@@ -2,35 +2,42 @@
 filesystem (e.g.: local, S3, GCS). It uses native json to handle the JSON file.
 The ``JSONDataSet`` is part of Kedro Experiment Tracking. The dataset is versioned by default.
 """
-from typing import Dict
-
-from kedro.io.core import DataSetError
+from typing import NoReturn
 
 from kedro_datasets.json import JSONDataSet as JDS
+from kedro.io.core import DataSetError
 
 
 class JSONDataSet(JDS):
     """``JSONDataSet`` saves data to a JSON file using an underlying
     filesystem (e.g.: local, S3, GCS). It uses native json to handle the JSON file.
     The ``JSONDataSet`` is part of Kedro Experiment Tracking.
-    The dataset is versioned by default.
+    The dataset is write-only and it is versioned by default.
 
-        Example:
-        ::
+    Example adding a catalog entry with
+    `YAML API
+    <https://kedro.readthedocs.io/en/stable/data/\
+        data_catalog.html#use-the-data-catalog-with-the-yaml-api>`_:
+
+    .. code-block:: yaml
+
+        >>> cars:
+        >>>   type: tracking.JSONDataSet
+        >>>   filepath: data/09_tracking/cars.json
+
+    Example using Python API:
+    ::
 
         >>> from kedro_datasets.tracking import JSONDataSet
         >>>
         >>> data = {'col1': 1, 'col2': 0.23, 'col3': 0.002}
         >>>
-        >>> # data_set = JSONDataSet(filepath="gcs://bucket/test.json")
         >>> data_set = JSONDataSet(filepath="test.json")
         >>> data_set.save(data)
-        >>> reloaded = data_set.load()
-        >>> assert data == reloaded
 
     """
 
     versioned = True
 
-    def _load(self) -> Dict:
+    def _load(self) -> NoReturn:
         raise DataSetError(f"Loading not supported for '{self.__class__.__name__}'")

--- a/kedro-datasets/kedro_datasets/tracking/metrics_dataset.py
+++ b/kedro-datasets/kedro_datasets/tracking/metrics_dataset.py
@@ -6,8 +6,9 @@ and only takes metrics of numeric values.
 import json
 from typing import Dict, NoReturn
 
-from kedro_datasets.json import JSONDataSet
 from kedro.io.core import DataSetError, get_filepath_str
+
+from kedro_datasets.json import JSONDataSet
 
 
 class MetricsDataSet(JSONDataSet):

--- a/kedro-datasets/kedro_datasets/tracking/metrics_dataset.py
+++ b/kedro-datasets/kedro_datasets/tracking/metrics_dataset.py
@@ -4,37 +4,44 @@ The ``MetricsDataSet`` is part of Kedro Experiment Tracking. The dataset is vers
 and only takes metrics of numeric values.
 """
 import json
-from typing import Dict
-
-from kedro.io.core import DataSetError, get_filepath_str
+from typing import Dict, NoReturn
 
 from kedro_datasets.json import JSONDataSet
+from kedro.io.core import DataSetError, get_filepath_str
 
 
 class MetricsDataSet(JSONDataSet):
     """``MetricsDataSet`` saves data to a JSON file using an underlying
-    filesystem (e.g.: local, S3, GCS). It uses native json to handle the JSON file.
-    The ``MetricsDataSet`` is part of Kedro Experiment Tracking. The dataset is versioned by default
-    and only takes metrics of numeric values.
+    filesystem (e.g.: local, S3, GCS). It uses native json to handle the JSON file. The
+    ``MetricsDataSet`` is part of Kedro Experiment Tracking. The dataset is write-only,
+    it is versioned by default and only takes metrics of numeric values.
 
-        Example:
-        ::
+Example adding a catalog entry with
+    `YAML API
+    <https://kedro.readthedocs.io/en/stable/data/\
+        data_catalog.html#use-the-data-catalog-with-the-yaml-api>`_:
+
+    .. code-block:: yaml
+
+        >>> cars:
+        >>>   type: metrics.MetricsDataSet
+        >>>   filepath: data/09_tracking/cars.json
+
+    Example using Python API:
+    ::
 
         >>> from kedro_datasets.tracking import MetricsDataSet
         >>>
         >>> data = {'col1': 1, 'col2': 0.23, 'col3': 0.002}
         >>>
-        >>> # data_set = MetricsDataSet(filepath="gcs://bucket/test.json")
         >>> data_set = MetricsDataSet(filepath="test.json")
         >>> data_set.save(data)
-        >>> reloaded = data_set.load()
-        >>> assert data == reloaded
 
     """
 
     versioned = True
 
-    def _load(self) -> Dict:
+    def _load(self) -> NoReturn:
         raise DataSetError(f"Loading not supported for '{self.__class__.__name__}'")
 
     def _save(self, data: Dict[str, float]) -> None:

--- a/kedro-datasets/kedro_datasets/yaml/yaml_dataset.py
+++ b/kedro-datasets/kedro_datasets/yaml/yaml_dataset.py
@@ -7,7 +7,6 @@ from typing import Any, Dict
 
 import fsspec
 import yaml
-
 from kedro.io.core import (
     AbstractVersionedDataSet,
     DataSetError,

--- a/kedro-datasets/kedro_datasets/yaml/yaml_dataset.py
+++ b/kedro-datasets/kedro_datasets/yaml/yaml_dataset.py
@@ -7,6 +7,7 @@ from typing import Any, Dict
 
 import fsspec
 import yaml
+
 from kedro.io.core import (
     AbstractVersionedDataSet,
     DataSetError,
@@ -16,18 +17,28 @@ from kedro.io.core import (
 )
 
 
-class YAMLDataSet(AbstractVersionedDataSet):
+class YAMLDataSet(AbstractVersionedDataSet[Dict, Dict]):
     """``YAMLDataSet`` loads/saves data from/to a YAML file using an underlying
     filesystem (e.g.: local, S3, GCS). It uses PyYAML to handle the YAML file.
 
-    Example:
+    Example adding a catalog entry with
+    `YAML API
+    <https://kedro.readthedocs.io/en/stable/data/\
+        data_catalog.html#use-the-data-catalog-with-the-yaml-api>`_:
+
+    .. code-block:: yaml
+
+        >>> cars:
+        >>>   type: yaml.YAMLDataSet
+        >>>   filepath: cars.yaml
+
+    Example using Python API:
     ::
 
         >>> from kedro_datasets.yaml import YAMLDataSet
         >>>
         >>> data = {'col1': [1, 2], 'col2': [4, 5], 'col3': [5, 6]}
         >>>
-        >>> # data_set = YAMLDataSet(filepath="gcs://bucket/test.yaml")
         >>> data_set = YAMLDataSet(filepath="test.yaml")
         >>> data_set.save(data)
         >>> reloaded = data_set.load()

--- a/kedro-datasets/tests/conftest.py
+++ b/kedro-datasets/tests/conftest.py
@@ -5,9 +5,8 @@ discover them automatically. More info here:
 https://docs.pytest.org/en/latest/fixture.html
 """
 
-from pytest import fixture
-
 from kedro.io.core import generate_timestamp
+from pytest import fixture
 
 
 @fixture(params=[None])

--- a/kedro-datasets/tests/conftest.py
+++ b/kedro-datasets/tests/conftest.py
@@ -5,8 +5,9 @@ discover them automatically. More info here:
 https://docs.pytest.org/en/latest/fixture.html
 """
 
-from kedro.io.core import generate_timestamp
 from pytest import fixture
+
+from kedro.io.core import generate_timestamp
 
 
 @fixture(params=[None])

--- a/kedro-datasets/tests/pandas/test_csv_dataset.py
+++ b/kedro-datasets/tests/pandas/test_csv_dataset.py
@@ -7,12 +7,12 @@ from adlfs import AzureBlobFileSystem
 from fsspec.implementations.http import HTTPFileSystem
 from fsspec.implementations.local import LocalFileSystem
 from gcsfs import GCSFileSystem
+from kedro.io import DataSetError
+from kedro.io.core import PROTOCOL_DELIMITER, Version, generate_timestamp
 from pandas.testing import assert_frame_equal
 from s3fs.core import S3FileSystem
 
 from kedro_datasets.pandas import CSVDataSet
-from kedro.io import DataSetError
-from kedro.io.core import PROTOCOL_DELIMITER, Version, generate_timestamp
 
 
 @pytest.fixture

--- a/kedro-datasets/tests/pandas/test_csv_dataset.py
+++ b/kedro-datasets/tests/pandas/test_csv_dataset.py
@@ -1,6 +1,9 @@
+import os
+import sys
 from pathlib import Path, PurePosixPath
 from time import sleep
 
+import boto3
 import pandas as pd
 import pytest
 from adlfs import AzureBlobFileSystem
@@ -9,10 +12,14 @@ from fsspec.implementations.local import LocalFileSystem
 from gcsfs import GCSFileSystem
 from kedro.io import DataSetError
 from kedro.io.core import PROTOCOL_DELIMITER, Version, generate_timestamp
+from moto import mock_s3
 from pandas.testing import assert_frame_equal
 from s3fs.core import S3FileSystem
 
 from kedro_datasets.pandas import CSVDataSet
+
+BUCKET_NAME = "test_bucket"
+FILE_NAME = "test.csv"
 
 
 @pytest.fixture
@@ -37,6 +44,45 @@ def versioned_csv_data_set(filepath_csv, load_version, save_version):
 @pytest.fixture
 def dummy_dataframe():
     return pd.DataFrame({"col1": [1, 2], "col2": [4, 5], "col3": [5, 6]})
+
+
+@pytest.fixture
+def partitioned_data_pandas():
+    return {
+        f"p{counter:02d}/data.csv": pd.DataFrame(
+            {"part": counter, "col": list(range(counter + 1))}
+        )
+        for counter in range(5)
+    }
+
+
+@pytest.fixture
+def mocked_s3_bucket():
+    """Create a bucket for testing using moto."""
+    with mock_s3():
+        conn = boto3.client(
+            "s3",
+            aws_access_key_id="fake_access_key",
+            aws_secret_access_key="fake_secret_key",
+        )
+        conn.create_bucket(Bucket=BUCKET_NAME)
+        yield conn
+
+
+@pytest.fixture
+def mocked_dataframe():
+    df = pd.DataFrame([{"dummy": "dummy"}])
+    return df
+
+
+@pytest.fixture
+def mocked_csv_in_s3(mocked_s3_bucket, mocked_dataframe):
+    mocked_s3_bucket.put_object(
+        Bucket=BUCKET_NAME,
+        Key=FILE_NAME,
+        Body=mocked_dataframe.to_csv(index=False),
+    )
+    return f"s3://{BUCKET_NAME}/{FILE_NAME}"
 
 
 class TestCSVDataSet:
@@ -298,3 +344,27 @@ class TestCSVDataSetVersioned:
         Path(csv_data_set._filepath.as_posix()).unlink()
         versioned_csv_data_set.save(dummy_dataframe)
         assert versioned_csv_data_set.exists()
+
+
+class TestCSVDataSetS3:
+    os.environ["AWS_ACCESS_KEY_ID"] = "FAKE_ACCESS_KEY"
+    os.environ["AWS_SECRET_ACCESS_KEY"] = "FAKE_SECRET_KEY"
+
+    def test_load_and_confirm(self, mocker, mocked_csv_in_s3, mocked_dataframe):
+        """Test the standard flow for loading, confirming and reloading a
+        IncrementalDataSet in S3
+
+        Unmodified Test fails in Python >= 3.10 if executed after test_protocol_usage
+        (any implementation using S3FileSystem). Likely to be a bug with moto (tested
+        with moto==4.0.8, moto==3.0.4) -- see #67
+        """
+        df = CSVDataSet(mocked_csv_in_s3)
+        assert df._protocol == "s3"
+        # if Python >= 3.10, modify test procedure (see #67)
+        if sys.version_info[1] >= 10:
+            read_patch = mocker.patch("pandas.read_csv", return_value=mocked_dataframe)
+            df.load()
+            read_patch.assert_called_once_with(mocked_csv_in_s3, storage_options={})
+        else:
+            loaded = df.load()
+            assert_frame_equal(loaded, mocked_dataframe)

--- a/kedro-datasets/tests/pandas/test_csv_dataset.py
+++ b/kedro-datasets/tests/pandas/test_csv_dataset.py
@@ -1,25 +1,18 @@
-import os
-import sys
 from pathlib import Path, PurePosixPath
 from time import sleep
 
-import boto3
 import pandas as pd
 import pytest
 from adlfs import AzureBlobFileSystem
 from fsspec.implementations.http import HTTPFileSystem
 from fsspec.implementations.local import LocalFileSystem
 from gcsfs import GCSFileSystem
-from kedro.io import DataSetError
-from kedro.io.core import PROTOCOL_DELIMITER, Version, generate_timestamp
-from moto import mock_s3
 from pandas.testing import assert_frame_equal
 from s3fs.core import S3FileSystem
 
 from kedro_datasets.pandas import CSVDataSet
-
-BUCKET_NAME = "test_bucket"
-FILE_NAME = "test.csv"
+from kedro.io import DataSetError
+from kedro.io.core import PROTOCOL_DELIMITER, Version, generate_timestamp
 
 
 @pytest.fixture
@@ -44,45 +37,6 @@ def versioned_csv_data_set(filepath_csv, load_version, save_version):
 @pytest.fixture
 def dummy_dataframe():
     return pd.DataFrame({"col1": [1, 2], "col2": [4, 5], "col3": [5, 6]})
-
-
-@pytest.fixture
-def partitioned_data_pandas():
-    return {
-        f"p{counter:02d}/data.csv": pd.DataFrame(
-            {"part": counter, "col": list(range(counter + 1))}
-        )
-        for counter in range(5)
-    }
-
-
-@pytest.fixture
-def mocked_s3_bucket():
-    """Create a bucket for testing using moto."""
-    with mock_s3():
-        conn = boto3.client(
-            "s3",
-            aws_access_key_id="fake_access_key",
-            aws_secret_access_key="fake_secret_key",
-        )
-        conn.create_bucket(Bucket=BUCKET_NAME)
-        yield conn
-
-
-@pytest.fixture
-def mocked_dataframe():
-    df = pd.DataFrame([{"dummy": "dummy"}])
-    return df
-
-
-@pytest.fixture
-def mocked_csv_in_s3(mocked_s3_bucket, mocked_dataframe):
-    mocked_s3_bucket.put_object(
-        Bucket=BUCKET_NAME,
-        Key=FILE_NAME,
-        Body=mocked_dataframe.to_csv(index=False),
-    )
-    return f"s3://{BUCKET_NAME}/{FILE_NAME}"
 
 
 class TestCSVDataSet:
@@ -344,27 +298,3 @@ class TestCSVDataSetVersioned:
         Path(csv_data_set._filepath.as_posix()).unlink()
         versioned_csv_data_set.save(dummy_dataframe)
         assert versioned_csv_data_set.exists()
-
-
-class TestCSVDataSetS3:
-    os.environ["AWS_ACCESS_KEY_ID"] = "FAKE_ACCESS_KEY"
-    os.environ["AWS_SECRET_ACCESS_KEY"] = "FAKE_SECRET_KEY"
-
-    def test_load_and_confirm(self, mocker, mocked_csv_in_s3, mocked_dataframe):
-        """Test the standard flow for loading, confirming and reloading a
-        IncrementalDataSet in S3
-
-        Unmodified Test fails in Python >= 3.10 if executed after test_protocol_usage
-        (any implementation using S3FileSystem). Likely to be a bug with moto (tested
-        with moto==4.0.8, moto==3.0.4) -- see #67
-        """
-        df = CSVDataSet(mocked_csv_in_s3)
-        assert df._protocol == "s3"
-        # if Python >= 3.10, modify test procedure (see #67)
-        if sys.version_info[1] >= 10:
-            read_patch = mocker.patch("pandas.read_csv", return_value=mocked_dataframe)
-            df.load()
-            read_patch.assert_called_once_with(mocked_csv_in_s3, storage_options={})
-        else:
-            loaded = df.load()
-            assert_frame_equal(loaded, mocked_dataframe)

--- a/kedro-datasets/tests/spark/test_spark_hive_dataset.py
+++ b/kedro-datasets/tests/spark/test_spark_hive_dataset.py
@@ -4,13 +4,13 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 
 import pytest
+from kedro.io import DataSetError
 from psutil import Popen
 from pyspark import SparkContext
 from pyspark.sql import SparkSession
 from pyspark.sql.types import IntegerType, StringType, StructField, StructType
 
 from kedro_datasets.spark import SparkHiveDataSet
-from kedro.io import DataSetError
 
 TESTSPARKDIR = "test_spark_dir"
 

--- a/kedro-datasets/tests/spark/test_spark_hive_dataset.py
+++ b/kedro-datasets/tests/spark/test_spark_hive_dataset.py
@@ -4,13 +4,13 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 
 import pytest
-from kedro.io import DataSetError
 from psutil import Popen
 from pyspark import SparkContext
 from pyspark.sql import SparkSession
 from pyspark.sql.types import IntegerType, StringType, StructField, StructType
 
 from kedro_datasets.spark import SparkHiveDataSet
+from kedro.io import DataSetError
 
 TESTSPARKDIR = "test_spark_dir"
 
@@ -301,3 +301,14 @@ class TestSparkHiveDataSet:
             r"table_doesnt_exist\], \[\], false\n",
         ):
             dataset.load()
+
+    def test_save_delta_format(self, mocker):
+        dataset = SparkHiveDataSet(
+            database="default_1", table="delta_table", save_args={"format": "delta"}
+        )
+        mocked_save = mocker.patch("pyspark.sql.DataFrameWriter.saveAsTable")
+        dataset.save(_generate_spark_df_one())
+        mocked_save.assert_called_with(
+            "default_1.delta_table", mode="errorifexists", format="delta"
+        )
+        assert dataset._format == "delta"

--- a/kedro-datasets/tests/tensorflow/test_tensorflow_model_dataset.py
+++ b/kedro-datasets/tests/tensorflow/test_tensorflow_model_dataset.py
@@ -6,10 +6,9 @@ import pytest
 from fsspec.implementations.http import HTTPFileSystem
 from fsspec.implementations.local import LocalFileSystem
 from gcsfs import GCSFileSystem
-from s3fs import S3FileSystem
-
 from kedro.io import DataSetError
 from kedro.io.core import PROTOCOL_DELIMITER, Version
+from s3fs import S3FileSystem
 
 
 # In this test module, we wrap tensorflow and TensorFlowModelDataset imports into a module-scoped

--- a/kedro-datasets/tests/tensorflow/test_tensorflow_model_dataset.py
+++ b/kedro-datasets/tests/tensorflow/test_tensorflow_model_dataset.py
@@ -6,9 +6,10 @@ import pytest
 from fsspec.implementations.http import HTTPFileSystem
 from fsspec.implementations.local import LocalFileSystem
 from gcsfs import GCSFileSystem
+from s3fs import S3FileSystem
+
 from kedro.io import DataSetError
 from kedro.io.core import PROTOCOL_DELIMITER, Version
-from s3fs import S3FileSystem
 
 
 # In this test module, we wrap tensorflow and TensorFlowModelDataset imports into a module-scoped
@@ -84,6 +85,24 @@ def dummy_tf_base_model(dummy_x_train, dummy_y_train, tf):
     outputs = tf.keras.layers.Dense(1)(x)
 
     model = tf.keras.Model(inputs=inputs, outputs=outputs, name="1_layer_dummy")
+    model.compile("rmsprop", "mse")
+    model.fit(dummy_x_train, dummy_y_train, batch_size=64, epochs=1)
+    # from https://www.tensorflow.org/guide/keras/save_and_serialize
+    # Reset metrics before saving so that loaded model has same state,
+    # since metric states are not preserved by Model.save_weights
+    model.reset_metrics()
+    return model
+
+
+@pytest.fixture
+def dummy_tf_base_model_new(dummy_x_train, dummy_y_train, tf):
+    # dummy 2 layer model
+    inputs = tf.keras.Input(shape=(2, 1))
+    x = tf.keras.layers.Dense(1)(inputs)
+    x = tf.keras.layers.Dense(1)(x)
+    outputs = tf.keras.layers.Dense(1)(x)
+
+    model = tf.keras.Model(inputs=inputs, outputs=outputs, name="2_layer_dummy")
     model.compile("rmsprop", "mse")
     model.fit(dummy_x_train, dummy_y_train, batch_size=64, epochs=1)
     # from https://www.tensorflow.org/guide/keras/save_and_serialize
@@ -245,6 +264,19 @@ class TestTensorFlowModelDataset:
         mocker.patch("kedro.io.core.get_filepath_str", side_effct=DataSetError)
         assert not tf_model_dataset.exists()
 
+    def test_save_and_overwrite_existing_model(
+        self, tf_model_dataset, dummy_tf_base_model, dummy_tf_base_model_new
+    ):
+        """Test models are correcty overwritten."""
+        tf_model_dataset.save(dummy_tf_base_model)
+
+        tf_model_dataset.save(dummy_tf_base_model_new)
+
+        reloaded = tf_model_dataset.load()
+
+        assert len(dummy_tf_base_model.layers) != len(reloaded.layers)
+        assert len(dummy_tf_base_model_new.layers) == len(reloaded.layers)
+
 
 class TestTensorFlowModelDatasetVersioned:
     """Test suite with versioning argument passed into TensorFlowModelDataset creator"""
@@ -384,3 +416,26 @@ class TestTensorFlowModelDatasetVersioned:
         assert tf_model_dataset._filepath == versioned_tf_model_dataset._filepath
         versioned_tf_model_dataset.save(dummy_tf_base_model)
         assert versioned_tf_model_dataset.exists()
+
+    def test_save_and_load_with_device(
+        self,
+        dummy_tf_base_model,
+        dummy_x_test,
+        filepath,
+        tensorflow_model_dataset,
+        load_version,
+        save_version,
+    ):
+        """Test versioned TensorflowModelDataset can load models using an explicit tf_device"""
+        hdf5_dataset = tensorflow_model_dataset(
+            filepath=filepath,
+            load_args={"tf_device": "/CPU:0"},
+            version=Version(load_version, save_version),
+        )
+
+        predictions = dummy_tf_base_model.predict(dummy_x_test)
+        hdf5_dataset.save(dummy_tf_base_model)
+
+        reloaded = hdf5_dataset.load()
+        new_predictions = reloaded.predict(dummy_x_test)
+        np.testing.assert_allclose(predictions, new_predictions, rtol=1e-6, atol=1e-6)


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
kedro-datasets is a bit out of date from `kedro.extras.dataset`, causing issues in https://github.com/kedro-org/kedro/pull/2006 where linkcheck in CI would fail once kedro-dataset is copied to `kedro.datasets`. 
## Development notes
<!-- What have you changed, and how has this been tested? -->

- Copied all `kedro.extras.datasets` into kedro-datasets
- Copied relevant tests that needed updating

## Checklist

- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
