### PR TITLE
fix: TF model load failure when model is saved as a TensorFlow Saved Model format

### DIFF
--- a/kedro-datasets/RELEASE.md
+++ b/kedro-datasets/RELEASE.md
@@ -1,7 +1,10 @@
 # Upcoming Release
 ## Major features and improvements
 ## Bug fixes and other changes
+* Fixed bug with loading models saved with `TensorFlowModelDataset`.
 ## Community contributions
+Many thanks to the following Kedroids for contributing PRs to this release:
+* [Edouard59](https://github.com/Edouard59)
 
 # Release 1.8.0
 ## Major features and improvements

--- a/kedro-datasets/kedro_datasets/tensorflow/tensorflow_model_dataset.py
+++ b/kedro-datasets/kedro_datasets/tensorflow/tensorflow_model_dataset.py
@@ -136,7 +136,7 @@ class TensorFlowModelDataset(AbstractVersionedDataset[tf.keras.Model, tf.keras.M
                 path = str(PurePath(path) / TEMPORARY_H5_FILE)  # noqa: PLW2901
                 self._fs.copy(load_path, path)
             else:
-                self._fs.get(load_path, path, recursive=True)
+                self._fs.get(load_path+"/", path, recursive=True)
 
             # Pass the local temporary directory/file path to keras.load_model
             device_name = self._load_args.pop("tf_device", None)

--- a/kedro-datasets/kedro_datasets/tensorflow/tensorflow_model_dataset.py
+++ b/kedro-datasets/kedro_datasets/tensorflow/tensorflow_model_dataset.py
@@ -136,7 +136,7 @@ class TensorFlowModelDataset(AbstractVersionedDataset[tf.keras.Model, tf.keras.M
                 path = str(PurePath(path) / TEMPORARY_H5_FILE)  # noqa: PLW2901
                 self._fs.copy(load_path, path)
             else:
-                self._fs.get(load_path+"/", path, recursive=True)
+                self._fs.get(load_path + "/", path, recursive=True)
 
             # Pass the local temporary directory/file path to keras.load_model
             device_name = self._load_args.pop("tf_device", None)


### PR DESCRIPTION
## Description
when a model is saved in the TensorFlow SavedModel format ("tf" default option in tf.save_model when using TF 2.x) via the catalog.xml file, the subsequent loading of that model for further use in a subsequent node fails. The issue is linked to the fact that the model files don't get copied into the temporary folder, presumably because the _fs.get function "thinks" that the provided path is a file and not a folder.

## Development notes
Adding an terminating "/" to the path fixes the issue. This has been tested with the following catalog.yml entry to validate that the fix works:

"model_trained_experiment0":
  type: tensorflow.TensorFlowModelDataset
  filepath: data/06_models/experiment0/model/

This together with a pipeline made of a node outputting "model_trained_experiment0" and a subsequent node inputting "model_trained_experiment0"

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
