### PR TITLE
docs: Instructions on custom Airflow Operators

### DIFF
--- a/kedro-airflow/README.md
+++ b/kedro-airflow/README.md
@@ -55,3 +55,11 @@ You can use the additional command line argument `--jinja-file` (alias `-j`) to 
 ```bash
 kedro airflow create --jinja-file=./custom/template.j2
 ```
+
+#### What if I want to use a different Airflow Operator?
+
+Which Airflow Operator to use depends on the environment your project is running in.
+You can set the operator to use by providing a custom template.
+See ["What if I want to use a different Jinja2 template?"](#what-if-i-want-to-use-a-different-jinja2-template) for instructions on using custom templates.
+The [rich offering](https://airflow.apache.org/docs/apache-airflow-providers/operators-and-hooks-ref/index.html) of operators means that the `kedro-airflow` plugin is providing templates for specific operators.
+The default template provided by `kedro-airflow` uses the `BaseOperator`.


### PR DESCRIPTION
## Description
Document how to use alternative Airflow Operators. `kedro-airflow` should not support all operators in the current situation: apart from there being too many to keep track of, this would introduce unnecessary maintenance burden.

Being explicit about the non-goals of a project is better than leave it undocumented. 

Note that these instructions remain valid if the template would be written using the [TaskFlow](https://airflow.apache.org/docs/apache-airflow/stable/tutorial/taskflow.html#using-the-taskflow-api-with-complex-conflicting-python-dependencies) syntax as proposed in https://github.com/kedro-org/kedro-plugins/issues/25.

Open for discussion of course.

## Development notes
Closes https://github.com/kedro-org/kedro-plugins/issues/27

## Checklist

- [X] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [X] Updated the documentation to reflect the code changes
- [X] Added a description of this change in the relevant `RELEASE.md` file
- [X] Added tests to cover my changes
