### PR TITLE
Update Release to fail when release isn't triggered properly

### DIFF
--- a/tools/circleci/circleci_release.py
+++ b/tools/circleci/circleci_release.py
@@ -4,6 +4,7 @@ CircleCI pipeline to check if it needs to trigger a release
 """
 
 import os
+import sys
 
 import requests
 from requests.structures import CaseInsensitiveDict
@@ -33,12 +34,6 @@ def circleci_release(project_slug, payload, circle_endpoint, circle_release_toke
     headers["Circle-Token"] = circle_release_token
 
     resp = requests.post(circle_endpoint, headers=headers, json=payload, timeout=10)
-    print(f"Status Code: {resp.status_code}")
-    if resp.status_code == 201:
-        print("Creating CircleCI Pipeline successfully")
-        print(resp.content)
-    else:
-        print("Failed to create CircleCI Pipeline")
     return resp
 
 
@@ -70,6 +65,14 @@ if __name__ == "__main__":
 
         print(package_name, package_version)
         if check_no_version_pypi(pypi_endpoint, package_name, package_version):
-            circleci_release(
+            res = circleci_release(
                 PROJECT_SLUG, payload, circleci_endpoint, CIRCLE_RELEASE_TOKEN
             )
+            print(f"Status Code: {resp.status_code}")
+            if resp.status_code == 201:
+                print("Creating CircleCI Pipeline successfully")
+            else:
+                print("Failed to create CircleCI Pipeline")
+            print(resp.content)
+            if resp.status_code != 201:
+                sys.exit(1)


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
#43 implement the Auto Release process, so we don't have to manually publish plugins. Recently, there are some release CI fails silently, [the CI shows green even those the request didn't went through](https://app.circleci.com/pipelines/github/kedro-org/kedro-plugins/997/workflows/19909855-36ea-4792-a99a-8251c3abe534/jobs/11212)


## Development notes
<!-- What have you changed, and how has this been tested? -->
Update the script to use `sys.exit(1)` when the request response is unexpected.

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
