### PR TITLE
fix(datasets): Fix secret scan entropy error

### DIFF
--- a/kedro-datasets/kedro_datasets/pickle/pickle_dataset.py
+++ b/kedro-datasets/kedro_datasets/pickle/pickle_dataset.py
@@ -111,7 +111,7 @@ class PickleDataset(AbstractVersionedDataset[Any, Any]):
                 compress_pickle.load:
                 https://lucianopaz.github.io/compress_pickle/html/api/compress_pickle.html#compress_pickle.compress_pickle.load
                 cloudpickle.load:
-                https://github.com/cloudpipe/cloudpickle/blob/0f330b6afe55313fc1efc090a7d350f5ad5c9317/tests/cloudpickle_test.py
+                https://github.com/cloudpipe/cloudpickle/blob/master/tests/cloudpickle_test.py
                 All defaults are preserved.
             save_args: Pickle options for saving pickle files.
                 You can pass in arguments that the backend dump function specified accepts, e.g:
@@ -121,7 +121,7 @@ class PickleDataset(AbstractVersionedDataset[Any, Any]):
                 compress_pickle.dump:
                 https://lucianopaz.github.io/compress_pickle/html/api/compress_pickle.html#compress_pickle.compress_pickle.dump
                 cloudpickle.dump:
-                https://github.com/cloudpipe/cloudpickle/blob/0f330b6afe55313fc1efc090a7d350f5ad5c9317/tests/cloudpickle_test.py
+                https://github.com/cloudpipe/cloudpickle/blob/master/tests/cloudpickle_test.py
                 All defaults are preserved.
             version: If specified, should be an instance of
                 ``kedro.io.core.Version``. If its ``load`` attribute is

--- a/kedro-datasets/kedro_datasets/redis/redis_dataset.py
+++ b/kedro-datasets/kedro_datasets/redis/redis_dataset.py
@@ -96,7 +96,7 @@ class PickleDataset(AbstractDataset[Any, Any]):
                 compress_pickle.loads:
                 https://lucianopaz.github.io/compress_pickle/html/api/compress_pickle.html#compress_pickle.compress_pickle.loads
                 cloudpickle.loads:
-                https://github.com/cloudpipe/cloudpickle/blob/0f330b6afe55313fc1efc090a7d350f5ad5c9317/tests/cloudpickle_test.py
+                https://github.com/cloudpipe/cloudpickle/blob/master/tests/cloudpickle_test.py
                 All defaults are preserved.
             save_args: Pickle options for saving pickle files.
                 You can pass in arguments that the backend dump function specified accepts, e.g:
@@ -105,7 +105,7 @@ class PickleDataset(AbstractDataset[Any, Any]):
                 compress_pickle.dumps:
                 https://lucianopaz.github.io/compress_pickle/html/api/compress_pickle.html#compress_pickle.compress_pickle.dumps
                 cloudpickle.dumps:
-                https://github.com/cloudpipe/cloudpickle/blob/0f330b6afe55313fc1efc090a7d350f5ad5c9317/tests/cloudpickle_test.py
+                https://github.com/cloudpipe/cloudpickle/blob/master/tests/cloudpickle_test.py
                 All defaults are preserved.
             credentials: Credentials required to get access to the redis server.
                 E.g. `{"password": None}`.


### PR DESCRIPTION
## Description
https://github.com/kedro-org/kedro-plugins/pull/361 introduced a link to github which causes the secret scan to fail. 

## Development notes
Fixed it by updating the link to point to the `master` branch of the linked repo. 

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
