### PR TITLE
Closes #166 Dataset api add save method

### DIFF
--- a/kedro-datasets/kedro_datasets/api/api_dataset.py
+++ b/kedro-datasets/kedro_datasets/api/api_dataset.py
@@ -50,6 +50,8 @@ class APIDataSet(AbstractDataSet[None, requests.Response]):
         >>>     }
         >>> )
         >>> data = data_set.load()
+
+    Example of saving data with a REST API.
     """
 
     DEFAULT_SAVE_ARGS = {
@@ -79,15 +81,16 @@ class APIDataSet(AbstractDataSet[None, requests.Response]):
         """Creates a new instance of ``APIDataSet`` to fetch data from an API endpoint.
 
         Args:
-            url: The API URL endpoint.
-            method: The Method of the request, GET, POST, PUT, DELETE, HEAD, etc...
-            data: The request payload, used for POST, PUT, etc requests
+            url: The API URL endpoint. method: The Method of the request, GET, POST, PUT,
+            DELETE, HEAD, etc... data: The request payload, used for POST, PUT, etc
+            requests
                 https://requests.readthedocs.io/en/latest/user/quickstart/#more-complicated-post-requests
             params: The url parameters of the API.
                 https://requests.readthedocs.io/en/latest/user/quickstart/#passing-parameters-in-urls
             headers: The HTTP headers.
                 https://requests.readthedocs.io/en/latest/user/quickstart/#custom-headers
-            auth: Anything ``requests`` accepts. Normally it's either ``('login', 'password')``,
+            auth: Anything ``requests`` accepts. Normally it's either ``('login',
+            'password')``,
                 or ``AuthBase``, ``HTTPBasicAuth`` instance for more complex cases. Any
                 iterable will be cast to a tuple.
             json: The request payload, used for POST, PUT, etc requests, passed in
@@ -97,8 +100,10 @@ class APIDataSet(AbstractDataSet[None, requests.Response]):
                 https://requests.readthedocs.io/en/latest/user/quickstart/#timeouts
             credentials: same as ``auth``. Allows specifying ``auth`` secrets in
                 credentials.yml.
-            chunk_size: only used by save method, size of each individual packet sent to server
-
+            save_args: Options for saving data on server. Includes all parameters used
+            during load method.
+                        Adds an optional parameter, ``chunk_size`` which determines the
+                        size of the package sent at each request.
         Raises:
             ValueError: if both ``credentials`` and ``auth`` are specified.
         """

--- a/kedro-datasets/tests/api/test_api_dataset.py
+++ b/kedro-datasets/tests/api/test_api_dataset.py
@@ -88,9 +88,11 @@ class TestAPIDataSet:
             api_data_set.load()
 
     def test_successful_save(self, requests_mocker, method):
-        # When we want to save some data on a server
-        # Given an APIDataSet class
-        # Then check we get a response
+        """
+        When we want to save some data on a server
+        Given an APIDataSet class
+        Then check we get a response
+        """
         api_data_set = APIDataSet(
             url=TEST_URL,
             method=method,


### PR DESCRIPTION
## Description
We sometimes want to save some data with a REST Api (say with Django Rest Framework), most of the time issuing a POST request. So far, the APIDataSet is read only, with the _save method raising a DataSetError, we'd want to extend it to make a request.

## Development notes
If applied, this commit will:

1. Enable save method for APIDataSet, by sending packets of size chunk_size, default is 100 to server. Default HTTP method is POST and returns a request.Response object.

1.Enable save method for APIDataSet, by sending packets of size chunk_size, default is 100 to server. Default HTTP method is POST and returns a request.Response object.
2.Add, save_args dictionary to start conforming with other datasets.
    Raise error when trying to save non-json data
    Raise error for save in case of HTTP error

Checklist

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
