### PR TITLE
build(telemetry): Add python 3.11 to telemetry

### DIFF
--- a/.github/workflows/kedro-telemetry.yml
+++ b/.github/workflows/kedro-telemetry.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        python-version: [ "3.7", "3.8", "3.9", "3.10" ]
+        python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11" ]
     uses: ./.github/workflows/unit-tests.yml
     with:
       plugin: kedro-telemetry
@@ -31,16 +31,19 @@ jobs:
 
   lint:
     uses: ./.github/workflows/lint.yml
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     with:
       plugin: kedro-telemetry
       os: ubuntu-latest
-      python-version: "3.8"
+      python-version: ${{ matrix.python-version }}
 
   e2e-tests:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        python-version: [ "3.7", "3.8", "3.9", "3.10" ]
+        python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11" ]
     uses: ./.github/workflows/e2e-tests.yml
     with:
       plugin: kedro-telemetry

--- a/.github/workflows/kedro-telemetry.yml
+++ b/.github/workflows/kedro-telemetry.yml
@@ -31,13 +31,10 @@ jobs:
 
   lint:
     uses: ./.github/workflows/lint.yml
-    strategy:
-      matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
     with:
       plugin: kedro-telemetry
       os: ubuntu-latest
-      python-version: ${{ matrix.python-version }}
+      python-version: "3.8"
 
   e2e-tests:
     strategy:

--- a/kedro-telemetry/RELEASE.md
+++ b/kedro-telemetry/RELEASE.md
@@ -1,4 +1,5 @@
 # Upcoming release
+* Added support for Python 3.11
 
 # Release 0.2.5
 * Migrate all project metadata to static `pyproject.toml`.

--- a/kedro-telemetry/tests/test_masking.py
+++ b/kedro-telemetry/tests/test_masking.py
@@ -64,13 +64,13 @@ def fake_metadata(fake_root_dir):
 class TestCLIMasking:
     def test_get_cli_structure_raw(self, mocker, fake_metadata):
         Module = namedtuple("Module", ["cli"])
-        mocker.patch(
-            "kedro.framework.cli.cli.importlib.import_module",
-            return_value=Module(cli=cli),
-        )
         mocker.patch("kedro.framework.cli.cli._is_project", return_value=True)
         mocker.patch(
             "kedro.framework.cli.cli.bootstrap_project", return_value=fake_metadata
+        )
+        mocker.patch(
+            "kedro.framework.cli.cli.importlib.import_module",
+            return_value=Module(cli=cli),
         )
         kedro_cli = KedroCLI(fake_metadata.project_path)
         raw_cli_structure = _get_cli_structure(kedro_cli, get_help=False)
@@ -89,13 +89,13 @@ class TestCLIMasking:
 
     def test_get_cli_structure_depth(self, mocker, fake_metadata):
         Module = namedtuple("Module", ["cli"])
-        mocker.patch(
-            "kedro.framework.cli.cli.importlib.import_module",
-            return_value=Module(cli=cli),
-        )
         mocker.patch("kedro.framework.cli.cli._is_project", return_value=True)
         mocker.patch(
             "kedro.framework.cli.cli.bootstrap_project", return_value=fake_metadata
+        )
+        mocker.patch(
+            "kedro.framework.cli.cli.importlib.import_module",
+            return_value=Module(cli=cli),
         )
         kedro_cli = KedroCLI(fake_metadata.project_path)
         raw_cli_structure = _get_cli_structure(kedro_cli, get_help=False)
@@ -121,13 +121,13 @@ class TestCLIMasking:
 
     def test_get_cli_structure_help(self, mocker, fake_metadata):
         Module = namedtuple("Module", ["cli"])
-        mocker.patch(
-            "kedro.framework.cli.cli.importlib.import_module",
-            return_value=Module(cli=cli),
-        )
         mocker.patch("kedro.framework.cli.cli._is_project", return_value=True)
         mocker.patch(
             "kedro.framework.cli.cli.bootstrap_project", return_value=fake_metadata
+        )
+        mocker.patch(
+            "kedro.framework.cli.cli.importlib.import_module",
+            return_value=Module(cli=cli),
         )
         kedro_cli = KedroCLI(fake_metadata.project_path)
         help_cli_structure = _get_cli_structure(kedro_cli, get_help=True)


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
Partial solution for #265
## Development notes
<!-- What have you changed, and how has this been tested? -->

NOTE: linter's still running on python 3.8 because of some `pre-commit` errors. To be done as a follow up for all plugins. #331 

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
