### PR TITLE
[FIX] Mask all arguments if last argument was a parameter

### DIFF
--- a/kedro-telemetry/kedro_telemetry/masking.py
+++ b/kedro-telemetry/kedro_telemetry/masking.py
@@ -78,14 +78,27 @@ def _mask_kedro_cli(cli_struct: Dict[str, Any], command_args: List[str]) -> List
     output = []
     vocabulary = _get_vocabulary(cli_struct)
     for arg in command_args:
+        # if it starts with - -> flag
         if arg.startswith("-"):
-            for arg_part in arg.split("="):
-                if arg_part in vocabulary:
-                    output.append(arg_part)
-                elif arg_part:
+            # if there is an equal sign we mask after the sign
+            if "=" in arg:
+                list_arg = arg.split("=")
+                if list_arg[0] in vocabulary:
+                    output.append(list_arg[0])
+                else:
+                    output.append(MASK)
+                # we mask what comes after equal sign
+                output.append(MASK)
+            else:
+                if arg in vocabulary:
+                    output.append(arg)
+                else:
                     output.append(MASK)
         elif arg in vocabulary:
-            output.append(arg)
+            if len(output) > 1 and output[-1].startswith("-"):
+                output.append(MASK)
+            else:
+                output.append(arg)
         elif arg:
             output.append(MASK)
     return output

--- a/kedro-telemetry/tests/test_masking.py
+++ b/kedro-telemetry/tests/test_masking.py
@@ -235,6 +235,11 @@ class TestCLIMasking:
                 ["none", "of", "this", "should", "be", "seen", "except", "command_a"],
                 [MASK, MASK, MASK, MASK, MASK, MASK, MASK, "command_a"],
             ),
+            (
+                {"kedro": {"command_a": {"--param": "airflow"}}},
+                ["command_a", "--param", "airflow"],
+                ["command_a", "--param", MASK],
+            ),
         ],
     )
     def test_mask_kedro_cli(


### PR DESCRIPTION
## Description
This is a proposal PR to fix issue #371. 

## Development notes
A temporary solution is to mask any arguments following a parameter indifferently of if this argument is present in the vocabulary.

However this still relies on Kedro CLI for the masking I'll look further into this to propose a solution without Kedro CLI. 

## Checklist

- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
