### PR TITLE
test(datasets): skip `tensorflow` tests on Windows

### DIFF
--- a/kedro-datasets/tests/tensorflow/test_tensorflow_model_dataset.py
+++ b/kedro-datasets/tests/tensorflow/test_tensorflow_model_dataset.py
@@ -1,4 +1,5 @@
 import importlib
+import sys
 from pathlib import PurePosixPath
 
 import numpy as np
@@ -10,6 +11,12 @@ from kedro.io.core import PROTOCOL_DELIMITER, Version
 from s3fs import S3FileSystem
 
 from kedro_datasets._io import DatasetError
+
+if sys.platform == "win32":
+    pytest.skip(
+        "TensorFlow tests have become inexplicably flaky in Windows CI",
+        allow_module_level=True,
+    )
 
 
 # In this test module, we wrap tensorflow and TensorFlowModelDataset imports into a module-scoped


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
Tests are flaky; they pass if you run them enough times.

## Development notes
<!-- What have you changed, and how has this been tested? -->
https://kedro-org.slack.com/archives/C054U0LJLAC/p1696272611234859?thread_ts=1693846107.068859&cid=C054U0LJLAC

## Checklist

- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
