### PR TITLE
Fix an error in docstring of MetricsDataSet

### DIFF
--- a/kedro-datasets/kedro_datasets/tracking/metrics_dataset.py
+++ b/kedro-datasets/kedro_datasets/tracking/metrics_dataset.py
@@ -25,7 +25,7 @@ Example adding a catalog entry with
     .. code-block:: yaml
 
         >>> cars:
-        >>>   type: metrics.MetricsDataSet
+        >>>   type: tracking.MetricsDataSet
         >>>   filepath: data/09_tracking/cars.json
 
     Example using Python API:


### PR DESCRIPTION
## Description
The doc loooks to have an error in the example.

Incorrect:

```yaml
cars:
  type: metrics.MetricsDataSet
  filepath: data/09_tracking/cars.json
```

Correct:

```yaml
cars:
  type: tracking.MetricsDataSet
  filepath: data/09_tracking/cars.json
```

## Development notes

This is just for the doc. No modification on code.

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
