### PR TITLE
Fix `kedro-telemetry` dependency breaking packaged projects without `pyproject.toml`

### DIFF
--- a/kedro-telemetry/kedro_telemetry/plugin.py
+++ b/kedro-telemetry/kedro_telemetry/plugin.py
@@ -136,7 +136,7 @@ class KedroTelemetryProjectHooks:  # pylint: disable=too-few-public-methods
 
 def _get_project_properties(hashed_username: str) -> Dict:
 
-    hashed_package_name = _hash(PACKAGE_NAME)
+    hashed_package_name = _hash(PACKAGE_NAME) if PACKAGE_NAME else "undefined"
 
     return {
         "username": hashed_username,

--- a/kedro-telemetry/kedro_telemetry/plugin.py
+++ b/kedro-telemetry/kedro_telemetry/plugin.py
@@ -144,9 +144,12 @@ def _get_project_properties(
     hashed_username: str, project_metadata: Optional[ProjectMetadata] = None
 ) -> Dict:
 
-    hashed_package_name = _hash(getattr(project_metadata, "package_name", "undefined"))
-    hashed_project_name = _hash(getattr(project_metadata, "project_name", "undefined"))
-    project_version = getattr(project_metadata, "project_version", "undefined")
+    if project_metadata:
+        hashed_package_name = _hash(project_metadata.package_name)
+        hashed_project_name = _hash(project_metadata.project_name)
+        project_version = project_metadata.project_version
+    else:
+        hashed_package_name = hashed_project_name = project_version = "undefined"
 
     return {
         "username": hashed_username,

--- a/kedro-telemetry/tests/test_plugin.py
+++ b/kedro-telemetry/tests/test_plugin.py
@@ -81,6 +81,7 @@ class TestKedroTelemetryCLIHooks:
         )
         mocked_anon_id = mocker.patch("kedro_telemetry.plugin._hash")
         mocked_anon_id.return_value = "digested"
+        mocker.patch("kedro_telemetry.plugin.PACKAGE_NAME", "spaceflights")
         mocker.patch(
             "kedro_telemetry.plugin._get_hashed_username",
             return_value="hashed_username",
@@ -93,7 +94,6 @@ class TestKedroTelemetryCLIHooks:
         expected_properties = {
             "username": "hashed_username",
             "package_name": "digested",
-            "project_name": "digested",
             "project_version": kedro_version,
             "telemetry_version": TELEMETRY_VERSION,
             "python_version": sys.version,
@@ -125,6 +125,7 @@ class TestKedroTelemetryCLIHooks:
         )
         mocked_anon_id = mocker.patch("kedro_telemetry.plugin._hash")
         mocked_anon_id.return_value = "digested"
+        mocker.patch("kedro_telemetry.plugin.PACKAGE_NAME", "spaceflights")
 
         mocked_heap_call = mocker.patch("kedro_telemetry.plugin._send_heap_event")
         telemetry_hook = KedroTelemetryCLIHooks()
@@ -133,7 +134,6 @@ class TestKedroTelemetryCLIHooks:
         expected_properties = {
             "username": "digested",
             "package_name": "digested",
-            "project_name": "digested",
             "project_version": kedro_version,
             "telemetry_version": TELEMETRY_VERSION,
             "python_version": sys.version,
@@ -193,6 +193,7 @@ class TestKedroTelemetryCLIHooks:
         )
         mocked_anon_id = mocker.patch("kedro_telemetry.plugin._hash")
         mocked_anon_id.return_value = "digested"
+        mocker.patch("kedro_telemetry.plugin.PACKAGE_NAME", "spaceflights")
         mocker.patch("getpass.getuser", side_effect=Exception)
 
         mocked_heap_call = mocker.patch("kedro_telemetry.plugin._send_heap_event")
@@ -203,7 +204,6 @@ class TestKedroTelemetryCLIHooks:
             "username": "",
             "command": "kedro --version",
             "package_name": "digested",
-            "project_name": "digested",
             "project_version": kedro_version,
             "telemetry_version": TELEMETRY_VERSION,
             "python_version": sys.version,
@@ -336,7 +336,6 @@ class TestKedroTelemetryHooks:
         fake_default_pipeline,
         fake_sub_pipeline,
     ):
-
         mocker.patch.dict(
             pipelines, {"__default__": fake_default_pipeline, "sub": fake_sub_pipeline}
         )
@@ -344,14 +343,12 @@ class TestKedroTelemetryHooks:
             "kedro_telemetry.plugin._check_for_telemetry_consent", return_value=True
         )
         mocker.patch("kedro_telemetry.plugin._hash", return_value="digested")
