### PR TITLE
Fix SnowparkTableDataSet docstrings

### DIFF
--- a/kedro-datasets/kedro_datasets/snowflake/snowpark_dataset.py
+++ b/kedro-datasets/kedro_datasets/snowflake/snowpark_dataset.py
@@ -20,6 +20,7 @@ class SnowparkTableDataSet(AbstractDataSet):
     data_catalog.html#use-the-data-catalog-with-the-yaml-api>`_:
 
     .. code-block:: yaml
+
         weather:
           type: kedro_datasets.snowflake.SnowparkTableDataSet
           table_name: "weather_data"
@@ -45,6 +46,7 @@ class SnowparkTableDataSet(AbstractDataSet):
     catalog.yml
 
     .. code-block:: yaml
+
         weather:
           type: kedro_datasets.snowflake.SnowparkTableDataSet
           table_name: "weather_data"
@@ -65,6 +67,7 @@ class SnowparkTableDataSet(AbstractDataSet):
     credentials.yml
 
     .. code-block:: yaml
+
         snowflake_client:
           account: 'ab12345.eu-central-1'
           port: 443
@@ -77,6 +80,7 @@ class SnowparkTableDataSet(AbstractDataSet):
     credentials.yml (with externalbrowser authenticator)
 
     .. code-block:: yaml
+
         snowflake_client:
           account: 'ab12345.eu-central-1'
           port: 443
@@ -85,6 +89,7 @@ class SnowparkTableDataSet(AbstractDataSet):
           schema: "observations"
           user: "john_doe@wdomain.com"
           authenticator: "externalbrowser"
+
     """
 
     # this dataset cannot be used with ``ParallelRunner``,


### PR DESCRIPTION
## Description
See errors at https://github.com/kedro-org/kedro/pull/2485.

## Development notes
I tried a docs build locally:

```diff
diff --git a/docs/kedro-datasets-docs.sh b/docs/kedro-datasets-docs.sh
index 10054034..aa4bc8f7 100755
--- a/docs/kedro-datasets-docs.sh
+++ b/docs/kedro-datasets-docs.sh
@@ -7,7 +7,7 @@ set -o nounset
 # Exit script if a statement returns a non-true return value.
 set -o errexit
 
-pip install kedro-datasets
-pip install --no-deps -t kedro/to_delete kedro-datasets
+pip install ../kedro-plugins/kedro-datasets
+pip install --no-deps -t kedro/to_delete ../kedro-plugins/kedro-datasets
 mv kedro/to_delete/kedro_datasets kedro/datasets
 rm -r kedro/to_delete
```

And then `make build-docs`.

Without the change, it fails:

```
/home/docs/checkouts/readthedocs.org/user_builds/kedro/checkouts/2485/kedro/datasets/snowflake/snowpark_dataset.py:docstring of kedro.datasets.snowflake.snowpark_dataset.SnowparkTableDataSet:3:Error in "code-block" directive:
maximum 1 argument(s) allowed, 19 supplied.

.. code-block:: yaml
    weather:
      type: kedro_datasets.snowflake.SnowparkTableDataSet
      table_name: "weather_data"
      database: "meteorology"
      schema: "observations"
      credentials: db_credentials
      save_args:
        mode: overwrite
        column_order: name
        table_type: ''
```

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
