### PR TITLE
build(datasets): upgrade to newer, CalVered `s3fs`

### DIFF
--- a/kedro-datasets/setup.py
+++ b/kedro-datasets/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup
 PANDAS = "pandas>=1.3, <3.0"
 SPARK = "pyspark>=2.2, <4.0"
 HDFS = "hdfs>=2.5.8, <3.0"
-S3FS = "s3fs>=0.3.0, <0.5"
+S3FS = "s3fs>=2021.04, <2024.1"  # Upper bound set arbitrarily, to be reassessed in early 2024
 POLARS = "polars~=0.15.16"
 
 

--- a/kedro-datasets/test_requirements.txt
+++ b/kedro-datasets/test_requirements.txt
@@ -48,7 +48,7 @@ pytest~=7.2
 redis~=4.1
 requests-mock~=1.6
 requests~=2.20
-s3fs>=0.3.0, <0.5  # Needs to be at least 0.3.0 to make use of `cachable` attribute on S3FileSystem.
+s3fs>=2021.04, <2024.1  # Upper bound set arbitrarily, to be reassessed in early 2024
 scikit-learn~=1.0.2
 scipy~=1.7.3
 snowflake-snowpark-python~=1.0.0; python_version == '3.8'


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->

While working on `fsspec` bounds for https://github.com/kedro-org/kedro/pull/2515, I was curious what the `s3fs` bounds were set to for reference. Turns out they're bound to versions from 3 years ago. :(

If you `pip install kedro[spark.SparkDataSet]` (in a recent Python env), you probably get something like:

```bash
(kedro-test) deepyaman@Deepyamans-MacBook-Air kedro % pip freeze | grep fs
fsspec==2023.3.0
hdfs==2.7.0
s3fs==0.4.2
```

I'd be a bit surprised if this works properly, because new versions of `s3fs` pin an `fsspec` dependency to the exact same CalVer (e.g. `s3fs 2023.4.0` requires `fsspec==2023.4.0`). However, our `s3fs` is so old it doesn't place any such restriction (see https://github.com/fsspec/s3fs/blob/0.4.2/requirements.txt#L2).

Whatever the case, users shouldn't be forced to use such old `s3fs`.

## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
