### PR TITLE
[kedro-datasets] Bump version of `tables` in `test_requirements.txt` 

### DIFF
--- a/.github/workflows/check-plugin.yml
+++ b/.github/workflows/check-plugin.yml
@@ -43,9 +43,6 @@ jobs:
         run: |
           cd ${{ inputs.plugin }}
           pip install -r test_requirements.txt
-      - name: Install pytables (only for kedro-datasets on windows)
-        if: matrix.os == 'windows-latest' && inputs.plugin == 'kedro-datasets'
-        run: pip install tables
       - name: pip freeze
         run: pip freeze
       - name: Run unit tests for Linux / all plugins

--- a/kedro-datasets/test_requirements.txt
+++ b/kedro-datasets/test_requirements.txt
@@ -54,7 +54,7 @@ scipy~=1.7.3
 snowflake-snowpark-python~=1.0.0; python_version == '3.8'
 SQLAlchemy>=1.4, <3.0  # The `Inspector.has_table()` method replaces the `Engine.has_table()` method in version 1.4.
 tables~=3.8.0; platform_system == "Windows"
-tables~=3.8; platform_system != "Windows"
+tables~=3.6; platform_system != "Windows"
 tensorflow-macos~=2.0; platform_system == "Darwin" and platform_machine == "arm64"
 tensorflow~=2.0; platform_system != "Darwin" or platform_machine != "arm64"
 triad>=0.6.7, <1.0

--- a/kedro-datasets/test_requirements.txt
+++ b/kedro-datasets/test_requirements.txt
@@ -53,8 +53,8 @@ scikit-learn~=1.0.2
 scipy~=1.7.3
 snowflake-snowpark-python~=1.0.0; python_version == '3.8'
 SQLAlchemy>=1.4, <3.0  # The `Inspector.has_table()` method replaces the `Engine.has_table()` method in version 1.4.
-tables~=3.8.0; platform_system == "Windows"
-tables~=3.6; platform_system != "Windows"
+tables~=3.7.0; platform_system == "Windows"
+tables~=3.7; platform_system != "Windows"
 tensorflow-macos~=2.0; platform_system == "Darwin" and platform_machine == "arm64"
 tensorflow~=2.0; platform_system != "Darwin" or platform_machine != "arm64"
 triad>=0.6.7, <1.0

--- a/kedro-datasets/test_requirements.txt
+++ b/kedro-datasets/test_requirements.txt
@@ -53,8 +53,7 @@ scikit-learn~=1.0.2
 scipy~=1.7.3
 snowflake-snowpark-python~=1.0.0; python_version == '3.8'
 SQLAlchemy>=1.4, <3.0  # The `Inspector.has_table()` method replaces the `Engine.has_table()` method in version 1.4.
-tables~=3.7.0; platform_system == "Windows"
-tables~=3.7; platform_system != "Windows"
+tables~=3.7
 tensorflow-macos~=2.0; platform_system == "Darwin" and platform_machine == "arm64"
 tensorflow~=2.0; platform_system != "Darwin" or platform_machine != "arm64"
 triad>=0.6.7, <1.0

--- a/kedro-datasets/test_requirements.txt
+++ b/kedro-datasets/test_requirements.txt
@@ -53,8 +53,8 @@ scikit-learn~=1.0.2
 scipy~=1.7.3
 snowflake-snowpark-python~=1.0.0; python_version == '3.8'
 SQLAlchemy>=1.4, <3.0  # The `Inspector.has_table()` method replaces the `Engine.has_table()` method in version 1.4.
-tables~=3.6.0; platform_system == "Windows" and python_version < '3.9'
-tables~=3.6; platform_system != "Windows"
+tables~=3.8.0; platform_system == "Windows"
+tables~=3.8; platform_system != "Windows"
 tensorflow-macos~=2.0; platform_system == "Darwin" and platform_machine == "arm64"
 tensorflow~=2.0; platform_system != "Darwin" or platform_machine != "arm64"
 triad>=0.6.7, <1.0


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
Bumping the version of `pytables` from 3.6 to 3.7 allows it to be installed on windows system for higher versions (>3.9) of Python and we can remove the extra conditional step of installing `tables` separately for `windows` in the GitHub Actions `unit-test` job for `kedro-datasets`.

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
