### PR TITLE
ci: Update condition for creating a notification for nightly build failure

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -24,7 +24,7 @@ jobs:
       issues: write
     name: Notify failed build for airflow
     needs: airflow-test
-    if: failure()
+    if: ${{ !success() }}
     runs-on: ubuntu-latest
     steps:
       - uses: jayqi/failed-build-issue-action@v1
@@ -42,7 +42,7 @@ jobs:
       issues: write
     name: Notify failed build for datasets
     needs: datasets-test
-    if: failure()
+    if: ${{ !success() }}
     runs-on: ubuntu-latest
     steps:
       - uses: jayqi/failed-build-issue-action@v1
@@ -60,7 +60,7 @@ jobs:
       issues: write
     name: Notify failed build for docker
     needs: docker-test
-    if: failure()
+    if: ${{ !success() }}
     runs-on: ubuntu-latest
     steps:
       - uses: jayqi/failed-build-issue-action@v1
@@ -78,7 +78,7 @@ jobs:
       issues: write
     name: Notify failed build for telemetry
     needs: telemetry-test
-    if: failure()
+    if: ${{ !success() }}
     runs-on: ubuntu-latest
     steps:
       - uses: jayqi/failed-build-issue-action@v1


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
I noticed that the datasets tests were failing for a day or two but no issue was created. 
The if conditions on the success/failure of github actions jobs works weirdly. If one of the sub tasks fails the jobs for other python versions and os are cancelled so sometimes it skips the notification creation step. 

The status for the failed nightly build is shown as cancelled instead -> https://github.com/kedro-org/kedro-plugins/actions/workflows/nightly-build.yml

## Development notes
<!-- What have you changed, and how has this been tested? -->
Tested on fork -

With `if: failure()` condition - https://github.com/ankatiyar/kedro-plugins/actions/runs/6184855180
With `if: ${{ !success() }}` condition - https://github.com/ankatiyar/kedro-plugins/actions/runs/6184875778
## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
