### PR TITLE
ci: ensure title matches Conventional Commits spec

### DIFF
--- a/.github/workflows/validate-pr-title.yaml
+++ b/.github/workflows/validate-pr-title.yaml
@@ -1,0 +1,17 @@
+name: Validate PR title
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/validate-pr-title.yaml
+++ b/.github/workflows/validate-pr-title.yaml
@@ -6,6 +6,7 @@ on:
       - opened
       - edited
       - synchronize
+      - ready_for_review
 
 jobs:
   main:

--- a/.github/workflows/validate-pr-title.yaml
+++ b/.github/workflows/validate-pr-title.yaml
@@ -6,7 +6,6 @@ on:
       - opened
       - edited
       - synchronize
-      - ready_for_review
 
 jobs:
   main:

--- a/.github/workflows/validate-pr-title.yaml
+++ b/.github/workflows/validate-pr-title.yaml
@@ -1,7 +1,7 @@
 name: Validate PR title
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - edited

--- a/.github/workflows/validate-pr-title.yaml
+++ b/.github/workflows/validate-pr-title.yaml
@@ -1,4 +1,4 @@
-name: Validate PR title
+name: Lint PR
 
 on:
   pull_request:
@@ -13,5 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: amannn/action-semantic-pull-request@v5
+        with:
+          scopes: |
+            airflow
+            datasets
+            docker
+            telemetry
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->

### Challenges

[...]

- It's not clear which changes affect which plugins
  - Denoted inconsistently using tags like `[kedro-docker]` on PR/issues (nonstandard solution)

### Proposal

[...]

- [ ] [P1] Enforce use of [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) with per-plugin scopes with [`commitlint`](https://github.com/conventional-changelog/commitlint) -- rough estimate: trivial, <0.5 days

_Originally posted by @deepyaman in https://github.com/kedro-org/kedro/issues/2333#issuecomment-1434492921_

## Development notes
<!-- What have you changed, and how has this been tested? -->

Tested manually. Also, have used the Action on other projects previously. The configuration is pretty much that documented in the Action's repo.

Can somebody with rights ensure that the squash-merge strategy IS NOT set to use the commit message if there's only one commit? See https://github.com/amannn/action-semantic-pull-request#installation.

Is there (going to be) a CONTRIBUTING.md for this repo? If so, we can include the following:

### Pull request title conventions

The Kedro-Plugins repository requires that you [squash and merge your pull request commits](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits), and, in most cases, the [merge message for a squash merge](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/about-pull-request-merges#merge-message-for-a-squash-merge) then defaults to the pull request title.

Your pull request title must match the [Conventional Commits spec](https://www.conventionalcommits.org/). Also see the [list of supported commit types and their descriptions](https://github.com/conventional-changelog/commitlint/blob/master/%40commitlint/config-conventional/index.js#L41-L99). Commit scope can be one of the plugin names.

#### Examples

##### Commit message with no body

`ci: port lint, unit test, and e2e tests to Actions`

##### Commit message with scope

```build(datasets): add the missing `snowflake` extra```

## Checklist

- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
