### PR TITLE
feat(datasets): make datasets arguments keywords only

### DIFF
--- a/kedro-datasets/RELEASE.md
+++ b/kedro-datasets/RELEASE.md
@@ -6,11 +6,13 @@
 
 ## Bug fixes and other changes
 * Fixed bug with loading models saved with `TensorFlowModelDataset`.
+* Make dataset parameters keyword-only.
 
 ## Community contributions
 Many thanks to the following Kedroids for contributing PRs to this release:
 * [Edouard59](https://github.com/Edouard59)
 * [Miguel Rodriguez Gutierrez](https://github.com/MigQ2)
+* [felixscherz](https://github.com/felixscherz)
 
 # Release 1.8.0
 ## Major features and improvements

--- a/kedro-datasets/kedro_datasets/api/api_dataset.py
+++ b/kedro-datasets/kedro_datasets/api/api_dataset.py
@@ -95,6 +95,7 @@ class APIDataset(AbstractDataset[None, requests.Response]):
 
     def __init__(  # noqa: PLR0913
         self,
+        *,
         url: str,
         method: str = "GET",
         load_args: Dict[str, Any] = None,

--- a/kedro-datasets/kedro_datasets/biosequence/biosequence_dataset.py
+++ b/kedro-datasets/kedro_datasets/biosequence/biosequence_dataset.py
@@ -49,6 +49,7 @@ class BioSequenceDataset(AbstractDataset[List, List]):
 
     def __init__(  # noqa: PLR0913
         self,
+        *,
         filepath: str,
         load_args: Dict[str, Any] = None,
         save_args: Dict[str, Any] = None,

--- a/kedro-datasets/kedro_datasets/dask/parquet_dataset.py
+++ b/kedro-datasets/kedro_datasets/dask/parquet_dataset.py
@@ -91,6 +91,7 @@ class ParquetDataset(AbstractDataset[dd.DataFrame, dd.DataFrame]):
 
     def __init__(  # noqa: PLR0913
         self,
+        *,
         filepath: str,
         load_args: Dict[str, Any] = None,
         save_args: Dict[str, Any] = None,

--- a/kedro-datasets/kedro_datasets/databricks/managed_table_dataset.py
+++ b/kedro-datasets/kedro_datasets/databricks/managed_table_dataset.py
@@ -199,6 +199,7 @@ class ManagedTableDataset(AbstractVersionedDataset):
 
     def __init__(  # noqa: PLR0913
         self,
+        *,
         table: str,
         catalog: str = None,
         database: str = "default",
@@ -206,7 +207,6 @@ class ManagedTableDataset(AbstractVersionedDataset):
         dataframe_type: str = "spark",
         primary_key: Optional[Union[str, List[str]]] = None,
         version: Version = None,
-        *,
         # the following parameters are used by project hooks
         # to create or update table properties
         schema: Dict[str, Any] = None,

--- a/kedro-datasets/kedro_datasets/email/message_dataset.py
+++ b/kedro-datasets/kedro_datasets/email/message_dataset.py
@@ -54,6 +54,7 @@ class EmailMessageDataset(AbstractVersionedDataset[Message, Message]):
 
     def __init__(  # noqa: PLR0913
         self,
+        *,
         filepath: str,
         load_args: Dict[str, Any] = None,
         save_args: Dict[str, Any] = None,

--- a/kedro-datasets/kedro_datasets/geopandas/geojson_dataset.py
+++ b/kedro-datasets/kedro_datasets/geopandas/geojson_dataset.py
@@ -50,6 +50,7 @@ class GeoJSONDataset(
 
     def __init__(  # noqa: PLR0913
         self,
+        *,
         filepath: str,
         load_args: Dict[str, Any] = None,
         save_args: Dict[str, Any] = None,

--- a/kedro-datasets/kedro_datasets/holoviews/holoviews_writer.py
+++ b/kedro-datasets/kedro_datasets/holoviews/holoviews_writer.py
@@ -28,7 +28,7 @@ class HoloviewsWriter(AbstractVersionedDataset[HoloViews, NoReturn]):
         >>> from kedro_datasets.holoviews import HoloviewsWriter
         >>>
         >>> curve = hv.Curve(range(10))
-        >>> holoviews_writer = HoloviewsWriter("/tmp/holoviews")
+        >>> holoviews_writer = HoloviewsWriter(filepath="/tmp/holoviews")
         >>>
         >>> holoviews_writer.save(curve)
 

--- a/kedro-datasets/kedro_datasets/holoviews/holoviews_writer.py
+++ b/kedro-datasets/kedro_datasets/holoviews/holoviews_writer.py
@@ -38,6 +38,7 @@ class HoloviewsWriter(AbstractVersionedDataset[HoloViews, NoReturn]):
 
     def __init__(  # noqa: PLR0913
         self,
+        *,
         filepath: str,
         fs_args: Dict[str, Any] = None,
         credentials: Dict[str, Any] = None,

--- a/kedro-datasets/kedro_datasets/json/json_dataset.py
+++ b/kedro-datasets/kedro_datasets/json/json_dataset.py
@@ -52,6 +52,7 @@ class JSONDataset(AbstractVersionedDataset[Any, Any]):
 
     def __init__(  # noqa: PLR0913
         self,
+        *,
         filepath: str,
         save_args: Dict[str, Any] = None,
         version: Version = None,

--- a/kedro-datasets/kedro_datasets/matplotlib/matplotlib_writer.py
+++ b/kedro-datasets/kedro_datasets/matplotlib/matplotlib_writer.py
@@ -103,6 +103,7 @@ class MatplotlibWriter(
 
     def __init__(  # noqa: PLR0913
         self,
+        *,
         filepath: str,
         fs_args: Dict[str, Any] = None,
         credentials: Dict[str, Any] = None,

--- a/kedro-datasets/kedro_datasets/networkx/gml_dataset.py
+++ b/kedro-datasets/kedro_datasets/networkx/gml_dataset.py
@@ -40,6 +40,7 @@ class GMLDataset(AbstractVersionedDataset[networkx.Graph, networkx.Graph]):
 
     def __init__(  # noqa: PLR0913
         self,
+        *,
         filepath: str,
         load_args: Dict[str, Any] = None,
         save_args: Dict[str, Any] = None,

--- a/kedro-datasets/kedro_datasets/networkx/graphml_dataset.py
+++ b/kedro-datasets/kedro_datasets/networkx/graphml_dataset.py
@@ -39,6 +39,7 @@ class GraphMLDataset(AbstractVersionedDataset[networkx.Graph, networkx.Graph]):
 
     def __init__(  # noqa: PLR0913
         self,
+        *,
         filepath: str,
         load_args: Dict[str, Any] = None,
         save_args: Dict[str, Any] = None,

--- a/kedro-datasets/kedro_datasets/networkx/json_dataset.py
+++ b/kedro-datasets/kedro_datasets/networkx/json_dataset.py
@@ -40,6 +40,7 @@ class JSONDataset(AbstractVersionedDataset[networkx.Graph, networkx.Graph]):
 
     def __init__(  # noqa: PLR0913
         self,
+        *,
         filepath: str,
         load_args: Dict[str, Any] = None,
         save_args: Dict[str, Any] = None,

--- a/kedro-datasets/kedro_datasets/pandas/csv_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/csv_dataset.py
@@ -72,6 +72,7 @@ class CSVDataset(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
 
     def __init__(  # noqa: PLR0913
         self,
+        *,
         filepath: str,
         load_args: Dict[str, Any] = None,
         save_args: Dict[str, Any] = None,

--- a/kedro-datasets/kedro_datasets/pandas/deltatable_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/deltatable_dataset.py
@@ -88,6 +88,7 @@ class DeltaTableDataset(AbstractDataset):
 
     def __init__(  # noqa: PLR0913
         self,
+        *,
         filepath: Optional[str] = None,
         catalog_type: Optional[DataCatalog] = None,
         catalog_name: Optional[str] = None,

--- a/kedro-datasets/kedro_datasets/pandas/excel_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/excel_dataset.py
@@ -112,6 +112,7 @@ class ExcelDataset(
 
     def __init__(  # noqa: PLR0913
         self,
+        *,
         filepath: str,
         engine: str = "openpyxl",
         load_args: Dict[str, Any] = None,

--- a/kedro-datasets/kedro_datasets/pandas/feather_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/feather_dataset.py
@@ -73,6 +73,7 @@ class FeatherDataset(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
 
     def __init__(  # noqa: PLR0913
         self,
+        *,
         filepath: str,
         load_args: Dict[str, Any] = None,
         save_args: Dict[str, Any] = None,

--- a/kedro-datasets/kedro_datasets/pandas/gbq_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/gbq_dataset.py
@@ -66,6 +66,7 @@ class GBQTableDataset(AbstractDataset[None, pd.DataFrame]):
 
     def __init__(  # noqa: PLR0913
         self,
+        *,
         dataset: str,
         table_name: str,
         project: str = None,

--- a/kedro-datasets/kedro_datasets/pandas/generic_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/generic_dataset.py
@@ -84,6 +84,7 @@ class GenericDataset(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
 
     def __init__(  # noqa: PLR0913
         self,
+        *,
         filepath: str,
         file_format: str,
         load_args: Dict[str, Any] = None,

--- a/kedro-datasets/kedro_datasets/pandas/hdf_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/hdf_dataset.py
@@ -59,6 +59,7 @@ class HDFDataset(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
 
     def __init__(  # noqa: PLR0913
         self,
+        *,
         filepath: str,
         key: str,
         load_args: Dict[str, Any] = None,

--- a/kedro-datasets/kedro_datasets/pandas/json_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/json_dataset.py
@@ -67,6 +67,7 @@ class JSONDataset(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
 
     def __init__(  # noqa: PLR0913
         self,
+        *,
         filepath: str,
         load_args: Dict[str, Any] = None,
         save_args: Dict[str, Any] = None,

--- a/kedro-datasets/kedro_datasets/pandas/parquet_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/parquet_dataset.py
@@ -78,6 +78,7 @@ class ParquetDataset(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
 
     def __init__(  # noqa: PLR0913
         self,
+        *,
         filepath: str,
         load_args: Dict[str, Any] = None,
         save_args: Dict[str, Any] = None,

--- a/kedro-datasets/kedro_datasets/pandas/sql_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/sql_dataset.py
@@ -155,6 +155,7 @@ class SQLTableDataset(AbstractDataset[pd.DataFrame, pd.DataFrame]):
 
     def __init__(  # noqa: PLR0913
         self,
+        *,
         table_name: str,
         credentials: dict[str, Any],
         load_args: dict[str, Any] = None,

--- a/kedro-datasets/kedro_datasets/pandas/xml_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/xml_dataset.py
@@ -50,6 +50,7 @@ class XMLDataset(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
 
     def __init__(  # noqa: PLR0913
         self,
+        *,
         filepath: str,
         load_args: Dict[str, Any] = None,
         save_args: Dict[str, Any] = None,

--- a/kedro-datasets/kedro_datasets/partitions/incremental_dataset.py
+++ b/kedro-datasets/kedro_datasets/partitions/incremental_dataset.py
@@ -67,6 +67,7 @@ class IncrementalDataset(PartitionedDataset):
 
     def __init__(  # noqa: PLR0913
         self,
+        *,
         path: str,
         dataset: str | type[AbstractDataset] | dict[str, Any],
         checkpoint: str | dict[str, Any] | None = None,

--- a/kedro-datasets/kedro_datasets/pickle/pickle_dataset.py
+++ b/kedro-datasets/kedro_datasets/pickle/pickle_dataset.py
@@ -73,6 +73,7 @@ class PickleDataset(AbstractVersionedDataset[Any, Any]):
 
     def __init__(  # noqa: PLR0913
         self,
+        *,
         filepath: str,
         backend: str = "pickle",
         load_args: Dict[str, Any] = None,

--- a/kedro-datasets/kedro_datasets/pillow/image_dataset.py
+++ b/kedro-datasets/kedro_datasets/pillow/image_dataset.py
@@ -36,6 +36,7 @@ class ImageDataset(AbstractVersionedDataset[Image.Image, Image.Image]):
 
     def __init__(  # noqa: PLR0913
         self,
+        *,
         filepath: str,
         save_args: Dict[str, Any] = None,
         version: Version = None,

--- a/kedro-datasets/kedro_datasets/plotly/json_dataset.py
+++ b/kedro-datasets/kedro_datasets/plotly/json_dataset.py
@@ -54,6 +54,7 @@ class JSONDataset(
 
     def __init__(  # noqa: PLR0913
         self,
+        *,
         filepath: str,
         load_args: Dict[str, Any] = None,
         save_args: Dict[str, Any] = None,

--- a/kedro-datasets/kedro_datasets/plotly/plotly_dataset.py
+++ b/kedro-datasets/kedro_datasets/plotly/plotly_dataset.py
@@ -70,6 +70,7 @@ class PlotlyDataset(JSONDataset):
 
     def __init__(  # noqa: PLR0913
         self,
+        *,
         filepath: str,
         plotly_args: Dict[str, Any],
         load_args: Dict[str, Any] = None,
@@ -115,7 +116,14 @@ class PlotlyDataset(JSONDataset):
             metadata: Any arbitrary metadata.
                 This is ignored by Kedro, but may be consumed by users or external plugins.
         """
-        super().__init__(filepath, load_args, save_args, version, credentials, fs_args)
+        super().__init__(
+            filepath=filepath,
+            load_args=load_args,
+            save_args=save_args,
+            version=version,
+            credentials=credentials,
+            fs_args=fs_args,
+        )
         self._plotly_args = plotly_args
 
         _fs_args = deepcopy(fs_args) or {}

--- a/kedro-datasets/kedro_datasets/polars/csv_dataset.py
+++ b/kedro-datasets/kedro_datasets/polars/csv_dataset.py
@@ -70,6 +70,7 @@ class CSVDataset(AbstractVersionedDataset[pl.DataFrame, pl.DataFrame]):
 
     def __init__(  # noqa: PLR0913
         self,
+        *,
         filepath: str,
         load_args: Dict[str, Any] = None,
         save_args: Dict[str, Any] = None,

--- a/kedro-datasets/kedro_datasets/polars/eager_polars_dataset.py
+++ b/kedro-datasets/kedro_datasets/polars/eager_polars_dataset.py
@@ -56,6 +56,7 @@ class EagerPolarsDataset(AbstractVersionedDataset[pl.DataFrame, pl.DataFrame]):
 
     def __init__(  # noqa: PLR0913
         self,
+        *,
         filepath: str,
         file_format: str,
         load_args: Dict[str, Any] = None,

--- a/kedro-datasets/kedro_datasets/polars/lazy_polars_dataset.py
+++ b/kedro-datasets/kedro_datasets/polars/lazy_polars_dataset.py
@@ -75,6 +75,7 @@ class LazyPolarsDataset(AbstractVersionedDataset[pl.LazyFrame, PolarsFrame]):
 
     def __init__(  # noqa: PLR0913
         self,
+        *,
         filepath: str,
         file_format: str,
         load_args: Optional[Dict[str, Any]] = None,

--- a/kedro-datasets/kedro_datasets/redis/redis_dataset.py
+++ b/kedro-datasets/kedro_datasets/redis/redis_dataset.py
@@ -63,6 +63,7 @@ class PickleDataset(AbstractDataset[Any, Any]):
 
     def __init__(  # noqa: PLR0913
         self,
+        *,
         key: str,
         backend: str = "pickle",
         load_args: Dict[str, Any] = None,

--- a/kedro-datasets/kedro_datasets/snowflake/snowpark_dataset.py
+++ b/kedro-datasets/kedro_datasets/snowflake/snowpark_dataset.py
@@ -105,6 +105,7 @@ class SnowparkTableDataset(AbstractDataset):
 
     def __init__(  # noqa: PLR0913
         self,
+        *,
         table_name: str,
         schema: str = None,
         database: str = None,

--- a/kedro-datasets/kedro_datasets/spark/deltatable_dataset.py
+++ b/kedro-datasets/kedro_datasets/spark/deltatable_dataset.py
@@ -67,7 +67,7 @@ class DeltaTableDataset(AbstractDataset[None, DeltaTable]):
     # using ``ThreadRunner`` instead
     _SINGLE_PROCESS = True
 
-    def __init__(self, filepath: str, metadata: Dict[str, Any] = None) -> None:
+    def __init__(self, *, filepath: str, metadata: Dict[str, Any] = None) -> None:
         """Creates a new instance of ``DeltaTableDataset``.
 
         Args:

--- a/kedro-datasets/kedro_datasets/spark/spark_dataset.py
+++ b/kedro-datasets/kedro_datasets/spark/spark_dataset.py
@@ -264,6 +264,7 @@ class SparkDataset(AbstractVersionedDataset[DataFrame, DataFrame]):
 
     def __init__(  # noqa: PLR0913
         self,
+        *,
         filepath: str,
         file_format: str = "parquet",
         load_args: Dict[str, Any] = None,

--- a/kedro-datasets/kedro_datasets/spark/spark_hive_dataset.py
+++ b/kedro-datasets/kedro_datasets/spark/spark_hive_dataset.py
@@ -72,6 +72,7 @@ class SparkHiveDataset(AbstractDataset[DataFrame, DataFrame]):
 
     def __init__(  # noqa: PLR0913
         self,
+        *,
         database: str,
         table: str,
         write_mode: str = "errorifexists",

--- a/kedro-datasets/kedro_datasets/spark/spark_jdbc_dataset.py
+++ b/kedro-datasets/kedro_datasets/spark/spark_jdbc_dataset.py
@@ -72,6 +72,7 @@ class SparkJDBCDataset(AbstractDataset[DataFrame, DataFrame]):
 
     def __init__(  # noqa: PLR0913
         self,
+        *,
         url: str,
         table: str,
         credentials: Dict[str, Any] = None,

--- a/kedro-datasets/kedro_datasets/spark/spark_streaming_dataset.py
+++ b/kedro-datasets/kedro_datasets/spark/spark_streaming_dataset.py
@@ -44,6 +44,7 @@ class SparkStreamingDataset(AbstractDataset):
 
     def __init__(
         self,
+        *,
         filepath: str = "",
         file_format: str = "",
         save_args: Dict[str, Any] = None,

--- a/kedro-datasets/kedro_datasets/svmlight/svmlight_dataset.py
+++ b/kedro-datasets/kedro_datasets/svmlight/svmlight_dataset.py
@@ -90,6 +90,7 @@ class SVMLightDataset(AbstractVersionedDataset[_DI, _DO]):
 
     def __init__(  # noqa: PLR0913
         self,
+        *,
         filepath: str,
         load_args: Dict[str, Any] = None,
         save_args: Dict[str, Any] = None,

--- a/kedro-datasets/kedro_datasets/tensorflow/tensorflow_model_dataset.py
+++ b/kedro-datasets/kedro_datasets/tensorflow/tensorflow_model_dataset.py
@@ -64,6 +64,7 @@ class TensorFlowModelDataset(AbstractVersionedDataset[tf.keras.Model, tf.keras.M
 
     def __init__(  # noqa: PLR0913
         self,
+        *,
         filepath: str,
         load_args: Dict[str, Any] = None,
         save_args: Dict[str, Any] = None,

--- a/kedro-datasets/kedro_datasets/text/text_dataset.py
+++ b/kedro-datasets/kedro_datasets/text/text_dataset.py
@@ -46,6 +46,7 @@ class TextDataset(AbstractVersionedDataset[str, str]):
 
     def __init__(  # noqa: PLR0913
         self,
+        *,
         filepath: str,
         version: Version = None,
         credentials: Dict[str, Any] = None,

--- a/kedro-datasets/kedro_datasets/video/video_dataset.py
+++ b/kedro-datasets/kedro_datasets/video/video_dataset.py
@@ -270,6 +270,7 @@ class VideoDataset(AbstractDataset[AbstractVideo, AbstractVideo]):
 
     def __init__(  # noqa: PLR0913
         self,
+        *,
         filepath: str,
         fourcc: Optional[str] = "mp4v",
         credentials: Dict[str, Any] = None,

--- a/kedro-datasets/kedro_datasets/yaml/yaml_dataset.py
+++ b/kedro-datasets/kedro_datasets/yaml/yaml_dataset.py
@@ -49,6 +49,7 @@ class YAMLDataset(AbstractVersionedDataset[Dict, Dict]):
 
     def __init__(  # noqa: PLR0913
         self,
+        *,
         filepath: str,
         save_args: Dict[str, Any] = None,
         version: Version = None,

--- a/kedro-datasets/tests/holoviews/test_holoviews_writer.py
+++ b/kedro-datasets/tests/holoviews/test_holoviews_writer.py
@@ -27,12 +27,14 @@ def dummy_hv_object():
 
 @pytest.fixture
 def hv_writer(filepath_png, save_args, fs_args):
-    return HoloviewsWriter(filepath_png, save_args=save_args, fs_args=fs_args)
+    return HoloviewsWriter(filepath=filepath_png, save_args=save_args, fs_args=fs_args)
 
 
 @pytest.fixture
 def versioned_hv_writer(filepath_png, load_version, save_version):
-    return HoloviewsWriter(filepath_png, version=Version(load_version, save_version))
+    return HoloviewsWriter(
+        filepath=filepath_png, version=Version(load_version, save_version)
+    )
 
 
 @pytest.mark.skipif(
@@ -63,7 +65,7 @@ class TestHoloviewsWriter:
     )
     def test_open_extra_args(self, tmp_path, fs_args, mocker):
         fs_mock = mocker.patch("fsspec.filesystem")
-        writer = HoloviewsWriter(str(tmp_path), fs_args)
+        writer = HoloviewsWriter(filepath=str(tmp_path), fs_args=fs_args)
 
         fs_mock.assert_called_once_with("file", auto_mkdir=True, storage_option="value")
         assert writer._fs_open_args_save == fs_args["open_args_save"]

--- a/kedro-datasets/tests/pandas/test_csv_dataset.py
+++ b/kedro-datasets/tests/pandas/test_csv_dataset.py
@@ -413,7 +413,7 @@ class TestCSVDatasetS3:
         (any implementation using S3FileSystem). Likely to be a bug with moto (tested
         with moto==4.0.8, moto==3.0.4) -- see #67
         """
-        df = CSVDataset(mocked_csv_in_s3)
+        df = CSVDataset(filepath=mocked_csv_in_s3)
         assert df._protocol == "s3"
         # if Python >= 3.10, modify test procedure (see #67)
         if sys.version_info[1] >= 10:

--- a/kedro-datasets/tests/pandas/test_deltatable_dataset.py
+++ b/kedro-datasets/tests/pandas/test_deltatable_dataset.py
@@ -88,7 +88,7 @@ class TestDeltaTableDataset:
 
     def test_versioning(self, filepath, dummy_df):
         """Test loading different versions."""
-        deltatable_dataset_from_path = DeltaTableDataset(filepath)
+        deltatable_dataset_from_path = DeltaTableDataset(filepath=filepath)
         deltatable_dataset_from_path.save(dummy_df)
         assert deltatable_dataset_from_path.get_loaded_version() == 0
         new_df = pd.DataFrame({"col1": [0, 0], "col2": [1, 1], "col3": [2, 2]})
@@ -96,14 +96,14 @@ class TestDeltaTableDataset:
         assert deltatable_dataset_from_path.get_loaded_version() == 1
 
         deltatable_dataset_from_path0 = DeltaTableDataset(
-            filepath, load_args={"version": 0}
+            filepath=filepath, load_args={"version": 0}
         )
         version_0 = deltatable_dataset_from_path0.load()
         assert deltatable_dataset_from_path0.get_loaded_version() == 0
         assert_frame_equal(dummy_df, version_0)
 
         deltatable_dataset_from_path1 = DeltaTableDataset(
-            filepath, load_args={"version": 1}
+            filepath=filepath, load_args={"version": 1}
         )
         version_1 = deltatable_dataset_from_path1.load()
         assert deltatable_dataset_from_path1.get_loaded_version() == 1
@@ -123,7 +123,7 @@ class TestDeltaTableDataset:
 
     def test_describe(self, filepath):
         """Test the describe method."""
-        deltatable_dataset_from_path = DeltaTableDataset(filepath)
+        deltatable_dataset_from_path = DeltaTableDataset(filepath=filepath)
         desc = deltatable_dataset_from_path._describe()
         assert desc["filepath"] == filepath
         assert desc["version"] is None
@@ -167,7 +167,7 @@ class TestDeltaTableDataset:
         """Test write mode not supported."""
         pattern = "Write mode unsupported is not supported"
         with pytest.raises(DatasetError, match=pattern):
-            DeltaTableDataset(filepath, save_args={"mode": "unsupported"})
+            DeltaTableDataset(filepath=filepath, save_args={"mode": "unsupported"})
 
     def test_metadata(self, deltatable_dataset_from_path, dummy_df):
         """Test metadata property exists and return a metadata object."""

--- a/kedro-datasets/tests/pandas/test_gbq_dataset.py
+++ b/kedro-datasets/tests/pandas/test_gbq_dataset.py
@@ -86,7 +86,7 @@ class TestGBQDataset:
             "exists",
         ]
 
-        dataset = GBQTableDataset(DATASET, TABLE_NAME)
+        dataset = GBQTableDataset(dataset=DATASET, table_name=TABLE_NAME)
         assert not dataset.exists()
         assert dataset.exists()
 

--- a/kedro-datasets/tests/partitions/test_incremental_dataset.py
+++ b/kedro-datasets/tests/partitions/test_incremental_dataset.py
@@ -68,7 +68,7 @@ class TestIncrementalDatasetLocal:
     def test_load_and_confirm(self, local_csvs, partitioned_data_pandas):
         """Test the standard flow for loading, confirming and reloading
         an IncrementalDataset"""
-        pds = IncrementalDataset(str(local_csvs), DATASET)
+        pds = IncrementalDataset(path=str(local_csvs), dataset=DATASET)
         loaded = pds.load()
         assert loaded.keys() == partitioned_data_pandas.keys()
         for partition_id, data in loaded.items():
@@ -92,7 +92,7 @@ class TestIncrementalDatasetLocal:
         df = pd.DataFrame({"dummy": [1, 2, 3]})
         new_partition_key = "p05/data.csv"
         new_partition_path = local_csvs / new_partition_key
-        pds = IncrementalDataset(str(local_csvs), DATASET)
+        pds = IncrementalDataset(path=str(local_csvs), dataset=DATASET)
 
         assert not new_partition_path.exists()
         assert new_partition_key not in pds.load()
@@ -123,7 +123,7 @@ class TestIncrementalDatasetLocal:
         """Test how specifying filename_suffix affects the available
         partitions and their names"""
         pds = IncrementalDataset(
-            str(local_csvs), DATASET, filename_suffix=filename_suffix
+            path=str(local_csvs), dataset=DATASET, filename_suffix=filename_suffix
         )
         loaded = pds.load()
         assert loaded.keys() == expected_partitions
@@ -153,7 +153,9 @@ class TestIncrementalDatasetLocal:
     ):
         """Test how forcing checkpoint value affects the available partitions
         if the checkpoint file does not exist"""
-        pds = IncrementalDataset(str(local_csvs), DATASET, checkpoint=forced_checkpoint)
+        pds = IncrementalDataset(
+            path=str(local_csvs), dataset=DATASET, checkpoint=forced_checkpoint
+        )
         loaded = pds.load()
         assert loaded.keys() == expected_partitions
 
@@ -188,11 +190,13 @@ class TestIncrementalDatasetLocal:
     ):
         """Test how forcing checkpoint value affects the available partitions
         if the checkpoint file exists"""
-        IncrementalDataset(str(local_csvs), DATASET).confirm()
+        IncrementalDataset(path=str(local_csvs), dataset=DATASET).confirm()
         checkpoint = local_csvs / IncrementalDataset.DEFAULT_CHECKPOINT_FILENAME
         assert checkpoint.read_text() == "p04/data.csv"
 
-        pds = IncrementalDataset(str(local_csvs), DATASET, checkpoint=forced_checkpoint)
+        pds = IncrementalDataset(
+            path=str(local_csvs), dataset=DATASET, checkpoint=forced_checkpoint
+        )
         assert pds._checkpoint.exists()
         loaded = pds.load()
         assert loaded.keys() == expected_partitions
@@ -203,7 +207,9 @@ class TestIncrementalDatasetLocal:
     def test_force_checkpoint_no_partitions(self, forced_checkpoint, local_csvs):
         """Test that forcing the checkpoint to certain values results in no
         partitions being returned"""
-        pds = IncrementalDataset(str(local_csvs), DATASET, checkpoint=forced_checkpoint)
+        pds = IncrementalDataset(
+            path=str(local_csvs), dataset=DATASET, checkpoint=forced_checkpoint
+        )
         loaded = pds.load()
         assert not loaded
 
@@ -219,7 +225,9 @@ class TestIncrementalDatasetLocal:
         assert not checkpoint_path.exists()
 
         IncrementalDataset(
-            str(local_csvs), DATASET, checkpoint={"filepath": str(checkpoint_path)}
+            path=str(local_csvs),
+            dataset=DATASET,
+            checkpoint={"filepath": str(checkpoint_path)},
         ).confirm()
         assert checkpoint_path.is_file()
         assert checkpoint_path.read_text() == max(partitioned_data_pandas)
@@ -239,7 +247,9 @@ class TestIncrementalDatasetLocal:
         self, tmp_path, checkpoint_config, expected_checkpoint_class
     ):
         """Test configuring a different checkpoint dataset type"""
-        pds = IncrementalDataset(str(tmp_path), DATASET, checkpoint=checkpoint_config)
+        pds = IncrementalDataset(
+            path=str(tmp_path), dataset=DATASET, checkpoint=checkpoint_config
+        )
         assert isinstance(pds._checkpoint, expected_checkpoint_class)
 
     @pytest.mark.parametrize(
@@ -262,7 +272,9 @@ class TestIncrementalDatasetLocal:
     def test_version_not_allowed(self, tmp_path, checkpoint_config, error_pattern):
         """Test that invalid checkpoint configurations raise expected errors"""
         with pytest.raises(DatasetError, match=re.escape(error_pattern)):
-            IncrementalDataset(str(tmp_path), DATASET, checkpoint=checkpoint_config)
+            IncrementalDataset(
+                path=str(tmp_path), dataset=DATASET, checkpoint=checkpoint_config
+            )
 
     @pytest.mark.parametrize(
         "pds_config,fs_creds,dataset_creds,checkpoint_creds",
@@ -316,7 +328,7 @@ class TestIncrementalDatasetLocal:
     def test_credentials(self, pds_config, fs_creds, dataset_creds, checkpoint_creds):
         """Test correctness of credentials propagation into the dataset and
         checkpoint constructors"""
-        pds = IncrementalDataset(str(Path.cwd()), **pds_config)
+        pds = IncrementalDataset(path=str(Path.cwd()), **pds_config)
         assert pds._credentials == fs_creds
         assert pds._dataset_config[CREDENTIALS_KEY] == dataset_creds
         assert pds._checkpoint_config[CREDENTIALS_KEY] == checkpoint_creds
@@ -343,7 +355,9 @@ class TestIncrementalDatasetLocal:
             "force_checkpoint": "p02/data.csv",
             "comparison_func": comparison_func,
         }
-        pds = IncrementalDataset(str(local_csvs), DATASET, checkpoint=checkpoint_config)
+        pds = IncrementalDataset(
+            path=str(local_csvs), dataset=DATASET, checkpoint=checkpoint_config
+        )
         assert pds.load().keys() == expected_partitions
 
 
@@ -382,7 +396,7 @@ class TestIncrementalDatasetS3:
     def test_load_and_confirm(self, mocked_csvs_in_s3, partitioned_data_pandas):
         """Test the standard flow for loading, confirming and reloading
         a IncrementalDataset in S3"""
-        pds = IncrementalDataset(mocked_csvs_in_s3, DATASET)
+        pds = IncrementalDataset(path=mocked_csvs_in_s3, dataset=DATASET)
         assert pds._checkpoint._protocol == "s3"
         loaded = pds.load()
         assert loaded.keys() == partitioned_data_pandas.keys()
@@ -399,7 +413,7 @@ class TestIncrementalDatasetS3:
         self, mocked_csvs_in_s3, partitioned_data_pandas, mocker
     ):
         s3a_path = f"s3a://{mocked_csvs_in_s3.split('://', 1)[1]}"
-        pds = IncrementalDataset(s3a_path, DATASET)
+        pds = IncrementalDataset(path=s3a_path, dataset=DATASET)
         assert pds._protocol == "s3a"
         assert pds._checkpoint._protocol == "s3"
 
@@ -440,7 +454,7 @@ class TestIncrementalDatasetS3:
         """Test how forcing checkpoint value affects the available partitions
         in S3 if the checkpoint file does not exist"""
         pds = IncrementalDataset(
-            mocked_csvs_in_s3, DATASET, checkpoint=forced_checkpoint
+            path=mocked_csvs_in_s3, dataset=DATASET, checkpoint=forced_checkpoint
         )
         loaded = pds.load()
         assert loaded.keys() == expected_partitions
@@ -476,15 +490,15 @@ class TestIncrementalDatasetS3:
         """Test how forcing checkpoint value affects the available partitions
         in S3 if the checkpoint file exists"""
         # create checkpoint and assert that it exists
-        IncrementalDataset(mocked_csvs_in_s3, DATASET).confirm()
+        IncrementalDataset(path=mocked_csvs_in_s3, dataset=DATASET).confirm()
         checkpoint_path = (
             f"{mocked_csvs_in_s3}/{IncrementalDataset.DEFAULT_CHECKPOINT_FILENAME}"
         )
-        checkpoint_value = TextDataset(checkpoint_path).load()
+        checkpoint_value = TextDataset(filepath=checkpoint_path).load()
         assert checkpoint_value == "p04/data.csv"
 
         pds = IncrementalDataset(
-            mocked_csvs_in_s3, DATASET, checkpoint=forced_checkpoint
+            path=mocked_csvs_in_s3, dataset=DATASET, checkpoint=forced_checkpoint
         )
         assert pds._checkpoint.exists()
         loaded = pds.load()
@@ -497,7 +511,7 @@ class TestIncrementalDatasetS3:
         """Test that forcing the checkpoint to certain values results in no
         partitions returned from S3"""
         pds = IncrementalDataset(
-            mocked_csvs_in_s3, DATASET, checkpoint=forced_checkpoint
+            path=mocked_csvs_in_s3, dataset=DATASET, checkpoint=forced_checkpoint
         )
         loaded = pds.load()
         assert not loaded

--- a/kedro-datasets/tests/pillow/test_image_dataset.py
+++ b/kedro-datasets/tests/pillow/test_image_dataset.py
@@ -135,7 +135,7 @@ class TestImageDataset:
     )
     def test_get_format(self, image_filepath, expected_extension):
         """Unit test for pillow.ImageDataset._get_format() fn"""
-        dataset = ImageDataset(image_filepath)
+        dataset = ImageDataset(filepath=image_filepath)
         ext = dataset._get_format(Path(image_filepath))
         assert expected_extension == ext
 

--- a/kedro-datasets/tests/polars/test_csv_dataset.py
+++ b/kedro-datasets/tests/polars/test_csv_dataset.py
@@ -373,7 +373,7 @@ class TestCSVDatasetS3:
         (any implementation using S3FileSystem). Likely to be a bug with moto (tested
         with moto==4.0.8, moto==3.0.4) -- see #67
         """
-        df = CSVDataset(mocked_csv_in_s3)
+        df = CSVDataset(filepath=mocked_csv_in_s3)
         assert df._protocol == "s3"
         # if Python >= 3.10, modify test procedure (see #67)
         if sys.version_info[1] >= 10:

--- a/kedro-datasets/tests/polars/test_lazy_polars_dataset.py
+++ b/kedro-datasets/tests/polars/test_lazy_polars_dataset.py
@@ -123,7 +123,7 @@ class TestLazyCSVDataset:
         assert df.collect().shape == (2, 3)
 
     def test_load_s3(self, dummy_dataframe, mocked_csv_in_s3):
-        ds = LazyPolarsDataset(mocked_csv_in_s3, file_format="csv")
+        ds = LazyPolarsDataset(filepath=mocked_csv_in_s3, file_format="csv")
 
         assert ds._protocol == "s3"
 

--- a/kedro-datasets/tests/redis/test_redis_dataset.py
+++ b/kedro-datasets/tests/redis/test_redis_dataset.py
@@ -175,4 +175,4 @@ class TestPickleDataset:
             side_effect=ImportError,
         )
         with pytest.raises(ImportError, match=pattern):
-            PickleDataset("key", backend="fake.backend.does.not.exist")
+            PickleDataset(key="key", backend="fake.backend.does.not.exist")

--- a/kedro-datasets/tests/spark/test_spark_dataset.py
+++ b/kedro-datasets/tests/spark/test_spark_dataset.py
@@ -988,9 +988,9 @@ class TestSparkDatasetVersionedHdfs:
 @pytest.fixture
 def data_catalog(tmp_path):
     source_path = Path(__file__).parent / "data/test.parquet"
-    spark_in = SparkDataset(source_path.as_posix())
-    spark_out = SparkDataset((tmp_path / "spark_data").as_posix())
-    pickle_ds = PickleDataset((tmp_path / "pickle/test.pkl").as_posix())
+    spark_in = SparkDataset(filepath=source_path.as_posix())
+    spark_out = SparkDataset(filepath=(tmp_path / "spark_data").as_posix())
+    pickle_ds = PickleDataset(filepath=(tmp_path / "pickle/test.pkl").as_posix())
 
     return DataCatalog(
         {"spark_in": spark_in, "spark_out": spark_out, "pickle_ds": pickle_ds}

--- a/kedro-datasets/tests/tensorflow/test_tensorflow_model_dataset.py
+++ b/kedro-datasets/tests/tensorflow/test_tensorflow_model_dataset.py
@@ -274,7 +274,7 @@ class TestTensorFlowModelDataset:
     @pytest.mark.parametrize("fs_args", [{"storage_option": "value"}])
     def test_fs_args(self, fs_args, mocker, tensorflow_model_dataset):
         fs_mock = mocker.patch("fsspec.filesystem")
-        tensorflow_model_dataset("test.tf", fs_args=fs_args)
+        tensorflow_model_dataset(filepath="test.tf", fs_args=fs_args)
 
         fs_mock.assert_called_once_with("file", auto_mkdir=True, storage_option="value")
 

--- a/kedro-datasets/tests/video/test_video_dataset.py
+++ b/kedro-datasets/tests/video/test_video_dataset.py
@@ -68,7 +68,7 @@ def test_deprecation(module_name, class_name):
 class TestVideoDataset:
     def test_load_mp4(self, filepath_mp4, mp4_object):
         """Loading a mp4 dataset should create a FileVideo"""
-        ds = VideoDataset(filepath_mp4)
+        ds = VideoDataset(filepath=filepath_mp4)
         loaded_video = ds.load()
         assert_videos_equal(loaded_video, mp4_object)
 
@@ -195,7 +195,7 @@ class TestVideoDataset:
         """
         video_name = f"video.{suffix}"
         video = SequenceVideo(color_video._frames, 25, fourcc)
-        ds = VideoDataset(video_name, fourcc=None)
+        ds = VideoDataset(filepath=video_name, fourcc=None)
         ds.save(video)
         # We also need to verify that the correct codec was used
         # since OpenCV silently (with a warning in the log) fall backs to


### PR DESCRIPTION
## Description
This is intended to fix #247.

## Development notes
I added the keyword only marker `*` to the `__init__` methods of all datasets and ran the respective tests. If any tests made use of positional arguments, I also updated them.


## Checklist

- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [x] Added tests to cover my changes
