### PR TITLE
ci(airflow): Pin apache-airflow version

### DIFF
--- a/kedro-airflow/pyproject.toml
+++ b/kedro-airflow/pyproject.toml
@@ -24,7 +24,7 @@ Tracker = "https://github.com/kedro-org/kedro-plugins/issues"
 
 [project.optional-dependencies]
 test = [
-    "apache-airflow<3.0",
+    "apache-airflow<2.7.0",
     "bandit>=1.6.2, <2.0",
     "behave",
     "black~=22.0",

--- a/kedro-airflow/pyproject.toml
+++ b/kedro-airflow/pyproject.toml
@@ -24,7 +24,7 @@ Tracker = "https://github.com/kedro-org/kedro-plugins/issues"
 
 [project.optional-dependencies]
 test = [
-    "apache-airflow<2.7.0",
+    "apache-airflow<2.7.0", # TODO: Temporary fix, make kedro-airflow compatible with new version of airflow
     "bandit>=1.6.2, <2.0",
     "behave",
     "black~=22.0",


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
Fix #295 failing end to end tests for `kedro-airflow`  
## Development notes
<!-- What have you changed, and how has this been tested? -->
There was a [new release for `apache-airflow` on 18th August 2023](https://airflow.apache.org/announcements/#august-18-2023) which broke something with `sqlalchemy`
What do we think about setting version for `apache-airflow` to `<2.7.0` for now?

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
