### PR TITLE
Update SparkDataSet's doc and add support for `fsspec`

### DIFF
--- a/kedro-datasets/RELEASE.md
+++ b/kedro-datasets/RELEASE.md
@@ -10,6 +10,7 @@
 | ------------------------------------ | -------------------------------------------------------------------------- | ----------------------------- |
 | `polars.CSVDataSet` | A `CSVDataSet` backed by [polars](https://www.pola.rs/), a lighting fast dataframe package built entirely using Rust. | `kedro_datasets.polars` |
 | `snowflake.SnowparkTableDataSet` | Work with [Snowpark](https://www.snowflake.com/en/data-cloud/snowpark/) DataFrames from tables in Snowflake. | `kedro_datasets.snowflake` |
+* Fix `SparkDataSet` bug when loading versioned DataSet on dbfs.
 
 ## Bug fixes and other changes
 * Add `mssql` backend to the `SQLQueryDataSet` DataSet using `pyodbc` library.

--- a/kedro-datasets/RELEASE.md
+++ b/kedro-datasets/RELEASE.md
@@ -10,7 +10,7 @@
 | ------------------------------------ | -------------------------------------------------------------------------- | ----------------------------- |
 | `polars.CSVDataSet` | A `CSVDataSet` backed by [polars](https://www.pola.rs/), a lighting fast dataframe package built entirely using Rust. | `kedro_datasets.polars` |
 | `snowflake.SnowparkTableDataSet` | Work with [Snowpark](https://www.snowflake.com/en/data-cloud/snowpark/) DataFrames from tables in Snowflake. | `kedro_datasets.snowflake` |
-* Fix `SparkDataSet` bug when loading versioned DataSet on dbfs.
+* Use `fsspec` in `SparkDataSet` to support more filesystems.
 
 ## Bug fixes and other changes
 * Add `mssql` backend to the `SQLQueryDataSet` DataSet using `pyodbc` library.

--- a/kedro-datasets/kedro_datasets/spark/spark_dataset.py
+++ b/kedro-datasets/kedro_datasets/spark/spark_dataset.py
@@ -286,23 +286,17 @@ class SparkDataSet(AbstractVersionedDataSet[DataFrame, DataFrame]):
                 if ``filepath`` prefix is ``hdfs://``. Ignored otherwise.
         """
         credentials = deepcopy(credentials) or {}
-        fs_prefix, filepath = _split_filepath(filepath)
+        protocol, filepath = get_protocol_and_path(filepath, version)
         exists_function = None
         glob_function = None
 
-        if fs_prefix in ("s3a://", "s3n://"):
-            if fs_prefix == "s3n://":
-                warn(
-                    "'s3n' filesystem has now been deprecated by Spark, "
-                    "please consider switching to 's3a'",
-                    DeprecationWarning,
-                )
+        if protocol == "s3":
             _s3 = S3FileSystem(**credentials)
             exists_function = _s3.exists
             glob_function = partial(_s3.glob, refresh=True)
             path = PurePosixPath(filepath)
 
-        elif fs_prefix == "hdfs://" and version:
+        elif protocol == "hdfs" and version:
             warn(
                 f"HDFS filesystem support for versioned {self.__class__.__name__} is "
                 f"in beta and uses 'hdfs.client.InsecureClient', please use with "

--- a/kedro-datasets/kedro_datasets/spark/spark_dataset.py
+++ b/kedro-datasets/kedro_datasets/spark/spark_dataset.py
@@ -281,14 +281,14 @@ class SparkDataSet(AbstractVersionedDataSet[DataFrame, DataFrame]):
         exists_function = None
         glob_function = None
 
-        if fs_prefix == "s3":
+        if fs_prefix == "s3://":
             _s3 = S3FileSystem(**credentials)
             exists_function = _s3.exists
             # Ensure cache is not used so latest version is retrieved correctly.
             glob_function = partial(_s3.glob, refresh=True)
             path = PurePosixPath(filepath)
 
-        elif fs_prefix == "hdfs" and version:
+        elif fs_prefix == "hdfs://" and version:
             warn(
                 f"HDFS filesystem support for versioned {self.__class__.__name__} is "
                 f"in beta and uses 'hdfs.client.InsecureClient', please use with "

--- a/kedro-datasets/kedro_datasets/spark/spark_dataset.py
+++ b/kedro-datasets/kedro_datasets/spark/spark_dataset.py
@@ -277,18 +277,12 @@ class SparkDataSet(AbstractVersionedDataSet[DataFrame, DataFrame]):
                 if ``filepath`` prefix is ``hdfs://``. Ignored otherwise.
         """
         credentials = deepcopy(credentials) or {}
-        # protocol, _ = get_protocol_and_path(filepath)
-        # if protocol == "hdfs":
-        #     # adhoc fix for hdfs on spark
-        #     filepath = _split_filepath(filepath)[1]
-        # else:
-        #     filepath = get_protocol_and_path(filepath)[1]
         fs_prefix, filepath = _split_filepath(filepath)
         path = PurePosixPath(filepath)
         exists_function = None
         glob_function = None
 
-        if not filepath.startswith("/dbfs") and _deployed_on_databricks():
+        if not filepath.startswith("/dbfs/") and _deployed_on_databricks():
             logger.warning(
                 "Using SparkDataSet on Databricks without the `/dbfs/` prefix in the "
                 "filepath is a known source of error. You must add this prefix to %s",
@@ -316,7 +310,7 @@ class SparkDataSet(AbstractVersionedDataSet[DataFrame, DataFrame]):
             exists_function = _hdfs_client.hdfs_exists
             glob_function = _hdfs_client.hdfs_glob  # type: ignore
 
-        elif filepath.startswith("/dbfs"):
+        elif filepath.startswith("/dbfs/"):
             # dbfs add prefix to Spark path by default
             # See https://github.com/kedro-org/kedro-plugins/issues/117
             dbutils = _get_dbutils(self._get_spark())

--- a/kedro-datasets/kedro_datasets/spark/spark_dataset.py
+++ b/kedro-datasets/kedro_datasets/spark/spark_dataset.py
@@ -277,17 +277,18 @@ class SparkDataSet(AbstractVersionedDataSet[DataFrame, DataFrame]):
                 if ``filepath`` prefix is ``hdfs://``. Ignored otherwise.
         """
         credentials = deepcopy(credentials) or {}
-        protocol, filepath = get_protocol_and_path(filepath, version)
+        fs_prefix, filepath = _split_filepath(filepath)
         exists_function = None
         glob_function = None
 
-        if protocol == "s3":
+        if fs_prefix == "s3":
             _s3 = S3FileSystem(**credentials)
             exists_function = _s3.exists
+            # Ensure cache is not used so latest version is retrieved correctly.
             glob_function = partial(_s3.glob, refresh=True)
             path = PurePosixPath(filepath)
 
-        elif protocol == "hdfs" and version:
+        elif fs_prefix == "hdfs" and version:
             warn(
                 f"HDFS filesystem support for versioned {self.__class__.__name__} is "
                 f"in beta and uses 'hdfs.client.InsecureClient', please use with "
@@ -295,7 +296,7 @@ class SparkDataSet(AbstractVersionedDataSet[DataFrame, DataFrame]):
             )
 
             # default namenode address
-            credentials.setdefault("url", "http://localhost:9870")
+            credentials.setdefault("url", "http://localhost:9`870")
             credentials.setdefault("user", "hadoop")
 
             _hdfs_client = KedroHdfsInsecureClient(**credentials)
@@ -305,6 +306,7 @@ class SparkDataSet(AbstractVersionedDataSet[DataFrame, DataFrame]):
 
         else:
             path = PurePosixPath(filepath)
+
             if filepath.startswith("/dbfs"):
                 dbutils = _get_dbutils(self._get_spark())
                 if dbutils:

--- a/kedro-datasets/kedro_datasets/spark/spark_dataset.py
+++ b/kedro-datasets/kedro_datasets/spark/spark_dataset.py
@@ -290,19 +290,19 @@ class SparkDataSet(AbstractVersionedDataSet[DataFrame, DataFrame]):
         exists_function = None
         glob_function = None
 
-        if fs_prefix in ("s3a://", "s3n://"):
-            if fs_prefix == "s3n://":
-                warn(
-                    "'s3n' filesystem has now been deprecated by Spark, "
-                    "please consider switching to 's3a'",
-                    DeprecationWarning,
-                )
-            _s3 = S3FileSystem(**credentials)
-            exists_function = _s3.exists
-            glob_function = partial(_s3.glob, refresh=True)
-            path = PurePosixPath(filepath)
+        # if fs_prefix in ("s3a://", "s3n://"):
+        #     if fs_prefix == "s3n://":
+        #         warn(
+        #             "'s3n' filesystem has now been deprecated by Spark, "
+        #             "please consider switching to 's3a'",
+        #             DeprecationWarning,
+        #         )
+        #     _s3 = S3FileSystem(**credentials)
+        #     exists_function = _s3.exists
+        #     glob_function = partial(_s3.glob, refresh=True)
+        #     path = PurePosixPath(filepath)
 
-        elif fs_prefix == "hdfs://" and version:
+        if fs_prefix == "hdfs://" and version:
             warn(
                 f"HDFS filesystem support for versioned {self.__class__.__name__} is "
                 f"in beta and uses 'hdfs.client.InsecureClient', please use with "
@@ -318,19 +318,20 @@ class SparkDataSet(AbstractVersionedDataSet[DataFrame, DataFrame]):
             glob_function = _hdfs_client.hdfs_glob  # type: ignore
             path = PurePosixPath(filepath)
 
-        else:
+        elif filepath.startswith("/dbfs"):
             path = PurePosixPath(filepath)
-            if _deployed_on_databricks() and not _path_has_dbfs_prefix(filepath):
-                logger.warning(
-                    "Using SparkDataSet on Databricks without the `/dbfs/` prefix in the "
-                    "filepath is a known source of error. You must add this prefix to %s",
-                    filepath,
-                )
-            if filepath.startswith("/dbfs"):
-                dbutils = _get_dbutils(self._get_spark())
-                if dbutils:
-                    glob_function = partial(_dbfs_glob, dbutils=dbutils)
-                    exists_function = partial(_dbfs_exists, dbutils=dbutils)
+            # Databricks handle the default path in a special way. See
+            # https://docs.databricks.com/files/index.html#understand-default-locations-with-examples
+            # More details in https://github.com/kedro-org/kedro-plugins/issues/117
+            dbutils = _get_dbutils(self._get_spark())
+            if dbutils:
+                glob_function = partial(_dbfs_glob, dbutils=dbutils)
+                exists_function = partial(_dbfs_exists, dbutils=dbutils)
+        else:
+            protocol, path = get_protocol_and_path(filepath, version)
+            self._protocol = protocol
+            self._storage_options = {**credentials}
+            self._fs = fsspec.filesystem(self._protocol, **self._storage_options)
 
         super().__init__(
             filepath=path,

--- a/kedro-datasets/tests/spark/test_spark_dataset.py
+++ b/kedro-datasets/tests/spark/test_spark_dataset.py
@@ -800,14 +800,6 @@ class TestSparkDataSetVersionedS3:
 
         mocked_spark_df.write.save.assert_not_called()
 
-    def test_s3n_warning(self, version):
-        pattern = (
-            "'s3n' filesystem has now been deprecated by Spark, "
-            "please consider switching to 's3a'"
-        )
-        with pytest.warns(DeprecationWarning, match=pattern):
-            SparkDataSet(filepath=f"s3n://{BUCKET_NAME}/{FILENAME}", version=version)
-
     def test_repr(self, versioned_dataset_s3, version):
         assert "filepath=s3a://" in str(versioned_dataset_s3)
         assert f"version=Version(load=None, save='{version.save}')" in str(


### PR DESCRIPTION
Signed-off-by: Nok Chan <nok.lam.chan@quantumblack.com>

## Description
<!-- Why was this PR created? -->
Close https://github.com/kedro-org/kedro-plugins/issues/117

The final decision is to just update the doc and add support for `fsspec.filesystem` since the `DatabricksFileSystem` isn't useful for the Spark usecase.

> To summarise the current issue:
> 
> ## Summary
> 1. When `dbfs/` not include in path:❌
> 
> * Spark will always add `dbfs/` prefix - see https://docs.databricks.com/files/index.html#understand-default-locations-with-examples
> * `_fetch_latest_version` will use `os` library, by default it doesn't use the `dbfs` as root - as a result it can't find the file because Spark saved it in `dbfs/filepath` but `os` is looking in `filepath`
> 
> This is why when `versioned: True` + `dbfs/` not used in the filepath it cannot load the data successfully.
> 
> 2. When `/dbfs` is included in path: ✅
>    `kedro` strip the "dbfs" in the dataset - When using Spark it adds the `dbfs/` prefix
> 
> * SparkDataSet try to save in `filepath` - Databricks will automatically add `dbfs/` prefix which saving it in `dbfs/filepath`
> * `_fetch_latest_version` using os.glob("dbfs/filepath") - finding the correct version
> 
> ## Alternative - Use fsspec DatabrickFileSystem?:
> * Tried `DatabricksFileSystem` - `from fsspec.implementations.dbfs import DatabricksFileSystem`
>   This could work in theory and you can pass the `token` as `credentials`. However it isn't that useful since you almost always run on **Databricks**, therefore you don't really want to authenticate via a token. This will be only useful when you try to access `dbfs` while you are running a program outside of **Databricks**.
> * It really only affect Spark, so conditioning in Spark seems inevitable to me. Even if `fsspec` works, as long as we use Spark to handle save/write it will have discrepancy between `fsspec` and `spark`
> 
> ## Anything we can do?
> * We should advise user always use `dbfs` prefix ✅ - We did it already.
> * We can potentially remove this block of condition and just let `fsspec` do the work. The `dbfs` logic still need to be kept though, the condition is only special to `dbfs` or `hdfs`


## Development notes
<!-- What have you changed, and how has this been tested? -->
* Add generic support using `fsspec.filesystem`
* Add documentation to explain clearly why the condition only apply to SparkDataSet
* Remove deprecation warning - since that warning has been there for many years already. I don't think it's kedro responsibility to flag Spark is not supporting `s3n` 

During development, I find it weird we actually didn't support filesystems other than `s3`. I was keen to remove the special condition for `s3` but it exists for a legacy bug (not sure if it is still a problem). IMO, I don't think that should be an issue since it should affect everything not just Spark.
However, I still keep it as I rather handle this conservatively since this is an important dataset and many legacies behind it. Once we open up this for things like `gcs`, it will give us more signal if that legacy bug still exists or not.

`glob_function = partial(_s3.glob, refresh=True)`  - This is the extra condition check for `s3` - otherwise it should be just fine to use `fsspec.filesystem` to handle.


## Additional notes (skip for review purpose)
Note:
I also found the `hdfs` tests are always wrong, I suspect no one actually uses it and I think it's a signal that we may need to re-work this dataset at some point. It's not a high priority now, but I think we stack up a lot of technical debts in this dataset already/

Some observations:
1.  Is the `hdfs` client useful at all? Some of the tests has not been running correctly for years
2. We don't have anything other than `s3` supported
3. The dataset invents it own `_split_filepath` logic which resembles `get_protocol_and_path` a lot, the only difference is the `hdfs` pathway, is this actually a bug that we should fix in `kedro`?
4. The use of `fs_prefix` and `protocol` is confusing, some of the code is read via `fsspec` some is read with Spark directly. I suspect it will break since there are inconsistencies. It works fine for `s3` and `dbfs` which is the majority of our user base I suspect.
5. Overall it just looks a lot different from other datasets, partly due to the I/O is mainly via `Spark` instead of `fsspec`

I want to refactor this dataset but I am not comfortable to do this because we don't have good coverage, maybe we will look at this again some day.

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
