### PR TITLE
Change check to check on plugin name

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -250,7 +250,7 @@ jobs:
       # For anything not `kedro-datasets`
       - unless:
           condition:
-            equal: [true, <<pipeline.parameters.run-build-kedro-datasets>>]
+            equal: ["kedro-datasets", <<parameters.plugin>>]
 
           # e2e tests are not currently runnable on CircleCI on Windows as
           # those require the ability to run Linux containers:
@@ -284,7 +284,7 @@ jobs:
             and:
               - not:
                   equal: [ "3.10", <<parameters.python_version>> ]
-              - equal: [true, <<pipeline.parameters.run-build-kedro-datasets>>]
+              - equal: [ "kedro-datasets", <<parameters.plugin>> ]
           steps:
             - run:
                 name: Run unit tests without spark in parallel
@@ -293,7 +293,7 @@ jobs:
           condition:
             and:
               - equal: [ "3.10", <<parameters.python_version>> ]
-              - equal: [true, <<pipeline.parameters.run-build-kedro-datasets>>]
+              - equal: [ "kedro-datasets", <<parameters.plugin>> ]
           steps:
             - run:
                 name: Run unit tests without spark sequentially


### PR DESCRIPTION
Signed-off-by: Merel Theisen <merel.theisen@quantumblack.com>

## Description
The setup for running `kedro-dataset` in other plugin workflows wasn't set up correctly. This was discovered in this PR: https://github.com/kedro-org/kedro-plugins/pull/99

## Development notes
To check whether the `kedro-datasets` test should be run or not the check should look at `<<parameters.plugin>>` and not at `<<pipeline.parameters.run-build-kedro-datasets>>`. This is because when changes are made in both `kedro-datasets` and another plugin, `<<pipeline.parameters.run-build-kedro-datasets>>` would be set to true for all builds, and thus all plugin builds would end up running `kedro-datasets` tests which is not what should happen. 

I tested the change by branching of https://github.com/kedro-org/kedro-plugins/pull/99 with https://github.com/kedro-org/kedro-plugins/tree/fix/cci-setup
## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes

