### PR TITLE
test(datasets): update the "no versioning" message

### DIFF
--- a/.github/workflows/check-plugin.yml
+++ b/.github/workflows/check-plugin.yml
@@ -38,7 +38,7 @@ jobs:
           key: ${{inputs.plugin}}-${{matrix.os}}-python-${{matrix.python-version}}
           restore-keys: ${{inputs.plugin}}
       - name: Install Kedro
-        run: pip install git+https://github.com/kedro-org/kedro@main
+        run: pip install git+https://github.com/kedro-org/kedro@refactor/rename-data-set
       - name: Install dependencies
         run: |
           cd ${{ inputs.plugin }}
@@ -83,7 +83,7 @@ jobs:
       - name: Install dependencies
         run: |
             cd ${{ inputs.plugin }}
-            pip install git+https://github.com/kedro-org/kedro@main
+            pip install git+https://github.com/kedro-org/kedro@refactor/rename-data-set
             pip install . -r test_requirements.txt  # TODO(deepyaman): Define `test` extra and `pip install .[test]`
             pip freeze
       - name: Install pre-commit hooks
@@ -120,7 +120,7 @@ jobs:
       - name: Install dependencies
         run: |
           cd ${{ inputs.plugin }}
-          pip install git+https://github.com/kedro-org/kedro@main
+          pip install git+https://github.com/kedro-org/kedro@refactor/rename-data-set
           pip install . -r test_requirements.txt  # TODO(deepyaman): Define `test` extra and `pip install .[test]`
       - name: pip freeze
         run: pip freeze

--- a/.github/workflows/check-plugin.yml
+++ b/.github/workflows/check-plugin.yml
@@ -38,7 +38,7 @@ jobs:
           key: ${{inputs.plugin}}-${{matrix.os}}-python-${{matrix.python-version}}
           restore-keys: ${{inputs.plugin}}
       - name: Install Kedro
-        run: pip install git+https://github.com/kedro-org/kedro@refactor/rename-data-set
+        run: pip install git+https://github.com/kedro-org/kedro@main
       - name: Install dependencies
         run: |
           cd ${{ inputs.plugin }}
@@ -83,7 +83,7 @@ jobs:
       - name: Install dependencies
         run: |
             cd ${{ inputs.plugin }}
-            pip install git+https://github.com/kedro-org/kedro@refactor/rename-data-set
+            pip install git+https://github.com/kedro-org/kedro@main
             pip install . -r test_requirements.txt  # TODO(deepyaman): Define `test` extra and `pip install .[test]`
             pip freeze
       - name: Install pre-commit hooks
@@ -120,7 +120,7 @@ jobs:
       - name: Install dependencies
         run: |
           cd ${{ inputs.plugin }}
-          pip install git+https://github.com/kedro-org/kedro@refactor/rename-data-set
+          pip install git+https://github.com/kedro-org/kedro@main
           pip install . -r test_requirements.txt  # TODO(deepyaman): Define `test` extra and `pip install .[test]`
       - name: pip freeze
         run: pip freeze

--- a/.github/workflows/validate-pr-title.yaml
+++ b/.github/workflows/validate-pr-title.yaml
@@ -19,5 +19,6 @@ jobs:
             datasets
             docker
             telemetry
+          wip: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/kedro-datasets/kedro_datasets/geopandas/__init__.py
+++ b/kedro-datasets/kedro_datasets/geopandas/__init__.py
@@ -1,4 +1,4 @@
-"""``GeoJSONLocalDataset`` is an ``AbstractVersionedDataSet`` to save and load GeoJSON files.
+"""``GeoJSONDataSet`` is an ``AbstractVersionedDataSet`` to save and load GeoJSON files.
 """
 __all__ = ["GeoJSONDataSet"]
 

--- a/kedro-datasets/kedro_datasets/geopandas/__init__.py
+++ b/kedro-datasets/kedro_datasets/geopandas/__init__.py
@@ -1,4 +1,4 @@
-"""``GeoJSONDataSet`` is an ``AbstractVersionedDataSet`` to save and load GeoJSON files.
+"""``GeoJSONLocalDataset`` is an ``AbstractVersionedDataSet`` to save and load GeoJSON files.
 """
 __all__ = ["GeoJSONDataSet"]
 

