### PR TITLE
Fix dataset docs

### DIFF
--- a/kedro-datasets/kedro_datasets/video/video_dataset.py
+++ b/kedro-datasets/kedro_datasets/video/video_dataset.py
@@ -205,9 +205,8 @@ class VideoDataSet(AbstractDataSet[AbstractVideo, AbstractVideo]):
         >>>   type: video.VideoDataSet
         >>>   filepath: data/01_raw/cars.mp4
         >>>
-        >>> cars:
+        >>> motorbikes:
         >>>   type: video.VideoDataSet
-        >>>   filepath: data/01_raw/cars.mp4
         >>>   filepath: s3://your_bucket/data/02_intermediate/company/motorbikes.mp4
         >>>   credentials: dev_s3
         >>>

--- a/kedro-datasets/kedro_datasets/video/video_dataset.py
+++ b/kedro-datasets/kedro_datasets/video/video_dataset.py
@@ -201,6 +201,7 @@ class VideoDataSet(AbstractDataSet[AbstractVideo, AbstractVideo]):
         data_catalog.html#use-the-data-catalog-with-the-yaml-api>`_:
 
     .. code-block:: yaml
+
         >>> cars:
         >>>   type: video.VideoDataSet
         >>>   filepath: data/01_raw/cars.mp4


### PR DESCRIPTION
## Description
The doc string had a syntax error, no space between `.. code-block:: yaml` and the start of the example, which makes the read the doc build fail. 

## Development notes
Ran the build locally to check it's working. 

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
