### PR TITLE
Fix bandit checks by adding timeout to `requests.post()` calls

### DIFF
--- a/tools/circleci/circleci_release.py
+++ b/tools/circleci/circleci_release.py
@@ -32,7 +32,7 @@ def circleci_release(project_slug, payload, circle_endpoint, circle_release_toke
     headers["Content-Type"] = "application/json"
     headers["Circle-Token"] = circle_release_token
 
-    resp = requests.post(circle_endpoint, headers=headers, json=payload)
+    resp = requests.post(circle_endpoint, headers=headers, json=payload, timeout=10)
     print(f"Status Code: {resp.status_code}")
     if resp.status_code == 201:
         print("Creating CircleCI Pipeline successfully")

--- a/tools/circleci/github_release.py
+++ b/tools/circleci/github_release.py
@@ -36,7 +36,7 @@ def github_release(
     headers = CaseInsensitiveDict()
     headers["Content-Type"] = "application/json"
     headers["Authorization"] = f"token {github_tagging_token}"
-    resp = requests.post(github_endpoint, headers=headers, json=payload)
+    resp = requests.post(github_endpoint, headers=headers, json=payload, timeout=10)
     if resp.status_code == 200:
         print("Create GitHub release successfully")
         print(resp.content)

--- a/tools/circleci/utils/check_no_version_pypi.py
+++ b/tools/circleci/utils/check_no_version_pypi.py
@@ -3,7 +3,7 @@ import requests
 
 def check_no_version_pypi(pypi_endpoint, package_name, package_version):
     print("Check if {package_name} {package_version} is on pypi")
-    response = requests.get(pypi_endpoint)
+    response = requests.get(pypi_endpoint, timeout=10)
     if response.status_code == 404:
         # Not exist on Pypi - do release
         print(f"Starting the release of {package_name} {package_version}")


### PR DESCRIPTION
## Description
Bandit security checks were failing with bandit `1.7.5`

## Development notes
Adding timeout to `requests.post()` calls fixed it. I ran the checks locally to verify.

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
