### PR TITLE
chore: Drop support for Python 3.7 on kedro-datasets

### DIFF
--- a/kedro-datasets/README.md
+++ b/kedro-datasets/README.md
@@ -1,7 +1,7 @@
 # Kedro-Datasets
 
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![Python Version](https://img.shields.io/badge/python-3.7%20%7C%203.8%20%7C%203.9%20%7C%203.10-blue.svg)](https://pypi.org/project/kedro-datasets/)
+[![Python Version](https://img.shields.io/badge/python-3.8%20%7C%203.9%20%7C%203.10%20%7C%203.11-blue.svg)](https://pypi.org/project/kedro-datasets/)
 [![PyPI Version](https://badge.fury.io/py/kedro-datasets.svg)](https://pypi.org/project/kedro-datasets/)
 [![Code Style: Black](https://img.shields.io/badge/code%20style-black-black.svg)](https://github.com/ambv/black)
 

--- a/kedro-datasets/RELEASE.md
+++ b/kedro-datasets/RELEASE.md
@@ -1,4 +1,6 @@
 # Upcoming Release
+* Removed support for Python 3.7
+
 ## Major features and improvements
 ## Bug fixes and other changes
 ## Community contributions

--- a/kedro-datasets/pyproject.toml
+++ b/kedro-datasets/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
     {name = "Kedro"}
 ]
 description = "Kedro-Datasets is where you can find all of Kedro's data connectors."
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 license = {text = "Apache Software License (Apache 2.0)"}
 dependencies = [
     "kedro>=0.16",

--- a/kedro-datasets/setup.py
+++ b/kedro-datasets/setup.py
@@ -155,7 +155,7 @@ extras_require["docs"] = [
     "Jinja2<3.1.0",
 ]
 extras_require["test"] = [
-    "adlfs~=2023.1; python_version >= '3.8'",
+    "adlfs~=2023.1",
     "bandit>=1.6.2, <2.0",
     "behave==1.2.6",
     "biopython~=1.73",
@@ -170,7 +170,7 @@ extras_require["test"] = [
     "deltalake>=0.10.0",
     "dill~=0.3.1",
     "filelock>=3.4.0, <4.0",
-    "gcsfs>=2023.1, <2023.3; python_version >= '3.8'",
+    "gcsfs>=2023.1, <2023.3",
     "geopandas>=0.6.0, <1.0",
     "hdfs>=2.5.8, <3.0",
     "holoviews>=1.13.0",
@@ -216,8 +216,7 @@ extras_require["test"] = [
     "scipy>=1.7.3",
     "packaging",
     "SQLAlchemy~=1.2",
-    "tables~=3.6.0; platform_system == 'Windows' and python_version<'3.8'",
-    "tables~=3.8.0; platform_system == 'Windows' and python_version>='3.8'",  # Import issues with python 3.8 with pytables pinning to 3.8.0 fixes this https://github.com/PyTables/PyTables/issues/933#issuecomment-1555917593
+    "tables~=3.8.0; platform_system == 'Windows'",  # Import issues with python 3.8 with pytables pinning to 3.8.0 fixes this https://github.com/PyTables/PyTables/issues/933#issuecomment-1555917593
     "tables~=3.6, <3.9; platform_system != 'Windows' and python_version<'3.9'",
     "tables~=3.6; platform_system != 'Windows' and python_version>='3.9'",
     "tensorflow-macos~=2.0; platform_system == 'Darwin' and platform_machine == 'arm64'",

--- a/kedro-datasets/setup.py
+++ b/kedro-datasets/setup.py
@@ -155,7 +155,6 @@ extras_require["docs"] = [
     "Jinja2<3.1.0",
 ]
 extras_require["test"] = [
-    "adlfs>=2021.7.1, <=2022.2; python_version == '3.7'",
     "adlfs~=2023.1; python_version >= '3.8'",
     "bandit>=1.6.2, <2.0",
     "behave==1.2.6",
@@ -171,7 +170,6 @@ extras_require["test"] = [
     "deltalake>=0.10.0",
     "dill~=0.3.1",
     "filelock>=3.4.0, <4.0",
-    "gcsfs>=2021.4, <=2023.1; python_version == '3.7'",
     "gcsfs>=2023.1, <2023.3; python_version >= '3.8'",
     "geopandas>=0.6.0, <1.0",
     "hdfs>=2.5.8, <3.0",


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->

Drops support for Python 3.7 on `kedro-datasets`. Part of https://github.com/kedro-org/kedro/issues/2158.

## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [x] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