--- a/kedro-datasets/tests/databricks/test_managed_table_dataset.py
+++ b/kedro-datasets/tests/databricks/test_managed_table_dataset.py
@@ -187,7 +187,7 @@ class TestManagedTableDataSet:
         assert unity_ds._table.full_table_location() == "`default`.`test`"
 
         with pytest.raises(TypeError):
-            ManagedTableDataSet()  # pylint: disable=no-value-for-parameter
+            ManagedTableDataSet()
 
     def test_describe(self):
         unity_ds = ManagedTableDataSet(table="test")

--- a/kedro-datasets/tests/email/test_message_dataset.py
+++ b/kedro-datasets/tests/email/test_message_dataset.py
@@ -198,7 +198,7 @@ class TestEmailMessageDataSetVersioned:
             versioned_message_data_set.save(dummy_msg)
 
     def test_http_filesystem_no_versioning(self):
-        pattern = r"HTTP\(s\) DataSet doesn't support versioning\."
+        pattern = "Versioning is not supported for HTTP protocols."
 
         with pytest.raises(DataSetError, match=pattern):
             EmailMessageDataSet(

--- a/kedro-datasets/tests/geojson/test_geojson_dataset.py
+++ b/kedro-datasets/tests/geojson/test_geojson_dataset.py
@@ -204,7 +204,7 @@ class TestGeoJSONDataSetVersioned:
             versioned_geojson_data_set.save(dummy_dataframe)
 
     def test_http_filesystem_no_versioning(self):
-        pattern = r"HTTP\(s\) DataSet doesn't support versioning\."
+        pattern = "Versioning is not supported for HTTP protocols."
 
         with pytest.raises(DataSetError, match=pattern):
             GeoJSONDataSet(

--- a/kedro-datasets/tests/holoviews/test_holoviews_writer.py
+++ b/kedro-datasets/tests/holoviews/test_holoviews_writer.py
@@ -167,7 +167,7 @@ class TestHoloviewsWriterVersioned:
             versioned_hv_writer.save(dummy_hv_object)
 
     def test_http_filesystem_no_versioning(self):
-        pattern = r"HTTP\(s\) DataSet doesn't support versioning\."
+        pattern = "Versioning is not supported for HTTP protocols."
 
         with pytest.raises(DataSetError, match=pattern):
             HoloviewsWriter(

--- a/kedro-datasets/tests/json/test_json_dataset.py
+++ b/kedro-datasets/tests/json/test_json_dataset.py
@@ -172,7 +172,7 @@ class TestJSONDataSetVersioned:
             versioned_json_data_set.save(dummy_data)
 
     def test_http_filesystem_no_versioning(self):
-        pattern = r"HTTP\(s\) DataSet doesn't support versioning\."
+        pattern = "Versioning is not supported for HTTP protocols."
 
         with pytest.raises(DataSetError, match=pattern):
             JSONDataSet(

--- a/kedro-datasets/tests/libsvm/test_svmlight_dataset.py
+++ b/kedro-datasets/tests/libsvm/test_svmlight_dataset.py
@@ -186,7 +186,7 @@ class TestSVMLightDataSetVersioned:
             versioned_svm_data_set.save(dummy_data)
 
     def test_http_filesystem_no_versioning(self):
-        pattern = r"HTTP\(s\) DataSet doesn't support versioning\."
+        pattern = "Versioning is not supported for HTTP protocols."
 
         with pytest.raises(DataSetError, match=pattern):
             SVMLightDataSet(

--- a/kedro-datasets/tests/matplotlib/test_matplotlib_writer.py
+++ b/kedro-datasets/tests/matplotlib/test_matplotlib_writer.py
@@ -316,7 +316,7 @@ class TestMatplotlibWriterVersioned:
             versioned_plot_writer.save(mock_single_plot)
 
     def test_http_filesystem_no_versioning(self):
-        pattern = r"HTTP\(s\) DataSet doesn't support versioning\."
+        pattern = "Versioning is not supported for HTTP protocols."
 
         with pytest.raises(DataSetError, match=pattern):
             MatplotlibWriter(

--- a/kedro-datasets/tests/pandas/test_csv_dataset.py
+++ b/kedro-datasets/tests/pandas/test_csv_dataset.py
@@ -361,7 +361,7 @@ class TestCSVDataSetVersioned:
             versioned_csv_data_set.save(dummy_dataframe)
 
     def test_http_filesystem_no_versioning(self):
-        pattern = r"HTTP\(s\) DataSet doesn't support versioning\."
+        pattern = "Versioning is not supported for HTTP protocols."
 
         with pytest.raises(DataSetError, match=pattern):
             CSVDataSet(

--- a/kedro-datasets/tests/pandas/test_excel_dataset.py
+++ b/kedro-datasets/tests/pandas/test_excel_dataset.py
@@ -296,7 +296,7 @@ class TestExcelDataSetVersioned:
             versioned_excel_data_set.save(dummy_dataframe)
 
     def test_http_filesystem_no_versioning(self):
-        pattern = r"HTTP\(s\) DataSet doesn't support versioning\."
+        pattern = "Versioning is not supported for HTTP protocols."
 
         with pytest.raises(DataSetError, match=pattern):
             ExcelDataSet(

--- a/kedro-datasets/tests/pandas/test_feather_dataset.py
+++ b/kedro-datasets/tests/pandas/test_feather_dataset.py
@@ -192,7 +192,7 @@ class TestFeatherDataSetVersioned:
             versioned_feather_data_set.save(dummy_dataframe)
 
     def test_http_filesystem_no_versioning(self):
-        pattern = r"HTTP\(s\) DataSet doesn't support versioning\."
+        pattern = "Versioning is not supported for HTTP protocols."
 
         with pytest.raises(DataSetError, match=pattern):
             FeatherDataSet(

--- a/kedro-datasets/tests/pandas/test_hdf_dataset.py
+++ b/kedro-datasets/tests/pandas/test_hdf_dataset.py
@@ -215,7 +215,7 @@ class TestHDFDataSetVersioned:
             versioned_hdf_data_set.save(dummy_dataframe)
 
     def test_http_filesystem_no_versioning(self):
-        pattern = r"HTTP\(s\) DataSet doesn't support versioning\."
+        pattern = "Versioning is not supported for HTTP protocols."
 
         with pytest.raises(DataSetError, match=pattern):
             HDFDataSet(

--- a/kedro-datasets/tests/pandas/test_json_dataset.py
+++ b/kedro-datasets/tests/pandas/test_json_dataset.py
@@ -213,7 +213,7 @@ class TestJSONDataSetVersioned:
             versioned_json_data_set.save(dummy_dataframe)
 
     def test_http_filesystem_no_versioning(self):
-        pattern = r"HTTP\(s\) DataSet doesn't support versioning\."
+        pattern = "Versioning is not supported for HTTP protocols."
 
         with pytest.raises(DataSetError, match=pattern):
             JSONDataSet(

--- a/kedro-datasets/tests/pandas/test_parquet_dataset.py
+++ b/kedro-datasets/tests/pandas/test_parquet_dataset.py
@@ -306,7 +306,7 @@ class TestParquetDataSetVersioned:
             versioned_parquet_data_set.save(dummy_dataframe)
 
     def test_http_filesystem_no_versioning(self):
-        pattern = r"HTTP\(s\) DataSet doesn't support versioning\."
+        pattern = "Versioning is not supported for HTTP protocols."
 
         with pytest.raises(DataSetError, match=pattern):
             ParquetDataSet(

--- a/kedro-datasets/tests/pandas/test_xml_dataset.py
+++ b/kedro-datasets/tests/pandas/test_xml_dataset.py
@@ -213,7 +213,7 @@ class TestXMLDataSetVersioned:
             versioned_xml_data_set.save(dummy_dataframe)
 
     def test_http_filesystem_no_versioning(self):
-        pattern = r"HTTP\(s\) DataSet doesn't support versioning\."
+        pattern = "Versioning is not supported for HTTP protocols."
 
         with pytest.raises(DataSetError, match=pattern):
             XMLDataSet(

--- a/kedro-datasets/tests/pickle/test_pickle_dataset.py
+++ b/kedro-datasets/tests/pickle/test_pickle_dataset.py
@@ -236,7 +236,7 @@ class TestPickleDataSetVersioned:
             versioned_pickle_data_set.save(dummy_dataframe)
 
     def test_http_filesystem_no_versioning(self):
-        pattern = r"HTTP\(s\) DataSet doesn't support versioning\."
+        pattern = "Versioning is not supported for HTTP protocols."
 
         with pytest.raises(DataSetError, match=pattern):
             PickleDataSet(

--- a/kedro-datasets/tests/pillow/test_image_dataset.py
+++ b/kedro-datasets/tests/pillow/test_image_dataset.py
@@ -203,7 +203,7 @@ class TestImageDataSetVersioned:
             versioned_image_dataset.save(image_object)
 
     def test_http_filesystem_no_versioning(self):
-        pattern = r"HTTP\(s\) DataSet doesn't support versioning\."
+        pattern = "Versioning is not supported for HTTP protocols."
 
         with pytest.raises(DataSetError, match=pattern):
             ImageDataSet(

--- a/kedro-datasets/tests/polars/test_csv_dataset.py
+++ b/kedro-datasets/tests/polars/test_csv_dataset.py
@@ -321,7 +321,7 @@ class TestCSVDataSetVersioned:
             versioned_csv_data_set.save(dummy_dataframe)
 
     def test_http_filesystem_no_versioning(self):
-        pattern = r"HTTP\(s\) DataSet doesn't support versioning\."
+        pattern = "Versioning is not supported for HTTP protocols."
 
         with pytest.raises(DataSetError, match=pattern):
             CSVDataSet(

--- a/kedro-datasets/tests/spark/test_memory_dataset.py
+++ b/kedro-datasets/tests/spark/test_memory_dataset.py
@@ -44,7 +44,7 @@ def test_load_modify_original_data(memory_dataset, spark_data_frame):
 def test_save_modify_original_data(spark_data_frame):
     """Check that the data set object is not updated when the original
     SparkDataFrame is changed."""
-    memory_dataset = MemoryDataSet()
+    memory_dataset = MemoryDataset()
     memory_dataset.save(spark_data_frame)
     spark_data_frame = _update_spark_df(spark_data_frame, 1, 1, "new value")
 

--- a/kedro-datasets/tests/spark/test_memory_dataset.py
+++ b/kedro-datasets/tests/spark/test_memory_dataset.py
@@ -63,4 +63,4 @@ def test_load_returns_same_spark_object(memory_dataset, spark_data_frame):
 
 def test_str_representation(memory_dataset):
     """Test string representation of the data set"""
-    assert "MemoryDataSet(data=<DataFrame>)" in str(memory_dataset)
+    assert "MemoryDataset(data=<DataFrame>)" in str(memory_dataset)

--- a/kedro-datasets/tests/spark/test_memory_dataset.py
+++ b/kedro-datasets/tests/spark/test_memory_dataset.py
@@ -1,5 +1,5 @@
 import pytest
-from kedro.io import MemoryDataSet
+from kedro.io import MemoryDataset
 from pyspark.sql import DataFrame as SparkDataFrame
 from pyspark.sql import SparkSession
 from pyspark.sql.functions import col, when
@@ -31,7 +31,7 @@ def spark_data_frame(spark_session):
 
 @pytest.fixture
 def memory_dataset(spark_data_frame):
-    return MemoryDataSet(data=spark_data_frame)
+    return MemoryDataset(data=spark_data_frame)
 
 
 def test_load_modify_original_data(memory_dataset, spark_data_frame):

--- a/kedro-datasets/tests/tensorflow/test_tensorflow_model_dataset.py
+++ b/kedro-datasets/tests/tensorflow/test_tensorflow_model_dataset.py
@@ -368,7 +368,7 @@ class TestTensorFlowModelDataSetVersioned:
             versioned_tf_model_dataset.save(dummy_tf_base_model)
 
     def test_http_filesystem_no_versioning(self, tensorflow_model_dataset):
-        pattern = r"HTTP\(s\) DataSet doesn't support versioning\."
+        pattern = "Versioning is not supported for HTTP protocols."
 
         with pytest.raises(DataSetError, match=pattern):
             tensorflow_model_dataset(

--- a/kedro-datasets/tests/text/test_text_dataset.py
+++ b/kedro-datasets/tests/text/test_text_dataset.py
@@ -157,7 +157,7 @@ class TestTextDataSetVersioned:
             versioned_txt_data_set.save(STRING)
 
     def test_http_filesystem_no_versioning(self):
-        pattern = r"HTTP\(s\) DataSet doesn't support versioning\."
+        pattern = "Versioning is not supported for HTTP protocols."
 
         with pytest.raises(DataSetError, match=pattern):
             TextDataSet(

--- a/kedro-datasets/tests/tracking/test_json_dataset.py
+++ b/kedro-datasets/tests/tracking/test_json_dataset.py
@@ -177,7 +177,7 @@ class TestJSONDataSet:
             explicit_versioned_json_dataset.save(dummy_data)
 
     def test_http_filesystem_no_versioning(self):
-        pattern = r"HTTP\(s\) DataSet doesn't support versioning\."
+        pattern = "Versioning is not supported for HTTP protocols."
 
         with pytest.raises(DataSetError, match=pattern):
             JSONDataSet(

--- a/kedro-datasets/tests/tracking/test_metrics_dataset.py
+++ b/kedro-datasets/tests/tracking/test_metrics_dataset.py
@@ -186,7 +186,7 @@ class TestMetricsDataSet:
             explicit_versioned_metrics_dataset.save(dummy_data)
 
     def test_http_filesystem_no_versioning(self):
-        pattern = r"HTTP\(s\) DataSet doesn't support versioning\."
+        pattern = "Versioning is not supported for HTTP protocols."
 
         with pytest.raises(DataSetError, match=pattern):
             MetricsDataSet(

--- a/kedro-datasets/tests/yaml/test_yaml_dataset.py
+++ b/kedro-datasets/tests/yaml/test_yaml_dataset.py
@@ -182,7 +182,7 @@ class TestYAMLDataSetVersioned:
             versioned_yaml_data_set.save(dummy_data)
 
     def test_http_filesystem_no_versioning(self):
-        pattern = r"HTTP\(s\) DataSet doesn't support versioning\."
+        pattern = "Versioning is not supported for HTTP protocols."
 
         with pytest.raises(DataSetError, match=pattern):
             YAMLDataSet(


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
In réponse to kedro-org/kedro#2500 changing the error message, any tests that specifically check that message need to be updated accordingly.

Note that this will no pass until kedro-org/kedro#2673 is merged. #239 showcases a passing build (hardcoded to build using the `refactor/rename-data-sets` branch of #2673).

## Development notes
<!-- What have you changed, and how has this been tested? -->
* Update the "no versioning" error message
* Other trivial cleanup (remove useless suppression, etc.)

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [x] Added tests to cover my changes
