### PR TITLE
Trigger kedro builds for docs when new kedro-datasets commit/release

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -391,44 +391,6 @@ jobs:
             make package
             make pypi
 
-  # Trigger kedro docs build on main branch
-  kedro_build_datasets_main:
-    docker:
-      - image: spotify/alpine # for bash and curl
-    steps:
-      - run:
-          name: Trigger kedro docs build
-          command: |
-            curl --location --request POST \
-              --url https://circleci.com/api/v2/project/github/kedro-org/kedro/pipeline \
-              --header "Circle-Token: $CIRCLE_KEDRO_BUILD_TOKEN" \
-              --header 'content-type: application/json' \
-              --data '{
-                "branch":"main",
-                "parameters": {
-                  "docs_change":true
-                }
-              }'
-
-  # Trigger kedro docs build on latest release
-  kedro_build_datasets_release:
-    docker:
-      - image: spotify/alpine # for bash and curl
-    steps:
-      - run:
-          name: Trigger kedro docs build
-          command: |
-            curl --location --request POST \
-              --url https://circleci.com/api/v2/project/github/kedro-org/kedro/pipeline \
-              --header "Circle-Token: $CIRCLE_KEDRO_BUILD_TOKEN" \
-              --header 'content-type: application/json' \
-              --data '{
-                "branch":"main",
-                "parameters": {
-                  "docs_change":true
-                }
-              }'
-
 workflows:
   # when pipeline parameter, run-build-kedro-telemetry is true, the
   # kedro-telemetry job is triggered.
@@ -540,7 +502,6 @@ workflows:
             # We just need one Python enviornment to trigger the job
             parameters:
               python_version: ["3.8"]
-      - kedro_build_datasets_main
 
   package_release:
     when:
@@ -555,4 +516,3 @@ workflows:
       - publish_package:
           requires:
             - build_package
-      - kedro_build_datasets_release

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -426,8 +426,7 @@ jobs:
               --data '{
                 "branch":"main",
                 "parameters": {
-                  "docs_change": true,
-                  "kedro_datasets_release": true
+                  "docs_change": true
                 }
               }'
 

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -406,8 +406,7 @@ jobs:
               --data '{
                 "branch":"main",
                 "parameters": {
-                  "docs_change": true,
-                  "kedro_datasets_release": false
+                  "docs_change": true
                 }
               }'
 

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -391,7 +391,7 @@ jobs:
             make package
             make pypi
 
-  # Trigger kedro docs build
+  # Trigger kedro docs build on main branch
   kedro_build_datasets_main:
     docker:
       - image: spotify/alpine # for bash and curl
@@ -403,7 +403,33 @@ jobs:
               --url https://circleci.com/api/v2/project/github/kedro-org/kedro/pipeline \
               --header "Circle-Token: $CIRCLE_KEDRO_BUILD_TOKEN" \
               --header 'content-type: application/json' \
-              --data '{"branch":"main"}'
+              --data '{
+                "branch":"main",
+                "parameters": {
+                  "docs_change": true,
+                  "kedro_datasets_release": false
+                }
+              }'
+
+  # Trigger kedro docs build on latest release
+  kedro_build_datasets_release:
+    docker:
+      - image: spotify/alpine # for bash and curl
+    steps:
+      - run:
+          name: Trigger kedro docs build
+          command: |
+            curl --location --request POST \
+              --url https://circleci.com/api/v2/project/github/kedro-org/kedro/pipeline \
+              --header "Circle-Token: $CIRCLE_KEDRO_BUILD_TOKEN" \
+              --header 'content-type: application/json' \
+              --data '{
+                "branch":"main",
+                "parameters": {
+                  "docs_change": true,
+                  "kedro_datasets_release": true
+                }
+              }'
 
 workflows:
   # when pipeline parameter, run-build-kedro-telemetry is true, the
@@ -516,6 +542,7 @@ workflows:
             # We just need one Python enviornment to trigger the job
             parameters:
               python_version: ["3.8"]
+      - kedro_build_datasets_main
 
   package_release:
     when:
@@ -530,3 +557,4 @@ workflows:
       - publish_package:
           requires:
             - build_package
+      - kedro_build_datasets_release

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -406,7 +406,7 @@ jobs:
               --data '{
                 "branch":"main",
                 "parameters": {
-                  "docs_change": true
+                  "docs_change":true
                 }
               }'
 
@@ -425,7 +425,7 @@ jobs:
               --data '{
                 "branch":"main",
                 "parameters": {
-                  "docs_change": true
+                  "docs_change":true
                 }
               }'
 

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -391,6 +391,19 @@ jobs:
             make package
             make pypi
 
+  # Trigger kedro docs build
+  kedro_build_datasets_main:
+    docker:
+      - image: spotify/alpine # for bash and curl
+    steps:
+      - run:
+          name: Trigger kedro docs build
+          command: |
+            curl --location --request POST \
+              --url https://circleci.com/api/v2/project/github/kedro-org/kedro/pipeline \
+              --header "Circle-Token: $CIRCLE_KEDRO_BUILD_TOKEN" \
+              --header 'content-type: application/json' \
+              --data '{"branch":"main"}'
 
 workflows:
   # when pipeline parameter, run-build-kedro-telemetry is true, the

--- a/kedro-datasets/README.md
+++ b/kedro-datasets/README.md
@@ -33,3 +33,5 @@ Here is a full list of [supported data connectors and APIs](https://kedro.readth
 
 
 Take a look at our [instructions on how to create your own `AbstractDataSet` implementation](https://kedro.readthedocs.io/en/stable/extend_kedro/custom_datasets.html).
+
+REMOVE_ME.

--- a/kedro-datasets/setup.py
+++ b/kedro-datasets/setup.py
@@ -47,8 +47,8 @@ pandas_require = {
     "pandas.CSVDataSet": [PANDAS],
     "pandas.ExcelDataSet": [PANDAS, "openpyxl>=3.0.6, <4.0"],
     "pandas.FeatherDataSet": [PANDAS],
-    "pandas.GBQTableDataSet": [PANDAS, "pandas-gbq>=0.12.0, <1.0"],
-    "pandas.GBQQueryDataSet": [PANDAS, "pandas-gbq>=0.12.0, <1.0"],
+    "pandas.GBQTableDataSet": [PANDAS, "pandas-gbq>=0.12.0, <0.18.0"],
+    "pandas.GBQQueryDataSet": [PANDAS, "pandas-gbq>=0.12.0, <0.18.0"],
     "pandas.HDFDataSet": [
         PANDAS,
         "tables~=3.6.0; platform_system == 'Windows'",

--- a/kedro-datasets/test_requirements.txt
+++ b/kedro-datasets/test_requirements.txt
@@ -28,7 +28,7 @@ moto==1.3.7; python_version < '3.10'
 moto==3.0.4; python_version == '3.10'
 networkx~=2.4
 openpyxl>=3.0.3, <4.0
-pandas-gbq>=0.12.0, <1.0
+pandas-gbq>=0.12.0, <0.18.0
 pandas~=1.3  # 1.3 for read_xml/to_xml
 Pillow~=9.0
 plotly>=4.8.0, <6.0


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
Part of the: https://github.com/kedro-org/kedro/pull/2006 PR

As part of the solution outlined in https://github.com/kedro-org/kedro/issues/1651#issuecomment-1240692700 when `kedro-datasets` has a commit to `main`, it needs to trigger a re-build of the kedro docs using `kedro` branch `main` and `kedro-datasets` branch `main`. This should update RTD `latest` build.

When `kedro-datasets` has a release, it needs to trigger a re-build of the kedro docs using `kedro` branch latest release (not `main`) and `kedro-datasets` branch `main` (which is the same as the latest release). This updates RTD `stable` and `${KEDRO_VERSION}` build.

## Development notes
<!-- What have you changed, and how has this been tested? -->
Following the `viz_build` job in kedro's `continue_config.yml` created kedro_build_datasets_main

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
