### PR TITLE
build: loosen the Python version requirement

### DIFF
--- a/kedro-airflow/pyproject.toml
+++ b/kedro-airflow/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
     {name = "Kedro"}
 ]
 description = "Kedro-Airflow makes it easy to deploy Kedro projects to Airflow"
-requires-python = ">=3.7, <3.11"
+requires-python = ">=3.7, <3.12"
 license = {text = "Apache Software License (Apache 2.0)"}
 dependencies = [
     "kedro>=0.17.5",

--- a/kedro-datasets/pyproject.toml
+++ b/kedro-datasets/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
     {name = "Kedro"}
 ]
 description = "Kedro-Datasets is where you can find all of Kedro's data connectors."
-requires-python = ">=3.7, <3.11"
+requires-python = ">=3.7, <3.12"
 license = {text = "Apache Software License (Apache 2.0)"}
 dependencies = [
     "kedro>=0.16",

--- a/kedro-docker/pyproject.toml
+++ b/kedro-docker/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
     {name = "Kedro"}
 ]
 description = "Kedro-Docker makes it easy to package Kedro projects with Docker."
-requires-python = ">=3.7, <3.11"
+requires-python = ">=3.7, <3.12"
 license = {text = "Apache Software License (Apache 2.0)"}
 dependencies = [
     "anyconfig~=0.10.0",  # not directly required, pinned by Snyk to avoid a vulnerability

--- a/kedro-telemetry/pyproject.toml
+++ b/kedro-telemetry/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
     {name = "Kedro"}
 ]
 description = "Kedro-Telemetry"
-requires-python = ">=3.7, <3.11"
+requires-python = ">=3.7, <3.12"
 license = {text = "Apache Software License (Apache 2.0)"}
 dependencies = [
     "kedro~=0.18.0",


### PR DESCRIPTION
## Description
Start for https://github.com/kedro-org/kedro-plugins/issues/265

This won't have any direct impact as all plugins require `kedro` which is not available for 3.11. (That's why I didn't add the `py3.11` test runner)
It does however loosen the circular dependency which we have now.

Frankly, there is little reason not to upgrade asap. 
(Some datasets that are too slow to update can just be only available for 3.10)

Alternatively, remove the upper bound completely

## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [X] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [X] Updated the documentation to reflect the code changes
- [X] Added a description of this change in the relevant `RELEASE.md` file
- [X] Added tests to cover my changes
