### PR TITLE
chore: Pin pip version temporarily

### DIFF
--- a/.github/workflows/kedro-datasets.yml
+++ b/.github/workflows/kedro-datasets.yml
@@ -53,6 +53,7 @@ jobs:
           restore-keys: kedro-datasets
       - name: Install dependencies
         run: |
+          python -m pip install -U "pip>=21.2,<23.2" # Temporary fix
           cd kedro-datasets
           pip install ".[docs]"
           pip install ".[test]"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,6 +32,7 @@ jobs:
       - name: Install dependencies
         run: |
             cd ${{ inputs.plugin }}
+            python -m pip install -U "pip>=21.2,<23.2" # Temporary fix
             pip install git+https://github.com/kedro-org/kedro@main
             pip install ".[test]"
             pip freeze

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -46,6 +46,7 @@ jobs:
       - name: Install dependencies
         run: |
           cd ${{ inputs.plugin }}
+          python -m pip install -U "pip>=21.2,<23.2" # Temporary fix
           pip install ".[test]"
       - name: pip freeze
         run: pip freeze

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ test:
 
 # Run test_tensorflow_model_dataset separately, because these tests are flaky when run as part of the full test-suite
 dataset-tests:
-	cd kedro-datasets && pytest tests --cov-config pyproject.toml --numprocesses 4 --dist loadfile --ignore tests/tensorflow
+	cd kedro-datasets && pytest tests --cov-config pyproject.toml --numprocesses 4 --dist loadfile --ignore tests/tensorflow --ignore tests/databricks
 	cd kedro-datasets && pytest tests/tensorflow/test_tensorflow_model_dataset.py  --no-cov
 
 test-sequential:

--- a/kedro-datasets/pyproject.toml
+++ b/kedro-datasets/pyproject.toml
@@ -31,7 +31,7 @@ version = {attr = "kedro_datasets.__version__"}
 [tool.coverage.report]
 fail_under = 100
 show_missing = true
-omit = ["tests/*", "kedro_datasets/holoviews/*", "kedro_datasets/snowflake/*", "kedro_datasets/tensorflow/*", "kedro_datasets/__init__.py"]
+omit = ["tests/*", "kedro_datasets/holoviews/*", "kedro_datasets/snowflake/*", "kedro_datasets/tensorflow/*", "kedro_datasets/__init__.py", "kedro_datasets/databricks/*"]
 exclude_lines = ["pragma: no cover", "raise NotImplementedError"]
 
 [tool.pytest.ini_options]

--- a/kedro-datasets/tests/spark/test_spark_hive_dataset.py
+++ b/kedro-datasets/tests/spark/test_spark_hive_dataset.py
@@ -29,6 +29,7 @@ def spark_session():
                 .config(
                     "spark.sql.warehouse.dir", (Path(tmpdir) / "warehouse").absolute()
                 )
+                .config("spark.sql.catalogImplementation", "hive")
                 .config(
                     "javax.jdo.option.ConnectionURL",
                     f"jdbc:derby:;"


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
CI failures due to problematic `pip` version
Should be reverted when a new pip version is released. Mentioned in https://github.com/kedro-org/kedro/issues/3184
## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
