### PR TITLE
Change `ParquetDataSet` to load using pandas instead of parquet

### DIFF
--- a/kedro-datasets/kedro_datasets/pandas/parquet_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/parquet_dataset.py
@@ -157,17 +157,7 @@ class ParquetDataSet(AbstractVersionedDataSet[pd.DataFrame, pd.DataFrame]):
 
     def _load(self) -> pd.DataFrame:
         load_path = get_filepath_str(self._get_load_path(), self._protocol)
-
-        if self._fs.isdir(load_path):
-            # It doesn't work at least on S3 if root folder was created manually
-            # https://issues.apache.org/jira/browse/ARROW-7867
-            data = (
-                pq.ParquetDataset(load_path, filesystem=self._fs)
-                .read(**self._load_args)
-                .to_pandas()
-            )
-        else:
-            data = self._load_from_pandas()
+        data = self._load_from_pandas()
 
         return data
 

--- a/kedro-datasets/kedro_datasets/pandas/parquet_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/parquet_dataset.py
@@ -9,7 +9,6 @@ from typing import Any, Dict
 
 import fsspec
 import pandas as pd
-import pyarrow.parquet as pq
 from kedro.io.core import (
     PROTOCOL_DELIMITER,
     AbstractVersionedDataSet,

--- a/kedro-datasets/kedro_datasets/pandas/parquet_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/parquet_dataset.py
@@ -156,12 +156,6 @@ class ParquetDataSet(AbstractVersionedDataSet[pd.DataFrame, pd.DataFrame]):
         )
 
     def _load(self) -> pd.DataFrame:
-        load_path = get_filepath_str(self._get_load_path(), self._protocol)
-        data = self._load_from_pandas()
-
-        return data
-
-    def _load_from_pandas(self):
         load_path = str(self._get_load_path())
         if self._protocol == "file":
             # file:// protocol seems to misbehave on Windows

--- a/kedro-datasets/tests/pandas/test_parquet_dataset.py
+++ b/kedro-datasets/tests/pandas/test_parquet_dataset.py
@@ -1,7 +1,6 @@
 from pathlib import Path, PurePosixPath
 
 import pandas as pd
-import pyarrow.parquet as pq
 import pytest
 from fsspec.implementations.http import HTTPFileSystem
 from fsspec.implementations.local import LocalFileSystem

--- a/kedro-datasets/tests/pandas/test_parquet_dataset.py
+++ b/kedro-datasets/tests/pandas/test_parquet_dataset.py
@@ -168,9 +168,7 @@ class TestParquetDataSet:
 
     def test_read_partitioned_file(self, mocker, tmp_path, dummy_dataframe):
         """Test read partitioned parquet file from local directory."""
-        pq_ds_mock = mocker.patch(
-            "pyarrow.parquet.ParquetDataset", wraps=pq.ParquetDataset
-        )
+        mock_pandas_call = mocker.patch("pandas.read_parquet", wraps=pd.read_parquet)
         dummy_dataframe.to_parquet(str(tmp_path), partition_cols=["col2"])
         data_set = ParquetDataSet(filepath=tmp_path.as_posix())
 
@@ -182,7 +180,7 @@ class TestParquetDataSet:
         assert_frame_equal(
             dummy_dataframe, reloaded, check_dtype=False, check_categorical=False
         )
-        pq_ds_mock.assert_called_once()
+        mock_pandas_call.assert_called_once()
 
     def test_write_to_dir(self, dummy_dataframe, tmp_path):
         data_set = ParquetDataSet(filepath=tmp_path.as_posix())
@@ -192,27 +190,20 @@ class TestParquetDataSet:
             data_set.save(dummy_dataframe)
 
     def test_read_from_non_local_dir(self, mocker):
-        fs_mock = mocker.patch("fsspec.filesystem").return_value
-        fs_mock.isdir.return_value = True
-        pq_ds_mock = mocker.patch("pyarrow.parquet.ParquetDataset")
+        mock_pandas_call = mocker.patch("pandas.read_parquet")
 
         data_set = ParquetDataSet(filepath="s3://bucket/dir")
 
         data_set.load()
-        fs_mock.isdir.assert_called_once()
-        assert not fs_mock.open.called
-        pq_ds_mock.assert_called_once_with("bucket/dir", filesystem=fs_mock)
-        pq_ds_mock().read().to_pandas.assert_called_once_with()
+        assert mock_pandas_call.call_count == 1
 
     def test_read_from_file(self, mocker):
-        fs_mock = mocker.patch("fsspec.filesystem").return_value
-        fs_mock.isdir.return_value = False
-        mocker.patch("pandas.read_parquet")
+        mock_pandas_call = mocker.patch("pandas.read_parquet")
 
         data_set = ParquetDataSet(filepath="/tmp/test.parquet")
 
         data_set.load()
-        fs_mock.isdir.assert_called_once()
+        assert mock_pandas_call.call_count == 1
 
     def test_arg_partition_cols(self, dummy_dataframe, tmp_path):
         data_set = ParquetDataSet(


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->

Related issue: https://github.com/kedro-org/kedro-plugins/issues/88

Pandas now support the loading of parquet natively. It should be possible to remove the if-else statement here: https://github.com/kedro-org/kedro-plugins/blob/main/kedro-datasets/kedro_datasets/pandas/parquet_dataset.py#L161-L169

## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
