### PR TITLE
Bump relax pyarrow version to work the same way as Pandas

### DIFF
--- a/kedro-datasets/RELEASE.md
+++ b/kedro-datasets/RELEASE.md
@@ -1,6 +1,8 @@
 
 # Upcoming Release:
 
+* Relaxed PyArrow range in line with Pandas
+
 # Release 1.0.1:
 
 ## Bug fixes and other changes

--- a/kedro-datasets/setup.py
+++ b/kedro-datasets/setup.py
@@ -55,7 +55,7 @@ pandas_require = {
         "tables~=3.6; platform_system != 'Windows'",
     ],
     "pandas.JSONDataSet": [PANDAS],
-    "pandas.ParquetDataSet": [PANDAS, "pyarrow>=1.0, <7.0"],
+    "pandas.ParquetDataSet": [PANDAS, "pyarrow>=6.0"],
     "pandas.SQLTableDataSet": [PANDAS, "SQLAlchemy~=1.2"],
     "pandas.SQLQueryDataSet": [PANDAS, "SQLAlchemy~=1.2"],
     "pandas.XMLDataSet": [PANDAS, "lxml~=4.6"],


### PR DESCRIPTION
## Description
We only use PyArrow for `pandas.ParquetDataSet` as such I suggest we keep our versions pinned to the same range as [Pandas does](https://github.com/pandas-dev/pandas/blob/96fc51f5ec678394373e2c779ccff37ddb966e75/pyproject.toml#L100) for the same reason.

As such I suggest we remove the upper bound as we have users requesting later versions in [support channels](https://kedro-org.slack.com/archives/C03RKP2LW64/p1674040509133529)


## Development notes
Tweaked boundaries

## Checklist

- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Added a description of this change in the relevant `RELEASE.md` file
- [x] Added tests to cover my changes
