### PR TITLE
ci: Pin `tables` version

### DIFF
--- a/kedro-airflow/features/steps/cli_steps.py
+++ b/kedro-airflow/features/steps/cli_steps.py
@@ -86,9 +86,9 @@ def prepare_catalog(context):
 def install_kedro(context, version):
     """Execute Kedro command and check the status."""
     if version == "latest":
-        cmd = [context.pip, "install", "-U", "kedro-datasets[CSVDataSet]"]
+        cmd = [context.pip, "install", "-U", "kedro-datasets[PANDAS]"]
     else:
-        cmd = [context.pip, "install", f"kedro-datasets[CSVDataSet]=={version}"]
+        cmd = [context.pip, "install", f"kedro-datasets[PANDAS]=={version}"]
     res = run(cmd, env=context.env)
 
     if res.returncode != OK_EXIT_CODE:

--- a/kedro-airflow/features/steps/cli_steps.py
+++ b/kedro-airflow/features/steps/cli_steps.py
@@ -86,9 +86,9 @@ def prepare_catalog(context):
 def install_kedro(context, version):
     """Execute Kedro command and check the status."""
     if version == "latest":
-        cmd = [context.pip, "install", "-U", "kedro-datasets[PANDAS]"]
+        cmd = [context.pip, "install", "-U", "kedro-datasets[CSVDataSet]"]
     else:
-        cmd = [context.pip, "install", f"kedro-datasets[PANDAS]=={version}"]
+        cmd = [context.pip, "install", f"kedro-datasets[CSVDataSet]=={version}"]
     res = run(cmd, env=context.env)
 
     if res.returncode != OK_EXIT_CODE:

--- a/kedro-datasets/setup.py
+++ b/kedro-datasets/setup.py
@@ -37,7 +37,8 @@ pandas_require = {
     "pandas.HDFDataSet": [
         PANDAS,
         "tables~=3.6.0; platform_system == 'Windows'",
-        "tables~=3.6; platform_system != 'Windows'",
+        "tables~=3.6, <3.9; platform_system != 'Windows' and python_version<'3.9'",
+        "tables~=3.6; platform_system != 'Windows' and python_version>='3.9'",
     ],
     "pandas.JSONDataSet": [PANDAS],
     "pandas.ParquetDataSet": [PANDAS, "pyarrow>=6.0"],
@@ -209,7 +210,8 @@ extras_require["test"] = [
     "SQLAlchemy~=1.2",
     "tables~=3.6.0; platform_system == 'Windows' and python_version<'3.8'",
     "tables~=3.8.0; platform_system == 'Windows' and python_version>='3.8'",  # Import issues with python 3.8 with pytables pinning to 3.8.0 fixes this https://github.com/PyTables/PyTables/issues/933#issuecomment-1555917593
-    "tables~=3.6; platform_system != 'Windows'",
+    "tables~=3.6, <3.9; platform_system != 'Windows' and python_version<'3.9'",
+    "tables~=3.6; platform_system != 'Windows' and python_version>='3.9'",
     "tensorflow-macos~=2.0; platform_system == 'Darwin' and platform_machine == 'arm64'",
     "tensorflow~=2.0; platform_system != 'Darwin' or platform_machine != 'arm64'",
     "triad>=0.6.7, <1.0",


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
Resolve #369 

## Development notes
<!-- What have you changed, and how has this been tested? -->
Same as on kedro https://github.com/kedro-org/kedro/pull/3126
New release of `pytables` which drops support for python 3.8 is causing this. 
* Pin `tables` version on `kedro-datasets` for python < 3.8
* ~~`kedro-airflow` e2e test uses `pandas-iris` starter but was downloading requirements for `kedro-datasets[PANDAS]` which includes the HDFdataset which relies on `tables` but `pandas-iris` just has a `CSVDataset` so updated this.~~ 
Some weird kubernetes related failure on `kedro-airflow` will fix as a follow up
## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
