### PR TITLE
feat: Added external_table_path attribute for ManagedTableDataset

### DIFF
--- a/kedro-datasets/kedro_datasets/databricks/managed_table_dataset.py
+++ b/kedro-datasets/kedro_datasets/databricks/managed_table_dataset.py
@@ -4,7 +4,6 @@ in Databricks.
 import logging
 import re
 from dataclasses import dataclass
-from pathlib import PurePosixPath
 from typing import Any, Dict, List, Optional, Union, Tuple
 
 import pandas as pd
@@ -128,9 +127,8 @@ class ManagedTable:
             DataSetError: If an invalid `external_table_path` is passed
         """
         fs_prefix, filepath = _split_filepath(self.external_table_path)
-        PurePosixPath(filepath)
         if fs_prefix in self._VALID_EXTERNAL_PREFIX:
-            raise DataSetError(f"`external_table_path` must a valid path")
+            raise DataSetError(f"`external_table_path` must begin with {self._VALID_EXTERNAL_PREFIX}")
 
     def full_table_location(self) -> str:
         """Returns the full table location

--- a/kedro-datasets/kedro_datasets/databricks/managed_table_dataset.py
+++ b/kedro-datasets/kedro_datasets/databricks/managed_table_dataset.py
@@ -126,9 +126,10 @@ class ManagedTable:
         Raises:
             DataSetError: If an invalid `external_table_path` is passed
         """
-        fs_prefix, filepath = _split_filepath(self.external_table_path)
-        if fs_prefix in self._VALID_EXTERNAL_TABLE_PREFIX:
-            raise DataSetError(f"`external_table_path` must begin with {self._VALID_EXTERNAL_TABLE_PREFIX}")
+        if self.external_table_path is not None:
+            fs_prefix, filepath = _split_filepath(self.external_table_path)
+            if fs_prefix in self._VALID_EXTERNAL_TABLE_PREFIX:
+                raise DataSetError(f"`external_table_path` must begin with {self._VALID_EXTERNAL_TABLE_PREFIX}")
 
     def full_table_location(self) -> str:
         """Returns the full table location

--- a/kedro-datasets/kedro_datasets/databricks/managed_table_dataset.py
+++ b/kedro-datasets/kedro_datasets/databricks/managed_table_dataset.py
@@ -31,7 +31,7 @@ class ManagedTable:
 
     # regex for tables, catalogs and schemas
     _NAMING_REGEX = r"\b[0-9a-zA-Z_-]{1,}\b"
-    _VALID_EXTERNAL_PREFIX = ["s3", "abfss", "abfs", "gs"]
+    _VALID_EXTERNAL_TABLE_PREFIX = ["s3", "abfss", "abfs", "gs"]
     _VALID_WRITE_MODES = ["overwrite", "upsert", "append"]
     _VALID_DATAFRAME_TYPES = ["spark", "pandas"]
     database: str
@@ -127,8 +127,8 @@ class ManagedTable:
             DataSetError: If an invalid `external_table_path` is passed
         """
         fs_prefix, filepath = _split_filepath(self.external_table_path)
-        if fs_prefix in self._VALID_EXTERNAL_PREFIX:
-            raise DataSetError(f"`external_table_path` must begin with {self._VALID_EXTERNAL_PREFIX}")
+        if fs_prefix in self._VALID_EXTERNAL_TABLE_PREFIX:
+            raise DataSetError(f"`external_table_path` must begin with {self._VALID_EXTERNAL_TABLE_PREFIX}")
 
     def full_table_location(self) -> str:
         """Returns the full table location

--- a/kedro-datasets/tests/databricks/test_managed_table_dataset.py
+++ b/kedro-datasets/tests/databricks/test_managed_table_dataset.py
@@ -227,6 +227,10 @@ class TestManagedTableDataSet:
         with pytest.raises(DataSetError):
             ManagedTableDataSet(table="test", catalog="invalid!")
 
+    def test_invalid_external_table_path(self):
+        with pytest.raises(DataSetError):
+            ManagedTableDataSet(table="test", external_table_path='invalid!')
+
     def test_schema(self):
         unity_ds = ManagedTableDataSet(
             table="test",


### PR DESCRIPTION
## Description
Added `external_table_path` attribute for `ManagedTable`

## Development notes
Added `external_table_path` attribute so it's feasible to store tables as a [external table](https://docs.databricks.com/sql/language-manual/sql-ref-external-tables.html) in Databricks

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
