### PR TITLE
chore(datasets): Fix inconsistent extra["docs"] dependencies

### DIFF
--- a/kedro-datasets/setup.py
+++ b/kedro-datasets/setup.py
@@ -122,15 +122,20 @@ extras_require = {
 
 extras_require["all"] = _collect_requirements(extras_require)
 extras_require["docs"] = [
-    "docutils==0.16",
-    "sphinx~=3.4.3",
-    "sphinx_rtd_theme==0.4.1",
-    "nbsphinx==0.8.1",
-    "nbstripout~=0.4",
-    "sphinx-autodoc-typehints==1.11.1",
-    "sphinx_copybutton==0.3.1",
-    "ipykernel>=5.3, <7.0",
-    "myst-parser~=0.17.2",
+        # docutils>=0.17 changed the HTML
+        # see https://github.com/readthedocs/sphinx_rtd_theme/issues/1115
+        "docutils==0.16",
+        "sphinx~=5.3.0",
+        "sphinx_rtd_theme==1.2.0",
+        # Regression on sphinx-autodoc-typehints 1.21
+        # that creates some problematic docstrings
+        "sphinx-autodoc-typehints==1.20.2",
+        "sphinx_copybutton==0.3.1",
+        "sphinx-notfound-page",
+        "ipykernel>=5.3, <7.0",
+        "sphinxcontrib-mermaid~=0.7.1",
+        "myst-parser~=1.0.0",
+        "Jinja2<3.1.0",
 ]
 
 setup(


### PR DESCRIPTION


## Description
<!-- Why was this PR created? -->
https://github.com/kedro-org/kedro/blob/2f3811aeab25c25fba8476f1152651753e85ee7e/setup.py#L88-L107
When we revamp our sphinx doc last time, the dependencies isn't sync, we should fix this so it is consistent.

Related https://github.com/kedro-org/kedro/pull/2459
## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
