### PR TITLE
fix(datasets): Correct pyproject.toml syntax for optional dependencies

### DIFF
--- a/kedro-datasets/pyproject.toml
+++ b/kedro-datasets/pyproject.toml
@@ -25,10 +25,7 @@ plotly-base = ["plotly>=4.8.0, <6.0"]
 polars-base = ["polars~=0.17.0"]
 s3fs-base = ["s3fs>=0.3.0, <0.5"]
 spark-base = ["pyspark>=2.2, <4.0"]
-"spark.DeltaTableDataSet" = [
-  "kedro-datasets[spark-base,hdfs-base,s3fs-base]",
-  "delta-spark>=1.0, <3.0"
-]
+
 
 # Datasets dependencies
 api = ["kedro-datasets[api.APIDataSet]"]
@@ -123,7 +120,11 @@ snowflake = ["kedro-datasets[snowflake.SnowparkTableDataSet]"]
 ]
 
 spark = [
-  "kedro-datasets[spark.SparkDataSet,spark.SparkHiveDataSet,spark.SparkJDBCDataSet,spark.DeltaTableDataSet]"
+  "kedro-datasets[spark.DeltaTableDataSet,spark.SparkDataSet,spark.SparkHiveDataSet,spark.SparkJDBCDataSet]"
+]
+"spark.DeltaTableDataSet" = [
+  "kedro-datasets[spark-base,hdfs-base,s3fs-base]",
+  "delta-spark>=1.0, <3.0"
 ]
 "spark.SparkDataSet" = ["kedro-datasets[spark-base,hdfs-base,s3fs-base]"]
 "spark.SparkHiveDataSet" = ["kedro-datasets[spark-base,hdfs-base,s3fs-base]"]

--- a/kedro-datasets/pyproject.toml
+++ b/kedro-datasets/pyproject.toml
@@ -18,11 +18,9 @@ dynamic = ["readme", "version"]
 
 [project.optional-dependencies]
 # Base dependencies
-delta-base = ["delta-spark~=1.2.1"]
 hdfs-base = ["hdfs>=2.5.8, <3.0"]
 pandas-base = ["pandas>=1.3, <3.0"]
 plotly-base = ["plotly>=4.8.0, <6.0"]
-polars-base = ["polars~=0.17.0"]
 s3fs-base = ["s3fs>=0.3.0, <0.5"]
 spark-base = ["pyspark>=2.2, <4.0"]
 
@@ -38,7 +36,7 @@ dask = ["kedro-datasets[dask.ParquetDataSet]"]
 "dask.ParquetDataSet" = ["dask[complete]>=2021.10", "triad>=0.6.7, <1.0"]
 
 databricks = ["kedro-datasets[databricks.ManagedTableDataSet]"]
-"databricks.ManagedTableDataSet" = ["kedro-datasets[spark-base,pandas-base,delta-base]"]
+"databricks.ManagedTableDataSet" = ["kedro-datasets[spark-base,pandas-base]", "delta-spark~=1.2.1"]
 
 geopandas = ["kedro-datasets[geopandas.GeoJSONDataSet]"]
 "geopandas.GeoJSONDataSet" = ["geopandas>=0.6.0, <1.0", "pyproj~=3.0"]
@@ -108,7 +106,7 @@ plotly = ["kedro-datasets[plotly.PlotlyDataSet,plotly.JSONDataSet]"]
 "plotly.PlotlyDataSet" = ["kedro-datasets[pandas-base,plotly-base]"]
 
 polars = ["kedro-datasets[polars.CSVDataSet]"]
-"polars.CSVDataSet" = ["kedro-datasets[polars-base]"]
+"polars.CSVDataSet" = ["polars~=0.17.0"]
 
 redis = ["kedro-datasets[redis.PickleDataSet]"]
 "redis.PickleDataSet" = ["redis~=4.1"]

--- a/kedro-datasets/pyproject.toml
+++ b/kedro-datasets/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
 dynamic = ["readme", "version"]
 
 [project.optional-dependencies]
-
+# Base dependencies
 delta-base = ["delta-spark~=1.2.1"]
 hdfs-base = ["hdfs>=2.5.8, <3.0"]
 pandas-base = ["pandas>=1.3, <3.0"]
