### PR TITLE
ci: don't run checks on both `push`/`pull_request`

### DIFF
--- a/.github/workflows/kedro-airflow.yml
+++ b/.github/workflows/kedro-airflow.yml
@@ -1,13 +1,20 @@
-name: Run checks on kedro-airflow
+name: Run checks on Kedro-Airflow
 
 on:
   push:
-    paths:
-      - "kedro-airflow/**"
+    branches:
+      - main
+    paths-ignore:
+      - "kedro-docker/**"
+      - "kedro-datasets/**"
+      - "kedro-telemetry/**"
   pull_request:
-    paths:
-      - "kedro-airflow/**"
-    types: [ synchronize ]
+    branches:
+      - main
+    paths-ignore:
+      - "kedro-docker/**"
+      - "kedro-datasets/**"
+      - "kedro-telemetry/**"
 
 jobs:
   airflow-test:

--- a/.github/workflows/kedro-datasets.yml
+++ b/.github/workflows/kedro-datasets.yml
@@ -1,13 +1,20 @@
-name: Run checks on kedro-datasets
+name: Run checks on Kedro-Datasets
 
 on:
   push:
-    paths:
-      - "kedro-datasets/**"
+    branches:
+      - main
+    paths-ignore:
+      - "kedro-airflow/**"
+      - "kedro-docker/**"
+      - "kedro-telemetry/**"
   pull_request:
-    paths:
-      - "kedro-datasets/**"
-    types: [ synchronize ]
+    branches:
+      - main
+    paths-ignore:
+      - "kedro-airflow/**"
+      - "kedro-docker/**"
+      - "kedro-telemetry/**"
 
 jobs:
   datasets-test:

--- a/.github/workflows/kedro-docker.yml
+++ b/.github/workflows/kedro-docker.yml
@@ -1,13 +1,20 @@
-name: Run checks on kedro-docker
+name: Run checks on Kedro-Docker
 
 on:
   push:
-    paths:
-      - "kedro-docker/**"
+    branches:
+      - main
+    paths-ignore:
+      - "kedro-airflow/**"
+      - "kedro-datasets/**"
+      - "kedro-telemetry/**"
   pull_request:
-    paths:
-      - "kedro-docker/**"
-    types: [ synchronize ]
+    branches:
+      - main
+    paths-ignore:
+      - "kedro-airflow/**"
+      - "kedro-datasets/**"
+      - "kedro-telemetry/**"
 
 jobs:
   docker-test:

--- a/.github/workflows/kedro-telemetry.yml
+++ b/.github/workflows/kedro-telemetry.yml
@@ -1,13 +1,20 @@
-name: Run checks on kedro-telemetry
+name: Run checks on Kedro-Telemetry
 
 on:
   push:
-    paths:
-      - "kedro-telemetry/**"
+    branches:
+      - main
+    paths-ignore:
+      - "kedro-airflow/**"
+      - "kedro-datasets/**"
+      - "kedro-docker/**"
   pull_request:
-    paths:
-      - "kedro-telemetry/**"
-    types: [ synchronize ]
+    branches:
+      - main
+    paths-ignore:
+      - "kedro-airflow/**"
+      - "kedro-datasets/**"
+      - "kedro-docker/**"
 
 jobs:
   telemetry-test:


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->

If you see a PR like #189, you'll see jobs are being run on `push` and `pull_request` (instead of either-or).

<img width="921" alt="image" src="https://user-images.githubusercontent.com/14007150/234686670-48dd5e8a-1741-4f60-9fd0-45def747a184.png">

Furthermore, the path filtering is a bit too aggressive, in that it won't consider changes to files like `.pre-commit-config.yaml`, etc. It may be a bit too conservative now, in that a change to `kedro-airflow.yaml` will trigger all the checks, but:

1. changing CI workflows is comparatively rare
2. ignoring folders is easier than including the plugin folder + an exhaustive list of files

Maybe we can just add the CI workflow definitions to `paths-ignore` as well. 

## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
