### PR TITLE
fix(telemetry): remove double execution by moving to after catalog created hook

### DIFF
--- a/kedro-telemetry/RELEASE.md
+++ b/kedro-telemetry/RELEASE.md
@@ -1,4 +1,5 @@
 # Upcoming release
+* Fixed double execution of `after_catalog_created` hook by moving the logic of determining and sending of project statistics from `after_context_created` to the `after_catalog_created` hook.
 
 # Release 0.3.0
 * Added support for Python 3.11

--- a/kedro-telemetry/kedro_telemetry/plugin.py
+++ b/kedro-telemetry/kedro_telemetry/plugin.py
@@ -113,8 +113,11 @@ class KedroTelemetryProjectHooks:
     @hook_impl
     def after_context_created(self, context):
         """Hook implementation to send project statistics data to Heap"""
-        consent = _check_for_telemetry_consent(context.project_path)
-        if not consent:
+        self.consent = _check_for_telemetry_consent(context.project_path)
+
+    @hook_impl
+    def after_catalog_created(self, catalog):
+        if not self.consent:
             logger.debug(
                 "Kedro-Telemetry is installed, but you have opted out of "
                 "sharing usage analytics so none will be collected.",
@@ -123,7 +126,6 @@ class KedroTelemetryProjectHooks:
 
         logger.debug("You have opted into product usage analytics.")
 
-        catalog = context.catalog
         default_pipeline = pipelines.get("__default__")  # __default__
         hashed_username = _get_hashed_username()
 

--- a/kedro-telemetry/tests/test_plugin.py
+++ b/kedro-telemetry/tests/test_plugin.py
@@ -334,11 +334,11 @@ class TestKedroTelemetryProjectHooks:
     def test_after_context_created_without_kedro_run(
         self,
         mocker,
-        fake_context,
         fake_catalog,
         fake_default_pipeline,
         fake_sub_pipeline,
     ):
+        fake_context = mocker.Mock()
         mocker.patch.dict(
             pipelines, {"__default__": fake_default_pipeline, "sub": fake_sub_pipeline}
         )
@@ -385,12 +385,12 @@ class TestKedroTelemetryProjectHooks:
     def test_after_context_created_with_kedro_run(  # noqa: PLR0913
         self,
         mocker,
-        fake_context,
         fake_catalog,
         fake_metadata,
         fake_default_pipeline,
         fake_sub_pipeline,
     ):
+        fake_context = mocker.Mock()
         mocker.patch.dict(
             pipelines, {"__default__": fake_default_pipeline, "sub": fake_sub_pipeline}
         )
@@ -438,7 +438,8 @@ class TestKedroTelemetryProjectHooks:
         # CLI hook makes the first 2 calls, the 3rd one is the Project hook
         assert mocked_heap_call.call_args_list[2] == expected_call
 
-    def test_after_context_created_no_consent_given(self, mocker, fake_context):
+    def test_after_context_created_no_consent_given(self, mocker):
+        fake_context = mocker.Mock()
         mocker.patch(
             "kedro_telemetry.plugin._check_for_telemetry_consent", return_value=False
         )

--- a/kedro-telemetry/tests/test_plugin.py
+++ b/kedro-telemetry/tests/test_plugin.py
@@ -40,13 +40,16 @@ def fake_metadata(tmp_path):
 @fixture
 def fake_context(mocker):
     mock_context = mocker.Mock()
+    return mock_context
+
+
+@fixture
+def fake_catalog():
     dummy_1 = MemoryDataset()
     dummy_2 = MemoryDataset()
     dummy_3 = MemoryDataset()
-    mock_context.catalog = DataCatalog(
-        {"dummy_1": dummy_1, "dummy_2": dummy_2, "dummy_3": dummy_3}
-    )
-    return mock_context
+    catalog = DataCatalog({"dummy_1": dummy_1, "dummy_2": dummy_2, "dummy_3": dummy_3})
+    return catalog
 
 
 def identity(arg):
@@ -332,6 +335,7 @@ class TestKedroTelemetryProjectHooks:
         self,
         mocker,
         fake_context,
+        fake_catalog,
         fake_default_pipeline,
         fake_sub_pipeline,
     ):
@@ -352,6 +356,7 @@ class TestKedroTelemetryProjectHooks:
         # Without CLI invoked - i.e. `session.run` in Jupyter/IPython
         telemetry_hook = KedroTelemetryProjectHooks()
         telemetry_hook.after_context_created(fake_context)
+        telemetry_hook.after_catalog_created(fake_catalog)
 
         project_properties = {
             "username": "hashed_username",
@@ -381,6 +386,7 @@ class TestKedroTelemetryProjectHooks:
         self,
         mocker,
         fake_context,
+        fake_catalog,
         fake_metadata,
         fake_default_pipeline,
         fake_sub_pipeline,
@@ -406,6 +412,7 @@ class TestKedroTelemetryProjectHooks:
         # Follow by project run
         telemetry_hook = KedroTelemetryProjectHooks()
         telemetry_hook.after_context_created(fake_context)
+        telemetry_hook.after_catalog_created(fake_catalog)
 
         project_properties = {
             "username": "hashed_username",

--- a/kedro-telemetry/tests/test_plugin.py
+++ b/kedro-telemetry/tests/test_plugin.py
@@ -38,12 +38,6 @@ def fake_metadata(tmp_path):
 
 
 @fixture
-def fake_context(mocker):
-    mock_context = mocker.Mock()
-    return mock_context
-
-
-@fixture
 def fake_catalog():
     dummy_1 = MemoryDataset()
     dummy_2 = MemoryDataset()


### PR DESCRIPTION
## Description
This PR fixes #382 by moving the sending of the heap to the `after_catalog_created` hook instead of the `after_context_created` hook. This prevents the creation of the catalog twice and thus double execution of `after_catalog_created` hooks as part of any downstream project.

## Checklist

- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Added a description of this change in the relevant `RELEASE.md` file
- [x] Added tests to cover my changes
