### PR TITLE
Fix malformed doc strings causing RTD builds to fail on Kedro

### DIFF
--- a/kedro-datasets/kedro_datasets/json/json_dataset.py
+++ b/kedro-datasets/kedro_datasets/json/json_dataset.py
@@ -23,6 +23,7 @@ class JSONDataSet(AbstractVersionedDataSet[Any, Any]):
     Example usage for the
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
     data_catalog.html#use-the-data-catalog-with-the-yaml-api>`_:
+
     .. code-block:: yaml
 
         cars:

--- a/kedro-datasets/kedro_datasets/spark/spark_hive_dataset.py
+++ b/kedro-datasets/kedro_datasets/spark/spark_hive_dataset.py
@@ -22,9 +22,8 @@ class SparkHiveDataSet(AbstractDataSet[DataFrame, DataFrame]):
     - Schemas do not change during the pipeline run (defined PKs must be present for the
     duration of the pipeline)
     - Tables are not being externally modified during upserts. The upsert method is NOT ATOMIC
-
-    to external changes to the target table while executing.
-    Upsert methodology works by leveraging Spark DataFrame execution plan checkpointing.
+    to external changes to the target table while executing. Upsert methodology works by leveraging
+    Spark DataFrame execution plan checkpointing.
 
     Example usage for the
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\


### PR DESCRIPTION
## Description
Resolves https://github.com/kedro-org/kedro-plugins/issues/134

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