@@ -30,6 +30,7 @@ spark-base = ["pyspark>=2.2, <4.0"]
   "delta-spark>=1.0, <3.0"
 ]
 
+# Datasets dependencies
 api = ["kedro-datasets[api.APIDataSet]"]
 "api.APIDataSet" = ["requests~=2.20"]
 biosequence = ["kedro-datasets[biosequence.BioSequenceDataSet]"]

--- a/kedro-datasets/pyproject.toml
+++ b/kedro-datasets/pyproject.toml
@@ -18,23 +18,23 @@ dynamic = ["readme", "version"]
 
 [project.optional-dependencies]
 api = ["kedro-datasets[api.APIDataSet]"]
-api-apidataset = ["requests~=2.20"]
+"api.APIDataSet" = ["requests~=2.20"]
 biosequence = ["kedro-datasets[biosequence.BioSequenceDataSet]"]
-biosequence-biosequencedataset = ["biopython~=1.73"]
+"biosequence.BioSequenceDataSet" = ["biopython~=1.73"]
 dask = ["kedro-datasets[dask.ParquetDataSet]"]
-dask-parquetdataset = ["dask[complete]>=2021.10", "triad>=0.6.7, <1.0"]
+"dask.ParquetDataSet" = ["dask[complete]>=2021.10", "triad>=0.6.7, <1.0"]
 databricks = ["kedro-datasets[databricks.ManagedTableDataSet]"]
-databricks-managedtabledataset = ["kedro-datasets[spark-base,pandas-base,delta-base]"]
+"databricks.ManagedTableDataSet" = ["kedro-datasets[spark-base,pandas-base,delta-base]"]
 delta-base = ["delta-spark~=1.2.1"]
 geopandas = ["kedro-datasets[geopandas.GeoJSONDataSet]"]
-geopandas-geojsondataset = ["geopandas>=0.6.0, <1.0", "pyproj~=3.0"]
+"geopandas.GeoJSONDataSet" = ["geopandas>=0.6.0, <1.0", "pyproj~=3.0"]
 hdfs-base = ["hdfs>=2.5.8, <3.0"]
 holoviews = ["kedro-datasets[holoviews.HoloviewsWriter]"]
-holoviews-holoviewswriter = ["holoviews~=1.13.0"]
+"holoviews.HoloviewsWriter" = ["holoviews~=1.13.0"]
 matplotlib = ["kedro-datasets[matplotlib.MatplotlibWriter]"]
-matplotlib-matplotlibwriter = ["matplotlib>=3.0.3, <4.0"]
+"matplotlib.MatplotlibWriter" = ["matplotlib>=3.0.3, <4.0"]
 networkx = ["kedro-datasets[networkx.NetworkXDataSet]"]
-networkx-networkxdataset = ["networkx~=2.4"]
+"networkx.NetworkXDataSet" = ["networkx~=2.4"]
 pandas = [
   """kedro-datasets[\
   pandas.CSVDataSet,\
@@ -47,53 +47,54 @@ pandas = [
   pandas.ParquetDataSet,\
   pandas.SQLTableDataSet,\
   pandas.SQLQueryDataSet,\
-  pandas.XMLDataSet,pandas.GenericDataSet\
+  pandas.XMLDataSet,pandas.GenericDataSet,\
+  pandas.DeltaTableDataSet\
   ]"""
 ]
 pandas-base = ["pandas>=1.3, <3.0"]
