### PR TITLE
[kedro-docker] Move coverage settings to pyproject.toml

### DIFF
--- a/kedro-docker/.coveragerc
+++ b/kedro-docker/.coveragerc
@@ -1,9 +1,0 @@
-[report]
-fail_under=100
-show_missing=True
-omit=
-        */plugin.py
-        tests/*
-exclude_lines =
-    pragma: no cover
-    raise NotImplementedError

--- a/kedro-docker/pyproject.toml
+++ b/kedro-docker/pyproject.toml
@@ -7,3 +7,9 @@ force_grid_wrap = 0
 use_parentheses = true
 line_length = 88
 default_section = "THIRDPARTY"
+
+[tool.coverage.report]
+fail_under = 100
+show_missing = true
+omit = ["tests/*",  "*/plugin.py"]
+exclude_lines = ["pragma: no cover", "raise NotImplementedError"]


### PR DESCRIPTION
Signed-off-by: Merel Theisen <merel.theisen@quantumblack.com>

## Description
Make the coverage settings consistent with the other plugins. Same as: https://github.com/kedro-org/kedro-plugins/pull/105


## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
