### PR TITLE
chore(datasets): replace "Pyspark" with "PySpark"

### DIFF
--- a/kedro-datasets/kedro_datasets/spark/README.md
+++ b/kedro-datasets/kedro_datasets/spark/README.md
@@ -4,8 +4,9 @@
 See [Spark Structured Streaming](https://spark.apache.org/docs/latest/structured-streaming-programming-guide.html) for details.
 
 To work with multiple streaming nodes, 2 hooks are required for:
-    - Integrating Pyspark, see [Build a Kedro pipeline with PySpark](https://docs.kedro.org/en/stable/integrations/pyspark_integration.html) for details
-    - Running streaming query without termination unless exception
+
+- Integrating PySpark, see [Build a Kedro pipeline with PySpark](https://docs.kedro.org/en/stable/integrations/pyspark_integration.html) for details
+- Running streaming query without termination unless exception
 
 #### Supported file formats
 


### PR DESCRIPTION
Also, fix list formatting

## Description
<!-- Why was this PR created? -->

As Jo mentioned, there are probably Pyspark instances in other repos than core

## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
