### PR TITLE
build(datasets): Release 1.5.1

### DIFF
--- a/kedro-datasets/RELEASE.md
+++ b/kedro-datasets/RELEASE.md
@@ -5,6 +5,11 @@
 
 ## Community contributions
 
+# Release 1.5.1:
+
+## Bug fixes and other changes
+* Fixed problematic docstrings in `pandas.DeltaTableDataSet` causing Read the Docs builds on Kedro to fail.
+
 # Release 1.5.0
 
 ## Major features and improvements
@@ -41,6 +46,7 @@ Many thanks to the following Kedroids for contributing PRs to this release:
 
 ## Bug fixes and other changes
 * Fixed problematic docstrings of `APIDataSet`.
+
 # Release 1.3.0:
 
 ## Major features and improvements

--- a/kedro-datasets/kedro_datasets/__init__.py
+++ b/kedro-datasets/kedro_datasets/__init__.py
@@ -1,3 +1,3 @@
 """``kedro_datasets`` is where you can find all of Kedro's data connectors."""
 
-__version__ = "1.5.0"
+__version__ = "1.5.1"


### PR DESCRIPTION
## Description
Patch release that fixes the bad docstring in the `DeltaTableDataSet`


## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