+        mocker.patch("kedro_telemetry.plugin.PACKAGE_NAME", "spaceflights")
         mocker.patch(
             "kedro_telemetry.plugin._get_hashed_username",
             return_value="hashed_username",
         )
         mocked_heap_call = mocker.patch("kedro_telemetry.plugin._send_heap_event")
-        mocker.patch(
-            "kedro_telemetry.plugin._get_project_metadata", return_value=fake_metadata
-        )
 
         # Without CLI invoked - i.e. `session.run` in Jupyter/IPython
         telemetry_hook = KedroTelemetryProjectHooks()
@@ -360,7 +357,6 @@ class TestKedroTelemetryHooks:
         project_properties = {
             "username": "hashed_username",
             "package_name": "digested",
-            "project_name": "digested",
             "project_version": kedro_version,
             "telemetry_version": TELEMETRY_VERSION,
             "python_version": sys.version,
@@ -398,14 +394,12 @@ class TestKedroTelemetryHooks:
             "kedro_telemetry.plugin._check_for_telemetry_consent", return_value=True
         )
         mocker.patch("kedro_telemetry.plugin._hash", return_value="digested")
+        mocker.patch("kedro_telemetry.plugin.PACKAGE_NAME", "spaceflights")
         mocker.patch(
             "kedro_telemetry.plugin._get_hashed_username",
             return_value="hashed_username",
         )
         mocked_heap_call = mocker.patch("kedro_telemetry.plugin._send_heap_event")
-        mocker.patch(
-            "kedro_telemetry.plugin._get_project_metadata", return_value=fake_metadata
-        )
         # CLI run first
         telemetry_cli_hook = KedroTelemetryCLIHooks()
         command_args = ["--version"]
@@ -418,7 +412,6 @@ class TestKedroTelemetryHooks:
         project_properties = {
             "username": "hashed_username",
             "package_name": "digested",
-            "project_name": "digested",
             "project_version": kedro_version,
             "telemetry_version": TELEMETRY_VERSION,
             "python_version": sys.version,

--- a/kedro-telemetry/tests/test_plugin.py
+++ b/kedro-telemetry/tests/test_plugin.py
@@ -332,7 +332,6 @@ class TestKedroTelemetryHooks:
         self,
         mocker,
         fake_context,
-        fake_metadata,
         fake_default_pipeline,
         fake_sub_pipeline,
     ):


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
Resolves #83.

## Development notes
Currently, when `kedro-telemetry` is installed in a packaged project that is deployed without a `pyproject.toml` file, a `RuntimeError` is thrown which prevents Kedro from being used at all in this way. It is currently necessary to read `pyproject.toml` to get three pieces of information about the project, which are then sent to heap:

- Package name
- Project name
- Project version


~~In the case that no `pyproject.toml` is present, I believe there is no other guaranteed 'source of truth' for these values. Therefore, my approach is to set these values to the string `undefined` in this case.~~

Instead of using `pyproject.toml` to find these values, this PR makes the following changes:

- Package name is found using the import `from kedro.framework.project import PACKAGE_NAME`.
- Project name is a leftover that is not important to store if we already know the package name and since there is currently no easy way of accessing this value, it is discarded.
- Project version is found using the import `from kedro import __version__`. This is the version of Kedro being used to run the project, which I feel is more important than the version of Kedro used to create the project. Feedback would be appreciated on this point.

`pyproject.toml` is therefore no longer read at all.

**Note:** in the case that `kedro.framework.project.PACKAGE_NAME` is `None`, `hashed_package_name` will be set to `undefined`. I am not sure when this would ever happen, but I think it would be better to have some value here that will at least stop the plugin from breaking the project if this case ever occurs.

## Checklist

- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
