### PR TITLE
Keep Kedro-Airflow plugin docstring from appearing in `kedro -h`

### DIFF
--- a/kedro-airflow/kedro_airflow/plugin.py
+++ b/kedro-airflow/kedro_airflow/plugin.py
@@ -12,8 +12,7 @@ from slugify import slugify
 
 
 @click.group(name="Kedro-Airflow")
-def commands():
-    """Kedro plugin for running a project with Airflow"""
+def commands():  # pylint: disable=missing-function-docstring
     pass
 
 


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
See
https://github.com/kedro-org/kedro/issues/1749

As plugin docstring end up showing in the kedro CLI, the easier solution is to remove the docstring. 

## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