-pandas-csvdataset = ["kedro-datasets[pandas-base]"]
-pandas-exceldataset = ["kedro-datasets[pandas-base]", "openpyxl>=3.0.6, <4.0"]
-pandas-deltatabledataset= ["kedro-datasets[pandas-base]", "deltalake>=0.10.0"]
-pandas-featherdataset = ["kedro-datasets[pandas-base]"]
-pandas-gbqquerydataset = [
+"pandas.CSVDataSet" = ["kedro-datasets[pandas-base]"]
+"pandas.ExcelDataSet" = ["kedro-datasets[pandas-base]", "openpyxl>=3.0.6, <4.0"]
+"pandas.DeltaTableDataSet" = ["kedro-datasets[pandas-base]", "deltalake>=0.10.0"]
+"pandas.FeatherDataSet" = ["kedro-datasets[pandas-base]"]
+"pandas.GBQQueryDataSet" = [
   "kedro-datasets[pandas-base]",
   "pandas-gbq>=0.12.0, <0.18.0"
 ]
-pandas-gbqtabledataset = [
+"pandas.GBQTableDataSet" = [
   "kedro-datasets[pandas-base]",
   "pandas-gbq>=0.12.0, <0.18.0"
 ]
-pandas-genericdataset = ["kedro-datasets[pandas-base]"]
-pandas-hdfdataset = [
+"pandas.GenericDataSet" = ["kedro-datasets[pandas-base]"]
+"pandas.HDFDataSet" = [
   "kedro-datasets[pandas-base]",
   "tables~=3.6.0; platform_system == 'Windows'",
   "tables~=3.6; platform_system != 'Windows'"
 ]
-pandas-jsondataset = ["kedro-datasets[pandas-base]"]
-pandas-parquetdataset = ["kedro-datasets[pandas-base]", "pyarrow>=6.0"]
-pandas-sqlquerydataset = [
+"pandas.JSONDataSet" = ["kedro-datasets[pandas-base]"]
+"pandas.ParquetDataSet" = ["kedro-datasets[pandas-base]", "pyarrow>=6.0"]
+"pandas.SQLQueryDataSet" = [
   "kedro-datasets[pandas-base]",
   "SQLAlchemy>=1.4, <3.0",
   "pyodbc~=4.0"
 ]
-pandas-sqltabledataset = ["kedro-datasets[pandas-base]", "SQLAlchemy>=1.4, <3.0"]
-pandas-xmldataset = ["kedro-datasets[pandas-base]", "lxml~=4.6"]
+"pandas.SQLTableDataSet" = ["kedro-datasets[pandas-base]", "SQLAlchemy>=1.4, <3.0"]
+"pandas.XMLDataSet" = ["kedro-datasets[pandas-base]", "lxml~=4.6"]
 pickle = ["kedro-datasets[pickle.PickleDataSet]"]
-pickle-pickledataset = ["compress-pickle[lz4]~=2.1.0"]
+"pickle.PickleDataSet" = ["compress-pickle[lz4]~=2.1.0"]
 pillow = ["kedro-datasets[pillow.ImageDataSet]"]
-pillow-imagedataset = ["Pillow~=9.0"]
+"pillow.ImageDataSet" = ["Pillow~=9.0"]
 plotly = ["kedro-datasets[plotly.PlotlyDataSet,plotly.JSONDataSet]"]
 plotly-base = ["plotly>=4.8.0, <6.0"]
-plotly-jsondataset = ["kedro-datasets[plotly-base]"]
-plotly-plotlydataset = ["kedro-datasets[pandas-base,plotly-base]"]
+"plotly.JSONDataSet" = ["kedro-datasets[plotly-base]"]
+"plotly.PlotlyDataSet" = ["kedro-datasets[pandas-base,plotly-base]"]
 polars = ["kedro-datasets[polars.CSVDataSet]"]
 polars-base = ["polars~=0.17.0"]
-polars-csvdataset = ["kedro-datasets[polars-base]"]
+"polars.CSVDataSet" = ["kedro-datasets[polars-base]"]
 redis = ["kedro-datasets[redis.PickleDataSet]"]
-redis-pickledataset = ["redis~=4.1"]
+"redis.PickleDataSet" = ["redis~=4.1"]
 s3fs-base = ["s3fs>=0.3.0, <0.5"]
 snowflake = ["kedro-datasets[snowflake.SnowparkTableDataSet]"]
-snowflake-snowparktabledataset = [
+"snowflake.SnowparkTableDataSet" = [
   "snowflake-snowpark-python~=1.0.0; python_version == '3.8'",
   "pyarrow~=8.0"
 ]
@@ -101,17 +102,17 @@ spark = [
   "kedro-datasets[spark.SparkDataSet,spark.SparkHiveDataSet,spark.SparkJDBCDataSet,spark.DeltaTableDataSet]"
 ]
 spark-base = ["pyspark>=2.2, <4.0"]
-spark-deltatabledataset = [
+"spark.DeltaTableDataSet" = [
   "kedro-datasets[spark-base,hdfs-base,s3fs-base]",
   "delta-spark>=1.0, <3.0"
 ]
-spark-sparkdataset = ["kedro-datasets[spark-base,hdfs-base,s3fs-base]"]
-spark-sparkhivedataset = ["kedro-datasets[spark-base,hdfs-base,s3fs-base]"]
-spark-sparkjdbcdataset = ["kedro-datasets[spark-base,hdfs-base,s3fs-base]"]
+"spark.SparkDataSet" = ["kedro-datasets[spark-base,hdfs-base,s3fs-base]"]
+"spark.SparkHiveDataSet" = ["kedro-datasets[spark-base,hdfs-base,s3fs-base]"]
+"spark.SparkJDBCDataSet" = ["kedro-datasets[spark-base,hdfs-base,s3fs-base]"]
 svmlight = ["kedro-datasets[svmlight.SVMLightDataSet]"]
-svmlight-svmlightdataset = ["scikit-learn~=1.0.2", "scipy~=1.7.3"]
+"svmlight.SVMLightDataSet" = ["scikit-learn~=1.0.2", "scipy~=1.7.3"]
 tensorflow = ["kedro-datasets[tensorflow.TensorFlowModelDataSet]"]
-tensorflow-tensorflowmodeldataset = [
+"tensorflow.TensorFlowModelDataSet" = [
   # currently only TensorFlow V2 supported for saving and loading.
   # V1 requires HDF5 and serialises differently
   "tensorflow~=2.0; platform_system != 'Darwin' or platform_machine != 'arm64'",
@@ -119,9 +120,9 @@ tensorflow-tensorflowmodeldataset = [
   "tensorflow-macos~=2.0; platform_system == 'Darwin' and platform_machine == 'arm64'"
 ]
 video = ["kedro-datasets[video.VideoDataSet]"]
-video-videodataset = ["opencv-python~=4.5.5.64"]
+"video.VideoDataSet" = ["opencv-python~=4.5.5.64"]
 yaml = ["kedro-datasets[yaml.YAMLDataSet]"]
-yaml-yamldataset = ["kedro-datasets[pandas-base]", "PyYAML>=4.2, <7.0"]
+"yaml.YAMLDataSet" = ["kedro-datasets[pandas-base]", "PyYAML>=4.2, <7.0"]
 
 all = [
   """kedro-datasets[\

--- a/kedro-datasets/pyproject.toml
+++ b/kedro-datasets/pyproject.toml
@@ -59,7 +59,9 @@ pandas = [
   """kedro-datasets[\
   pandas.CSVDataSet,\
   pandas.ExcelDataSet,\
+  pandas.DeltaTableDataSet,\
   pandas.FeatherDataSet,\
+  pandas.GenericDataSet,\
   pandas.GBQTableDataSet,\
   pandas.GBQQueryDataSet,\
   pandas.HDFDataSet,\
@@ -67,23 +69,22 @@ pandas = [
   pandas.ParquetDataSet,\
   pandas.SQLTableDataSet,\
   pandas.SQLQueryDataSet,\
-  pandas.XMLDataSet,pandas.GenericDataSet,\
-  pandas.DeltaTableDataSet\
+  pandas.XMLDataSet\
   ]"""
 ]
 "pandas.CSVDataSet" = ["kedro-datasets[pandas-base]"]
 "pandas.ExcelDataSet" = ["kedro-datasets[pandas-base]", "openpyxl>=3.0.6, <4.0"]
 "pandas.DeltaTableDataSet" = ["kedro-datasets[pandas-base]", "deltalake>=0.10.0"]
 "pandas.FeatherDataSet" = ["kedro-datasets[pandas-base]"]
-"pandas.GBQQueryDataSet" = [
-  "kedro-datasets[pandas-base]",
-  "pandas-gbq>=0.12.0, <0.18.0"
-]
+"pandas.GenericDataSet" = ["kedro-datasets[pandas-base]"]
 "pandas.GBQTableDataSet" = [
   "kedro-datasets[pandas-base]",
   "pandas-gbq>=0.12.0, <0.18.0"
 ]
-"pandas.GenericDataSet" = ["kedro-datasets[pandas-base]"]
+"pandas.GBQQueryDataSet" = [
+  "kedro-datasets[pandas-base]",
+  "pandas-gbq>=0.12.0, <0.18.0"
+]
 "pandas.HDFDataSet" = [
   "kedro-datasets[pandas-base]",
   "tables~=3.6.0; platform_system == 'Windows'",
@@ -91,12 +92,12 @@ pandas = [
 ]
 "pandas.JSONDataSet" = ["kedro-datasets[pandas-base]"]
 "pandas.ParquetDataSet" = ["kedro-datasets[pandas-base]", "pyarrow>=6.0"]
+"pandas.SQLTableDataSet" = ["kedro-datasets[pandas-base]", "SQLAlchemy>=1.4, <3.0"]
 "pandas.SQLQueryDataSet" = [
   "kedro-datasets[pandas-base]",
   "SQLAlchemy>=1.4, <3.0",
   "pyodbc~=4.0"
 ]
-"pandas.SQLTableDataSet" = ["kedro-datasets[pandas-base]", "SQLAlchemy>=1.4, <3.0"]
 "pandas.XMLDataSet" = ["kedro-datasets[pandas-base]", "lxml~=4.6"]
 
 pickle = ["kedro-datasets[pickle.PickleDataSet]"]

--- a/kedro-datasets/pyproject.toml
+++ b/kedro-datasets/pyproject.toml
@@ -33,10 +33,13 @@ spark-base = ["pyspark>=2.2, <4.0"]
 # Datasets dependencies
 api = ["kedro-datasets[api.APIDataSet]"]
 "api.APIDataSet" = ["requests~=2.20"]
+
 biosequence = ["kedro-datasets[biosequence.BioSequenceDataSet]"]
 "biosequence.BioSequenceDataSet" = ["biopython~=1.73"]
+
 dask = ["kedro-datasets[dask.ParquetDataSet]"]
 "dask.ParquetDataSet" = ["dask[complete]>=2021.10", "triad>=0.6.7, <1.0"]
+
 databricks = ["kedro-datasets[databricks.ManagedTableDataSet]"]
 "databricks.ManagedTableDataSet" = ["kedro-datasets[spark-base,pandas-base,delta-base]"]
 
@@ -45,10 +48,13 @@ geopandas = ["kedro-datasets[geopandas.GeoJSONDataSet]"]
 
 holoviews = ["kedro-datasets[holoviews.HoloviewsWriter]"]
 "holoviews.HoloviewsWriter" = ["holoviews~=1.13.0"]
+
 matplotlib = ["kedro-datasets[matplotlib.MatplotlibWriter]"]
 "matplotlib.MatplotlibWriter" = ["matplotlib>=3.0.3, <4.0"]
+
 networkx = ["kedro-datasets[networkx.NetworkXDataSet]"]
 "networkx.NetworkXDataSet" = ["networkx~=2.4"]
+
 pandas = [
   """kedro-datasets[\
   pandas.CSVDataSet,\
@@ -65,7 +71,6 @@ pandas = [
   pandas.DeltaTableDataSet\
   ]"""
 ]
-
 "pandas.CSVDataSet" = ["kedro-datasets[pandas-base]"]
 "pandas.ExcelDataSet" = ["kedro-datasets[pandas-base]", "openpyxl>=3.0.6, <4.0"]
 "pandas.DeltaTableDataSet" = ["kedro-datasets[pandas-base]", "deltalake>=0.10.0"]
@@ -93,17 +98,20 @@ pandas = [
 ]
 "pandas.SQLTableDataSet" = ["kedro-datasets[pandas-base]", "SQLAlchemy>=1.4, <3.0"]
 "pandas.XMLDataSet" = ["kedro-datasets[pandas-base]", "lxml~=4.6"]
+
 pickle = ["kedro-datasets[pickle.PickleDataSet]"]
 "pickle.PickleDataSet" = ["compress-pickle[lz4]~=2.1.0"]
+
 pillow = ["kedro-datasets[pillow.ImageDataSet]"]
 "pillow.ImageDataSet" = ["Pillow~=9.0"]
-plotly = ["kedro-datasets[plotly.PlotlyDataSet,plotly.JSONDataSet]"]
 
+plotly = ["kedro-datasets[plotly.PlotlyDataSet,plotly.JSONDataSet]"]
 "plotly.JSONDataSet" = ["kedro-datasets[plotly-base]"]
 "plotly.PlotlyDataSet" = ["kedro-datasets[pandas-base,plotly-base]"]
-polars = ["kedro-datasets[polars.CSVDataSet]"]
 
+polars = ["kedro-datasets[polars.CSVDataSet]"]
 "polars.CSVDataSet" = ["kedro-datasets[polars-base]"]
+
 redis = ["kedro-datasets[redis.PickleDataSet]"]
 "redis.PickleDataSet" = ["redis~=4.1"]
 
@@ -112,14 +120,17 @@ snowflake = ["kedro-datasets[snowflake.SnowparkTableDataSet]"]
   "snowflake-snowpark-python~=1.0.0; python_version == '3.8'",
   "pyarrow~=8.0"
 ]
+
 spark = [
   "kedro-datasets[spark.SparkDataSet,spark.SparkHiveDataSet,spark.SparkJDBCDataSet,spark.DeltaTableDataSet]"
 ]
 "spark.SparkDataSet" = ["kedro-datasets[spark-base,hdfs-base,s3fs-base]"]
 "spark.SparkHiveDataSet" = ["kedro-datasets[spark-base,hdfs-base,s3fs-base]"]
 "spark.SparkJDBCDataSet" = ["kedro-datasets[spark-base,hdfs-base,s3fs-base]"]
+
 svmlight = ["kedro-datasets[svmlight.SVMLightDataSet]"]
 "svmlight.SVMLightDataSet" = ["scikit-learn~=1.0.2", "scipy~=1.7.3"]
+
 tensorflow = ["kedro-datasets[tensorflow.TensorFlowModelDataSet]"]
 "tensorflow.TensorFlowModelDataSet" = [
   # currently only TensorFlow V2 supported for saving and loading.
@@ -128,8 +139,10 @@ tensorflow = ["kedro-datasets[tensorflow.TensorFlowModelDataSet]"]
   # https://developer.apple.com/metal/tensorflow-plugin/
   "tensorflow-macos~=2.0; platform_system == 'Darwin' and platform_machine == 'arm64'"
 ]
+
 video = ["kedro-datasets[video.VideoDataSet]"]
 "video.VideoDataSet" = ["opencv-python~=4.5.5.64"]
+
 yaml = ["kedro-datasets[yaml.YAMLDataSet]"]
 "yaml.YAMLDataSet" = ["kedro-datasets[pandas-base]", "PyYAML>=4.2, <7.0"]
 

--- a/kedro-datasets/pyproject.toml
+++ b/kedro-datasets/pyproject.toml
@@ -17,6 +17,19 @@ dependencies = [
 dynamic = ["readme", "version"]
 
 [project.optional-dependencies]
+
+delta-base = ["delta-spark~=1.2.1"]
+hdfs-base = ["hdfs>=2.5.8, <3.0"]
+pandas-base = ["pandas>=1.3, <3.0"]
+plotly-base = ["plotly>=4.8.0, <6.0"]
+polars-base = ["polars~=0.17.0"]
+s3fs-base = ["s3fs>=0.3.0, <0.5"]
+spark-base = ["pyspark>=2.2, <4.0"]
+"spark.DeltaTableDataSet" = [
+  "kedro-datasets[spark-base,hdfs-base,s3fs-base]",
+  "delta-spark>=1.0, <3.0"
+]
+
 api = ["kedro-datasets[api.APIDataSet]"]
 "api.APIDataSet" = ["requests~=2.20"]
 biosequence = ["kedro-datasets[biosequence.BioSequenceDataSet]"]
@@ -25,10 +38,10 @@ dask = ["kedro-datasets[dask.ParquetDataSet]"]
 "dask.ParquetDataSet" = ["dask[complete]>=2021.10", "triad>=0.6.7, <1.0"]
 databricks = ["kedro-datasets[databricks.ManagedTableDataSet]"]
 "databricks.ManagedTableDataSet" = ["kedro-datasets[spark-base,pandas-base,delta-base]"]
-delta-base = ["delta-spark~=1.2.1"]
+
 geopandas = ["kedro-datasets[geopandas.GeoJSONDataSet]"]
 "geopandas.GeoJSONDataSet" = ["geopandas>=0.6.0, <1.0", "pyproj~=3.0"]
-hdfs-base = ["hdfs>=2.5.8, <3.0"]
+
 holoviews = ["kedro-datasets[holoviews.HoloviewsWriter]"]
 "holoviews.HoloviewsWriter" = ["holoviews~=1.13.0"]
 matplotlib = ["kedro-datasets[matplotlib.MatplotlibWriter]"]
@@ -51,7 +64,7 @@ pandas = [
   pandas.DeltaTableDataSet\
   ]"""
 ]
-pandas-base = ["pandas>=1.3, <3.0"]
+
 "pandas.CSVDataSet" = ["kedro-datasets[pandas-base]"]
 "pandas.ExcelDataSet" = ["kedro-datasets[pandas-base]", "openpyxl>=3.0.6, <4.0"]
 "pandas.DeltaTableDataSet" = ["kedro-datasets[pandas-base]", "deltalake>=0.10.0"]
@@ -84,15 +97,15 @@ pickle = ["kedro-datasets[pickle.PickleDataSet]"]
 pillow = ["kedro-datasets[pillow.ImageDataSet]"]
 "pillow.ImageDataSet" = ["Pillow~=9.0"]
 plotly = ["kedro-datasets[plotly.PlotlyDataSet,plotly.JSONDataSet]"]
-plotly-base = ["plotly>=4.8.0, <6.0"]
+
 "plotly.JSONDataSet" = ["kedro-datasets[plotly-base]"]
 "plotly.PlotlyDataSet" = ["kedro-datasets[pandas-base,plotly-base]"]
 polars = ["kedro-datasets[polars.CSVDataSet]"]
-polars-base = ["polars~=0.17.0"]
+
 "polars.CSVDataSet" = ["kedro-datasets[polars-base]"]
 redis = ["kedro-datasets[redis.PickleDataSet]"]
 "redis.PickleDataSet" = ["redis~=4.1"]
-s3fs-base = ["s3fs>=0.3.0, <0.5"]
+
 snowflake = ["kedro-datasets[snowflake.SnowparkTableDataSet]"]
 "snowflake.SnowparkTableDataSet" = [
   "snowflake-snowpark-python~=1.0.0; python_version == '3.8'",
@@ -100,11 +113,6 @@ snowflake = ["kedro-datasets[snowflake.SnowparkTableDataSet]"]
 ]
 spark = [
   "kedro-datasets[spark.SparkDataSet,spark.SparkHiveDataSet,spark.SparkJDBCDataSet,spark.DeltaTableDataSet]"
-]
-spark-base = ["pyspark>=2.2, <4.0"]
-"spark.DeltaTableDataSet" = [
-  "kedro-datasets[spark-base,hdfs-base,s3fs-base]",
-  "delta-spark>=1.0, <3.0"
 ]
 "spark.SparkDataSet" = ["kedro-datasets[spark-base,hdfs-base,s3fs-base]"]
 "spark.SparkHiveDataSet" = ["kedro-datasets[spark-base,hdfs-base,s3fs-base]"]


### PR DESCRIPTION
## Description
#263 modified optional-dependencies in pyproject.toml, leading to issues with dependency loading for `spark` when running `kedro-datasets[spark.SparkDataSet, pandas.ParquetDataSet]` (as seen in the iris-databricks starter). This PR corrects the pyproject.toml syntax to resolve the issue.


## Development notes
Tested manually using the iris-databricks starter only.

## Checklist

- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
