### PR TITLE
Tiny fix to docstring

### DIFF
--- a/kedro-datasets/kedro_datasets/pandas/sql_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/sql_dataset.py
@@ -323,7 +323,7 @@ class SQLQueryDataSet(AbstractDataSet[None, pd.DataFrame]):
         >>>                            credentials=credentials)
         >>>
         >>> sql_data = data_set.load()
-        >>>
+
     Example of usage for mssql:
     ::
 


### PR DESCRIPTION
While working on https://github.com/kedro-org/kedro/pull/2459 I detected one more docstring that needed fixing. No urgent release is needed, as the strict mode is disabled on Read the Docs for now. We can re-enable it when the moment comes.