### PR TITLE
Fix outdated links in Kedro Datasets

### DIFF
--- a/kedro-datasets/kedro_datasets/pickle/pickle_dataset.py
+++ b/kedro-datasets/kedro_datasets/pickle/pickle_dataset.py
@@ -105,7 +105,7 @@ class PickleDataSet(AbstractVersionedDataSet[Any, Any]):
                 You can pass in arguments that the backend load function specified accepts, e.g:
                 pickle.load: https://docs.python.org/3/library/pickle.html#pickle.load
                 joblib.load: https://joblib.readthedocs.io/en/latest/generated/joblib.load.html
-                dill.load: https://dill.readthedocs.io/en/latest/dill.html#dill._dill.load
+                dill.load: https://dill.readthedocs.io/en/latest/index.html#dill.load
                 compress_pickle.load:
                 https://lucianopaz.github.io/compress_pickle/html/api/compress_pickle.html#compress_pickle.compress_pickle.load
                 All defaults are preserved.
@@ -113,7 +113,7 @@ class PickleDataSet(AbstractVersionedDataSet[Any, Any]):
                 You can pass in arguments that the backend dump function specified accepts, e.g:
                 pickle.dump: https://docs.python.org/3/library/pickle.html#pickle.dump
                 joblib.dump: https://joblib.readthedocs.io/en/latest/generated/joblib.dump.html
-                dill.dump: https://dill.readthedocs.io/en/latest/dill.html#dill._dill.dump
+                dill.dump: https://dill.readthedocs.io/en/latest/index.html#dill.dump
                 compress_pickle.dump:
                 https://lucianopaz.github.io/compress_pickle/html/api/compress_pickle.html#compress_pickle.compress_pickle.dump
                 All defaults are preserved.

--- a/kedro-datasets/kedro_datasets/redis/redis_dataset.py
+++ b/kedro-datasets/kedro_datasets/redis/redis_dataset.py
@@ -87,14 +87,14 @@ class PickleDataSet(AbstractDataSet[Any, Any]):
             load_args: Pickle options for loading pickle files.
                 You can pass in arguments that the backend load function specified accepts, e.g:
                 pickle.loads: https://docs.python.org/3/library/pickle.html#pickle.loads
-                dill.loads: https://dill.readthedocs.io/en/latest/dill.html#dill._dill.loads
+                dill.loads: https://dill.readthedocs.io/en/latest/index.html#dill.loads
                 compress_pickle.loads:
                 https://lucianopaz.github.io/compress_pickle/html/api/compress_pickle.html#compress_pickle.compress_pickle.loads
                 All defaults are preserved.
             save_args: Pickle options for saving pickle files.
                 You can pass in arguments that the backend dump function specified accepts, e.g:
                 pickle.dumps: https://docs.python.org/3/library/pickle.html#pickle.dump
-                dill.dumps: https://dill.readthedocs.io/en/latest/dill.html#dill._dill.dumps
+                dill.dumps: https://dill.readthedocs.io/en/latest/index.html#dill.dumps
                 compress_pickle.dumps:
                 https://lucianopaz.github.io/compress_pickle/html/api/compress_pickle.html#compress_pickle.compress_pickle.dumps
                 All defaults are preserved.


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
Two outdated URLs are causing kedro CI builds to fail on `linkcheck`, this change should fix it.
## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
