### PR TITLE
Optimize image layers with project code

### DIFF
--- a/kedro-docker/RELEASE.md
+++ b/kedro-docker/RELEASE.md
@@ -4,6 +4,8 @@
 
 ## Bug fixes and other changes
 
+* Optimized image layers that store project code
+
 ## Breaking changes to the API
 
 # Release 0.3.0

--- a/kedro-docker/kedro_docker/template/Dockerfile.simple
+++ b/kedro-docker/kedro_docker/template/Dockerfile.simple
@@ -13,10 +13,8 @@ useradd -d /home/kedro_docker -s /bin/bash -g ${KEDRO_GID} -u ${KEDRO_UID} kedro
 
 # copy the whole project except what is in .dockerignore
 WORKDIR /home/kedro_docker
-COPY . .
-RUN chown -R kedro_docker:${KEDRO_GID} /home/kedro_docker
 USER kedro_docker
-RUN chmod -R a+w /home/kedro_docker
+COPY --chown=${KEDRO_UID}:${KEDRO_GID} . .
 
 EXPOSE 8888
 

--- a/kedro-docker/kedro_docker/template/Dockerfile.spark
+++ b/kedro-docker/kedro_docker/template/Dockerfile.spark
@@ -52,10 +52,8 @@ useradd -d /home/kedro_docker -s /bin/bash -g ${KEDRO_GID} -u ${KEDRO_UID} kedro
 
 # copy the whole project except what is in .dockerignore
 WORKDIR /home/kedro_docker
-COPY . .
-RUN chown -R kedro_docker:${KEDRO_GID} /home/kedro_docker
 USER kedro_docker
-RUN chmod -R a+w /home/kedro_docker
+COPY --chown=${KEDRO_UID}:${KEDRO_GID} . .
 
 EXPOSE 8888
 


### PR DESCRIPTION
## Description

Current templates in `kedro-docker` create 3 layers with user code for every build (due to separate copy->chown->chmod stages). However, during image build we can specify what should be the target owner of the files. Also, there is no need to run `chmod`, as file/dirs permission is preserved.

## Development notes

Tested locally by building the docker image and examining the filesystem. Layers optimization reduce both build time and image size.

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [x] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
