### PR TITLE
fix(datasets): use `side_effect`, not `side_effct`

### DIFF
--- a/kedro-datasets/tests/tensorflow/test_tensorflow_model_dataset.py
+++ b/kedro-datasets/tests/tensorflow/test_tensorflow_model_dataset.py
@@ -260,7 +260,7 @@ class TestTensorFlowModelDataSet:
 
     def test_exists_with_exception(self, tf_model_dataset, mocker):
         """Test `exists` method invocation when `get_filepath_str` raises an exception."""
-        mocker.patch("kedro.io.core.get_filepath_str", side_effct=DataSetError)
+        mocker.patch("kedro.io.core.get_filepath_str", side_effect=DataSetError)
         assert not tf_model_dataset.exists()
 
     def test_save_and_overwrite_existing_model(


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
Luckily happens that `MagicMock`s are falsy, but this is a clear mistake.

## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
