### PR TITLE
build(datasets): Release/kedro datasets 1.5.3

### DIFF
--- a/kedro-datasets/RELEASE.md
+++ b/kedro-datasets/RELEASE.md
@@ -2,10 +2,14 @@
 ## Major features and improvements
 
 ## Bug fixes and other changes
+
+# Release 1.5.3:
+## Bug fixes and other changes
 * Made `databricks.ManagedTableDataSet` read-only by default.
     * The user needs to specify `write_mode` to allow `save` on the data set.
 * Fixed an issue on `api.APIDataSet` where the sent data was doubly converted to json
   string (once by us and once by the `requests` library).
+* Fixed problematic `kedro-datasets` optional dependencies, revert to `setup.py`
 
 ## Community contributions
 # Release 1.5.2:

--- a/kedro-datasets/kedro_datasets/__init__.py
+++ b/kedro-datasets/kedro_datasets/__init__.py
@@ -1,3 +1,3 @@
 """``kedro_datasets`` is where you can find all of Kedro's data connectors."""
 
-__version__ = "1.5.2"
+__version__ = "1.5.3"


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
Release 1.5.3

- This should be the last 1.5.x series for bug fix. Note this is important because from 1.5.0 -> 1.5.2 we suffer from different problems of optional dependencies, we want to ensure people can still upgrade painlessly (relatively) if they have pin `kedro-datasets~=1.5.0`. 
- Upcoming release should be 1.6.0 (Python 3.11 support)

## Development notes
<!-- What have you changed, and how has this been tested? -->
- Change ManagedTableDataSet default to read-only, with options to overwrite.
- Revert optional dependencies to `setup.py`, since setuptools does not support pyproject.toml fully.

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
