### PR TITLE
[kedro-airflow] Move coverage settings to pyproject.toml

### DIFF
--- a/kedro-airflow/.coveragerc
+++ b/kedro-airflow/.coveragerc
@@ -1,7 +1,0 @@
-[report]
-fail_under=100
-show_missing=True
-omit = *tests*
-exclude_lines =
-    pragma: no cover
-    raise NotImplementedError

--- a/kedro-airflow/pyproject.toml
+++ b/kedro-airflow/pyproject.toml
@@ -1,2 +1,8 @@
 [tool.black]
 exclude=".*template.py"
+
+[tool.coverage.report]
+fail_under = 100
+show_missing = true
+omit = ["tests/*"]
+exclude_lines = ["pragma: no cover", "raise NotImplementedError"]


### PR DESCRIPTION
Signed-off-by: Merel Theisen <merel.theisen@quantumblack.com>

## Description
Coverage was setup incorrectly and flagging lines in test files as not being covered. See https://app.circleci.com/pipelines/github/kedro-org/kedro-plugins/747/workflows/aef169d9-d389-4a08-9572-89f3e9f12125/jobs/8429

## Development notes
Moved the settings for coverage checking to `pyproject.toml` just like we have it in the core kedro repo. 

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
