### PR TITLE
refactor: Remove `DataSet` aliases and mentions

### DIFF
--- a/kedro-airflow/README.md
+++ b/kedro-airflow/README.md
@@ -153,3 +153,14 @@ You can set the operator to use by providing a custom template.
 See ["What if I want to use a different Jinja2 template?"](#what-if-i-want-to-use-a-different-jinja2-template) for instructions on using custom templates.
 The [rich offering](https://airflow.apache.org/docs/apache-airflow-providers/operators-and-hooks-ref/index.html) of operators means that the `kedro-airflow` plugin is providing templates for specific operators.
 The default template provided by `kedro-airflow` uses the `BaseOperator`.
+
+## Can I contribute?
+
+Yes! Want to help build Kedro-Airflow? Check out our guide to [contributing](https://github.com/kedro-org/kedro-plugins/blob/main/kedro-airflow/CONTRIBUTING.md).
+
+## What licence do you use?
+
+Kedro-Airflow is licensed under the [Apache 2.0](https://github.com/kedro-org/kedro-plugins/blob/main/LICENSE.md) License.
+
+## Python version support policy
+* The [Kedro-Airflow](https://github.com/kedro-org/kedro-plugins/tree/main/kedro-airflow) supports all Python versions that are actively maintained by the CPython core team. When a [Python version reaches end of life](https://devguide.python.org/versions/#versions), support for that version is dropped from `kedro-airflow`. This is not considered a breaking change.

--- a/kedro-datasets/README.md
+++ b/kedro-datasets/README.md
@@ -30,6 +30,15 @@ These data connectors are supported with the APIs of `pandas`, `spark`, `network
 Here is a full list of [supported data connectors and APIs](https://docs.kedro.org/en/stable/kedro_datasets.html).
 
 ## How can I create my own `AbstractDataSet` implementation?
-
-
 Take a look at our [instructions on how to create your own `AbstractDataSet` implementation](https://kedro.readthedocs.io/en/stable/extend_kedro/custom_datasets.html).
+
+## Can I contribute?
+
+Yes! Want to help build Kedro-Datasets? Check out our guide to [contributing](https://github.com/kedro-org/kedro-plugins/blob/main/kedro-datasets/CONTRIBUTING.md).
+
+## What licence do you use?
+
+Kedro-Datasets is licensed under the [Apache 2.0](https://github.com/kedro-org/kedro-plugins/blob/main/LICENSE.md) License.
+
+## Python version support policy
+* The [Kedro-Datasets](https://github.com/kedro-org/kedro-plugins/tree/main/kedro-datasets) package follows the [NEP 29](https://numpy.org/neps/nep-0029-deprecation_policy.html) Python version support policy.

--- a/kedro-datasets/README.md
+++ b/kedro-datasets/README.md
@@ -17,9 +17,9 @@ pip install kedro-datasets
 
 # Datasets
 
-Welcome to `kedro_datasets`, the home of Kedro's data connectors. Here you will find `AbstractDataSet` implementations created by QuantumBlack and external contributors.
+Welcome to `kedro_datasets`, the home of Kedro's data connectors. Here you will find `AbstractDataset` implementations created by QuantumBlack and external contributors.
 
-## What `AbstractDataSet` implementations are supported?
+## What `AbstractDataset` implementations are supported?
 
 We support a range of data connectors, including CSV, Excel, Parquet, Feather, HDF5, JSON, Pickle, SQL Tables, SQL Queries, Spark DataFrames and more. We even allow support for working with images.
 
@@ -29,8 +29,8 @@ These data connectors are supported with the APIs of `pandas`, `spark`, `network
 
 Here is a full list of [supported data connectors and APIs](https://docs.kedro.org/en/stable/kedro_datasets.html).
 
-## How can I create my own `AbstractDataSet` implementation?
-Take a look at our [instructions on how to create your own `AbstractDataSet` implementation](https://kedro.readthedocs.io/en/stable/extend_kedro/custom_datasets.html).
+## How can I create my own `AbstractDataset` implementation?
+Take a look at our [instructions on how to create your own `AbstractDataset` implementation](https://kedro.readthedocs.io/en/stable/extend_kedro/custom_datasets.html).
 
 ## Can I contribute?
 

--- a/kedro-datasets/docs/source/conf.py
+++ b/kedro-datasets/docs/source/conf.py
@@ -97,9 +97,7 @@ intersphinx_mapping = {
 
 type_targets = {
     "py:class": (
-        "kedro.io.core.AbstractDataSet",
         "kedro.io.core.AbstractDataset",
-        "kedro.io.AbstractDataSet",
         "kedro.io.AbstractDataset",
         "kedro.io.core.Version",
         "requests.auth.AuthBase",
@@ -114,7 +112,6 @@ type_targets = {
         "typing.Tuple",
     ),
     "py:exc": (
-        "DataSetError",
         "DatasetError",
     ),
 }

--- a/kedro-datasets/docs/source/conf.py
+++ b/kedro-datasets/docs/source/conf.py
@@ -98,7 +98,9 @@ intersphinx_mapping = {
 type_targets = {
     "py:class": (
         "kedro.io.core.AbstractDataSet",
+        "kedro.io.core.AbstractDataset",
         "kedro.io.AbstractDataSet",
+        "kedro.io.AbstractDataset",
         "kedro.io.core.Version",
         "requests.auth.AuthBase",
         "google.oauth2.credentials.Credentials",
@@ -251,16 +253,16 @@ def autolink_replacements(what: str) -> list[tuple[str, str, str]]:
     is a reStructuredText link to their documentation.
 
     For example, if the docstring reads:
-        This LambdaDataSet loads and saves ...
+        This LambdaDataset loads and saves ...
 
-    Then the word ``LambdaDataSet``, will be replaced by
-    :class:`~kedro.io.LambdaDataSet`
+    Then the word ``LambdaDataset``, will be replaced by
+    :class:`~kedro.io.LambdaDataset`
 
     Works for plural as well, e.g:
-        These ``LambdaDataSet``s load and save
+        These ``LambdaDataset``s load and save
 
     Will convert to:
-        These :class:`kedro.io.LambdaDataSet` load and save
+        These :class:`kedro.io.LambdaDataset` load and save
 
     Args:
         what: The objects to create replacement tuples for. Possible values

--- a/kedro-datasets/docs/source/kedro_datasets.rst
+++ b/kedro-datasets/docs/source/kedro_datasets.rst
@@ -11,97 +11,52 @@ kedro_datasets
    :toctree:
    :template: autosummary/class.rst
 
-   kedro_datasets.api.APIDataSet
    kedro_datasets.api.APIDataset
-   kedro_datasets.biosequence.BioSequenceDataSet
    kedro_datasets.biosequence.BioSequenceDataset
-   kedro_datasets.dask.ParquetDataSet
    kedro_datasets.dask.ParquetDataset
-   kedro_datasets.databricks.ManagedTableDataSet
    kedro_datasets.databricks.ManagedTableDataset
-   kedro_datasets.email.EmailMessageDataSet
    kedro_datasets.email.EmailMessageDataset
-   kedro_datasets.geopandas.GeoJSONDataSet
    kedro_datasets.geopandas.GeoJSONDataset
    kedro_datasets.holoviews.HoloviewsWriter
    kedro_datasets.huggingface.HFDataset
    kedro_datasets.huggingface.HFTransformerPipelineDataset
-   kedro_datasets.json.JSONDataSet
    kedro_datasets.json.JSONDataset
    kedro_datasets.matplotlib.MatplotlibWriter
-   kedro_datasets.networkx.GMLDataSet
    kedro_datasets.networkx.GMLDataset
-   kedro_datasets.networkx.GraphMLDataSet
    kedro_datasets.networkx.GraphMLDataset
-   kedro_datasets.networkx.JSONDataSet
    kedro_datasets.networkx.JSONDataset
-   kedro_datasets.pandas.CSVDataSet
    kedro_datasets.pandas.CSVDataset
-   kedro_datasets.pandas.DeltaTableDataSet
    kedro_datasets.pandas.DeltaTableDataset
-   kedro_datasets.pandas.ExcelDataSet
    kedro_datasets.pandas.ExcelDataset
-   kedro_datasets.pandas.FeatherDataSet
    kedro_datasets.pandas.FeatherDataset
-   kedro_datasets.pandas.GBQQueryDataSet
    kedro_datasets.pandas.GBQQueryDataset
-   kedro_datasets.pandas.GBQTableDataSet
    kedro_datasets.pandas.GBQTableDataset
-   kedro_datasets.pandas.GenericDataSet
    kedro_datasets.pandas.GenericDataset
-   kedro_datasets.pandas.HDFDataSet
    kedro_datasets.pandas.HDFDataset
-   kedro_datasets.pandas.JSONDataSet
    kedro_datasets.pandas.JSONDataset
-   kedro_datasets.pandas.ParquetDataSet
    kedro_datasets.pandas.ParquetDataset
-   kedro_datasets.pandas.SQLQueryDataSet
    kedro_datasets.pandas.SQLQueryDataset
-   kedro_datasets.pandas.SQLTableDataSet
    kedro_datasets.pandas.SQLTableDataset
-   kedro_datasets.pandas.XMLDataSet
    kedro_datasets.pandas.XMLDataset
-   kedro_datasets.partitions.IncrementalDataset
    kedro_datasets.partitions.PartitionedDataset
-   kedro_datasets.pickle.PickleDataSet
    kedro_datasets.pickle.PickleDataset
-   kedro_datasets.pillow.ImageDataSet
    kedro_datasets.pillow.ImageDataset
-   kedro_datasets.plotly.JSONDataSet
    kedro_datasets.plotly.JSONDataset
-   kedro_datasets.plotly.PlotlyDataSet
    kedro_datasets.plotly.PlotlyDataset
-   kedro_datasets.polars.CSVDataSet
    kedro_datasets.polars.CSVDataset
-   kedro_datasets.polars.GenericDataSet
-   kedro_datasets.polars.GenericDataset
    kedro_datasets.polars.EagerPolarsDataset
    kedro_datasets.polars.LazyPolarsDataset
-   kedro_datasets.redis.PickleDataSet
    kedro_datasets.redis.PickleDataset
-   kedro_datasets.snowflake.SnowparkTableDataSet
    kedro_datasets.snowflake.SnowparkTableDataset
-   kedro_datasets.spark.DeltaTableDataSet
    kedro_datasets.spark.DeltaTableDataset
-   kedro_datasets.spark.SparkDataSet
    kedro_datasets.spark.SparkDataset
-   kedro_datasets.spark.SparkHiveDataSet
    kedro_datasets.spark.SparkHiveDataset
-   kedro_datasets.spark.SparkJDBCDataSet
    kedro_datasets.spark.SparkJDBCDataset
-   kedro_datasets.spark.SparkStreamingDataSet
    kedro_datasets.spark.SparkStreamingDataset
-   kedro_datasets.svmlight.SVMLightDataSet
    kedro_datasets.svmlight.SVMLightDataset
-   kedro_datasets.tensorflow.TensorFlowModelDataSet
    kedro_datasets.tensorflow.TensorFlowModelDataset
-   kedro_datasets.text.TextDataSet
    kedro_datasets.text.TextDataset
-   kedro_datasets.tracking.JSONDataSet
    kedro_datasets.tracking.JSONDataset
-   kedro_datasets.tracking.MetricsDataSet
    kedro_datasets.tracking.MetricsDataset
-   kedro_datasets.video.VideoDataSet
    kedro_datasets.video.VideoDataset
-   kedro_datasets.yaml.YAMLDataSet
    kedro_datasets.yaml.YAMLDataset

--- a/kedro-datasets/kedro_datasets/README.md
+++ b/kedro-datasets/kedro_datasets/README.md
@@ -1,8 +1,8 @@
 # Datasets
 
-Welcome to `kedro_datasets.datasets`, the home of Kedro's data connectors. Here you will find `AbstractDataSet` implementations created by the core Kedro team and external contributors.
+Welcome to `kedro_datasets.datasets`, the home of Kedro's data connectors. Here you will find `AbstractDataset` implementations created by the core Kedro team and external contributors.
 
-## What `AbstractDataSet` implementations are supported?
+## What `AbstractDataset` implementations are supported?
 
 We support a range of data descriptions, including CSV, Excel, Parquet, Feather, HDF5, JSON, Pickle, SQL Tables, SQL Queries, Spark DataFrames and more.
 
@@ -12,7 +12,7 @@ These data descriptions are supported with the APIs of `pandas`, `spark`, `netwo
 
 Here is a full list of [supported data descriptions and APIs](https://docs.kedro.org/en/stable/kedro_datasets.html).
 
-## How can I create my own `AbstractDataSet` implementation?
+## How can I create my own `AbstractDataset` implementation?
 
 
-Take a look at our [instructions on how to create your own `AbstractDataSet` implementation](https://kedro.readthedocs.io/en/stable/extend_kedro/custom_datasets.html).
+Take a look at our [instructions on how to create your own `AbstractDataset` implementation](https://kedro.readthedocs.io/en/stable/extend_kedro/custom_datasets.html).

--- a/kedro-datasets/kedro_datasets/api/__init__.py
+++ b/kedro-datasets/kedro_datasets/api/__init__.py
@@ -9,9 +9,8 @@ from typing import Any
 import lazy_loader as lazy
 
 # https://github.com/pylint-dev/pylint/issues/4300#issuecomment-1043601901
-APIDataSet: type[APIDataset]
 APIDataset: Any
 
 __getattr__, __dir__, __all__ = lazy.attach(
-    __name__, submod_attrs={"api_dataset": ["APIDataSet", "APIDataset"]}
+    __name__, submod_attrs={"api_dataset": ["APIDataset"]}
 )

--- a/kedro-datasets/kedro_datasets/api/__init__.py
+++ b/kedro-datasets/kedro_datasets/api/__init__.py
@@ -2,8 +2,6 @@
 and returns them into either as string or json Dict.
 It uses the python requests library: https://requests.readthedocs.io/en/latest/
 """
-from __future__ import annotations
-
 from typing import Any
 
 import lazy_loader as lazy

--- a/kedro-datasets/kedro_datasets/api/api_dataset.py
+++ b/kedro-datasets/kedro_datasets/api/api_dataset.py
@@ -2,16 +2,13 @@
 It uses the python requests library: https://requests.readthedocs.io/en/latest/
 """
 import json as json_  # make pylint happy
-import warnings
 from copy import deepcopy
 from typing import Any, Dict, List, Tuple, Union
 
 import requests
+from kedro_datasets._io import AbstractDataset, DatasetError
 from requests import Session, sessions
 from requests.auth import AuthBase
-
-from kedro_datasets import KedroDeprecationWarning
-from kedro_datasets._io import AbstractDataset, DatasetError
 
 
 class APIDataset(AbstractDataset[None, requests.Response]):
@@ -236,21 +233,3 @@ class APIDataset(AbstractDataset[None, requests.Response]):
         with sessions.Session() as session:
             response = self._execute_request(session)
         return response.ok
-
-
-_DEPRECATED_CLASSES = {
-    "APIDataSet": APIDataset,
-}
-
-
-def __getattr__(name):
-    if name in _DEPRECATED_CLASSES:
-        alias = _DEPRECATED_CLASSES[name]
-        warnings.warn(
-            f"{repr(name)} has been renamed to {repr(alias.__name__)}, "
-            f"and the alias will be removed in Kedro-Datasets 2.0.0",
-            KedroDeprecationWarning,
-            stacklevel=2,
-        )
-        return alias
-    raise AttributeError(f"module {repr(__name__)} has no attribute {repr(name)}")

--- a/kedro-datasets/kedro_datasets/api/api_dataset.py
+++ b/kedro-datasets/kedro_datasets/api/api_dataset.py
@@ -6,9 +6,10 @@ from copy import deepcopy
 from typing import Any, Dict, List, Tuple, Union
 
 import requests
-from kedro_datasets._io import AbstractDataset, DatasetError
 from requests import Session, sessions
 from requests.auth import AuthBase
+
+from kedro_datasets._io import AbstractDataset, DatasetError
 
 
 class APIDataset(AbstractDataset[None, requests.Response]):

--- a/kedro-datasets/kedro_datasets/biosequence/__init__.py
+++ b/kedro-datasets/kedro_datasets/biosequence/__init__.py
@@ -1,6 +1,4 @@
 """``AbstractDataset`` implementation to read/write from/to a sequence file."""
-from __future__ import annotations
-
 from typing import Any
 
 import lazy_loader as lazy

--- a/kedro-datasets/kedro_datasets/biosequence/__init__.py
+++ b/kedro-datasets/kedro_datasets/biosequence/__init__.py
@@ -6,10 +6,9 @@ from typing import Any
 import lazy_loader as lazy
 
 # https://github.com/pylint-dev/pylint/issues/4300#issuecomment-1043601901
-BioSequenceDataSet: type[BioSequenceDataset]
 BioSequenceDataset: Any
 
 __getattr__, __dir__, __all__ = lazy.attach(
     __name__,
-    submod_attrs={"biosequence_dataset": ["BioSequenceDataSet", "BioSequenceDataset"]},
+    submod_attrs={"biosequence_dataset": ["BioSequenceDataset"]},
 )

--- a/kedro-datasets/kedro_datasets/biosequence/biosequence_dataset.py
+++ b/kedro-datasets/kedro_datasets/biosequence/biosequence_dataset.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, List
 import fsspec
 from Bio import SeqIO
 from kedro.io.core import get_filepath_str, get_protocol_and_path
+
 from kedro_datasets._io import AbstractDataset
 
 

--- a/kedro-datasets/kedro_datasets/biosequence/biosequence_dataset.py
+++ b/kedro-datasets/kedro_datasets/biosequence/biosequence_dataset.py
@@ -1,7 +1,6 @@
 """BioSequenceDataset loads and saves data to/from bio-sequence objects to
 file.
 """
-import warnings
 from copy import deepcopy
 from pathlib import PurePosixPath
 from typing import Any, Dict, List
@@ -9,8 +8,6 @@ from typing import Any, Dict, List
 import fsspec
 from Bio import SeqIO
 from kedro.io.core import get_filepath_str, get_protocol_and_path
-
-from kedro_datasets import KedroDeprecationWarning
 from kedro_datasets._io import AbstractDataset
 
 
@@ -142,21 +139,3 @@ class BioSequenceDataset(AbstractDataset[List, List]):
         """Invalidate underlying filesystem caches."""
         filepath = get_filepath_str(self._filepath, self._protocol)
         self._fs.invalidate_cache(filepath)
-
-
-_DEPRECATED_CLASSES = {
-    "BioSequenceDataSet": BioSequenceDataset,
-}
-
-
-def __getattr__(name):
-    if name in _DEPRECATED_CLASSES:
-        alias = _DEPRECATED_CLASSES[name]
-        warnings.warn(
-            f"{repr(name)} has been renamed to {repr(alias.__name__)}, "
-            f"and the alias will be removed in Kedro-Datasets 2.0.0",
-            KedroDeprecationWarning,
-            stacklevel=2,
-        )
-        return alias
-    raise AttributeError(f"module {repr(__name__)} has no attribute {repr(name)}")

--- a/kedro-datasets/kedro_datasets/dask/__init__.py
+++ b/kedro-datasets/kedro_datasets/dask/__init__.py
@@ -1,6 +1,4 @@
 """Provides I/O modules using dask dataframe."""
-from __future__ import annotations
-
 from typing import Any
 
 import lazy_loader as lazy

--- a/kedro-datasets/kedro_datasets/dask/__init__.py
+++ b/kedro-datasets/kedro_datasets/dask/__init__.py
@@ -6,9 +6,8 @@ from typing import Any
 import lazy_loader as lazy
 
 # https://github.com/pylint-dev/pylint/issues/4300#issuecomment-1043601901
-ParquetDataSet: type[ParquetDataset]
 ParquetDataset: Any
 
 __getattr__, __dir__, __all__ = lazy.attach(
-    __name__, submod_attrs={"parquet_dataset": ["ParquetDataSet", "ParquetDataset"]}
+    __name__, submod_attrs={"parquet_dataset": ["ParquetDataset"]}
 )

--- a/kedro-datasets/kedro_datasets/dask/parquet_dataset.py
+++ b/kedro-datasets/kedro_datasets/dask/parquet_dataset.py
@@ -7,6 +7,7 @@ import dask.dataframe as dd
 import fsspec
 import triad
 from kedro.io.core import get_protocol_and_path
+
 from kedro_datasets._io import AbstractDataset
 
 

--- a/kedro-datasets/kedro_datasets/dask/parquet_dataset.py
+++ b/kedro-datasets/kedro_datasets/dask/parquet_dataset.py
@@ -1,6 +1,5 @@
 """``ParquetDataset`` is a data set used to load and save data to parquet files using Dask
 dataframe"""
-import warnings
 from copy import deepcopy
 from typing import Any, Dict
 
@@ -8,8 +7,6 @@ import dask.dataframe as dd
 import fsspec
 import triad
 from kedro.io.core import get_protocol_and_path
-
-from kedro_datasets import KedroDeprecationWarning
 from kedro_datasets._io import AbstractDataset
 
 
@@ -210,21 +207,3 @@ class ParquetDataset(AbstractDataset[dd.DataFrame, dd.DataFrame]):
         protocol = get_protocol_and_path(self._filepath)[0]
         file_system = fsspec.filesystem(protocol=protocol, **self.fs_args)
         return file_system.exists(self._filepath)
-
-
-_DEPRECATED_CLASSES = {
-    "ParquetDataSet": ParquetDataset,
-}
-
-
-def __getattr__(name):
-    if name in _DEPRECATED_CLASSES:
-        alias = _DEPRECATED_CLASSES[name]
-        warnings.warn(
-            f"{repr(name)} has been renamed to {repr(alias.__name__)}, "
-            f"and the alias will be removed in Kedro-Datasets 2.0.0",
-            KedroDeprecationWarning,
-            stacklevel=2,
-        )
-        return alias
-    raise AttributeError(f"module {repr(__name__)} has no attribute {repr(name)}")

--- a/kedro-datasets/kedro_datasets/databricks/__init__.py
+++ b/kedro-datasets/kedro_datasets/databricks/__init__.py
@@ -10,7 +10,5 @@ ManagedTableDataset: Any
 
 __getattr__, __dir__, __all__ = lazy.attach(
     __name__,
-    submod_attrs={
-        "managed_table_dataset": ["ManagedTableDataset"]
-    },
+    submod_attrs={"managed_table_dataset": ["ManagedTableDataset"]},
 )

--- a/kedro-datasets/kedro_datasets/databricks/__init__.py
+++ b/kedro-datasets/kedro_datasets/databricks/__init__.py
@@ -6,12 +6,11 @@ from typing import Any
 import lazy_loader as lazy
 
 # https://github.com/pylint-dev/pylint/issues/4300#issuecomment-1043601901
-ManagedTableDataSet: type[ManagedTableDataset]
 ManagedTableDataset: Any
 
 __getattr__, __dir__, __all__ = lazy.attach(
     __name__,
     submod_attrs={
-        "managed_table_dataset": ["ManagedTableDataSet", "ManagedTableDataset"]
+        "managed_table_dataset": ["ManagedTableDataset"]
     },
 )

--- a/kedro-datasets/kedro_datasets/databricks/__init__.py
+++ b/kedro-datasets/kedro_datasets/databricks/__init__.py
@@ -1,6 +1,4 @@
 """Provides interface to Unity Catalog Tables."""
-from __future__ import annotations
-
 from typing import Any
 
 import lazy_loader as lazy

--- a/kedro-datasets/kedro_datasets/databricks/managed_table_dataset.py
+++ b/kedro-datasets/kedro_datasets/databricks/managed_table_dataset.py
@@ -3,19 +3,16 @@ in Databricks.
 """
 import logging
 import re
-import warnings
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Union
 
 import pandas as pd
 from kedro.io.core import Version, VersionNotFoundError
+from kedro_datasets._io import AbstractVersionedDataset, DatasetError
+from kedro_datasets.spark.spark_dataset import _get_spark
 from pyspark.sql import DataFrame
 from pyspark.sql.types import StructType
 from pyspark.sql.utils import AnalysisException, ParseException
-
-from kedro_datasets import KedroDeprecationWarning
-from kedro_datasets._io import AbstractVersionedDataset, DatasetError
-from kedro_datasets.spark.spark_dataset import _get_spark
 
 logger = logging.getLogger(__name__)
 
@@ -434,21 +431,3 @@ class ManagedTableDataset(AbstractVersionedDataset):
         except (ParseException, AnalysisException) as exc:
             logger.warning("error occured while trying to find table: %s", exc)
             return False
-
-
-_DEPRECATED_CLASSES = {
-    "ManagedTableDataSet": ManagedTableDataset,
-}
-
-
-def __getattr__(name):
-    if name in _DEPRECATED_CLASSES:
-        alias = _DEPRECATED_CLASSES[name]
-        warnings.warn(
-            f"{repr(name)} has been renamed to {repr(alias.__name__)}, "
-            f"and the alias will be removed in Kedro-Datasets 2.0.0",
-            KedroDeprecationWarning,
-            stacklevel=2,
-        )
-        return alias
-    raise AttributeError(f"module {repr(__name__)} has no attribute {repr(name)}")

--- a/kedro-datasets/kedro_datasets/databricks/managed_table_dataset.py
+++ b/kedro-datasets/kedro_datasets/databricks/managed_table_dataset.py
@@ -8,11 +8,12 @@ from typing import Any, Dict, List, Optional, Union
 
 import pandas as pd
 from kedro.io.core import Version, VersionNotFoundError
-from kedro_datasets._io import AbstractVersionedDataset, DatasetError
-from kedro_datasets.spark.spark_dataset import _get_spark
 from pyspark.sql import DataFrame
 from pyspark.sql.types import StructType
 from pyspark.sql.utils import AnalysisException, ParseException
+
+from kedro_datasets._io import AbstractVersionedDataset, DatasetError
+from kedro_datasets.spark.spark_dataset import _get_spark
 
 logger = logging.getLogger(__name__)
 

--- a/kedro-datasets/kedro_datasets/email/__init__.py
+++ b/kedro-datasets/kedro_datasets/email/__init__.py
@@ -6,10 +6,9 @@ from typing import Any
 import lazy_loader as lazy
 
 # https://github.com/pylint-dev/pylint/issues/4300#issuecomment-1043601901
-EmailMessageDataSet: type[EmailMessageDataset]
 EmailMessageDataset: Any
 
 __getattr__, __dir__, __all__ = lazy.attach(
     __name__,
-    submod_attrs={"message_dataset": ["EmailMessageDataSet", "EmailMessageDataset"]},
+    submod_attrs={"message_dataset": ["EmailMessageDataset"]},
 )

--- a/kedro-datasets/kedro_datasets/email/__init__.py
+++ b/kedro-datasets/kedro_datasets/email/__init__.py
@@ -1,6 +1,4 @@
 """``AbstractDataset`` implementations for managing email messages."""
-from __future__ import annotations
-
 from typing import Any
 
 import lazy_loader as lazy

--- a/kedro-datasets/kedro_datasets/email/message_dataset.py
+++ b/kedro-datasets/kedro_datasets/email/message_dataset.py
@@ -12,6 +12,7 @@ from typing import Any, Dict
 
 import fsspec
 from kedro.io.core import Version, get_filepath_str, get_protocol_and_path
+
 from kedro_datasets._io import AbstractVersionedDataset, DatasetError
 
 

--- a/kedro-datasets/kedro_datasets/email/message_dataset.py
+++ b/kedro-datasets/kedro_datasets/email/message_dataset.py
@@ -2,7 +2,6 @@
 using an underlying filesystem (e.g.: local, S3, GCS). It uses the
 ``email`` package in the standard library to manage email messages.
 """
-import warnings
 from copy import deepcopy
 from email.generator import Generator
 from email.message import Message
@@ -13,8 +12,6 @@ from typing import Any, Dict
 
 import fsspec
 from kedro.io.core import Version, get_filepath_str, get_protocol_and_path
-
-from kedro_datasets import KedroDeprecationWarning
 from kedro_datasets._io import AbstractVersionedDataset, DatasetError
 
 
@@ -182,21 +179,3 @@ class EmailMessageDataset(AbstractVersionedDataset[Message, Message]):
         """Invalidate underlying filesystem caches."""
         filepath = get_filepath_str(self._filepath, self._protocol)
         self._fs.invalidate_cache(filepath)
-
-
-_DEPRECATED_CLASSES = {
-    "EmailMessageDataSet": EmailMessageDataset,
-}
-
-
-def __getattr__(name):
-    if name in _DEPRECATED_CLASSES:
-        alias = _DEPRECATED_CLASSES[name]
-        warnings.warn(
-            f"{repr(name)} has been renamed to {repr(alias.__name__)}, "
-            f"and the alias will be removed in Kedro-Datasets 2.0.0",
-            KedroDeprecationWarning,
-            stacklevel=2,
-        )
-        return alias
-    raise AttributeError(f"module {repr(__name__)} has no attribute {repr(name)}")

--- a/kedro-datasets/kedro_datasets/geopandas/README.md
+++ b/kedro-datasets/kedro_datasets/geopandas/README.md
@@ -1,6 +1,6 @@
 # GeoJSON
 
-``GeoJSONDataSet`` loads and saves data to a local yaml file using ``geopandas``.
+``GeoJSONDataset`` loads and saves data to a local yaml file using ``geopandas``.
 See [geopandas.GeoDataFrame](http://geopandas.org/reference/geopandas.GeoDataFrame.html) for details.
 
 #### Example use:
@@ -8,13 +8,13 @@ See [geopandas.GeoDataFrame](http://geopandas.org/reference/geopandas.GeoDataFra
 ```python
 import geopandas as gpd
 from shapely.geometry import Point
-from kedro_datasets.geopandas import GeoJSONDataSet
+from kedro_datasets.geopandas import GeoJSONDataset
 
 data = gpd.GeoDataFrame(
     {"col1": [1, 2], "col2": [4, 5], "col3": [5, 6]},
     geometry=[Point(1, 1), Point(2, 4)],
 )
-data_set = GeoJSONDataSet(filepath="test.geojson")
+data_set = GeoJSONDataset(filepath="test.geojson")
 data_set.save(data)
 reloaded = data_set.load()
 assert data.equals(reloaded)
@@ -24,7 +24,7 @@ assert data.equals(reloaded)
 
 ```yaml
 example_geojson_data:
-  type: geopandas.GeoJSONDataSet
+  type: geopandas.GeoJSONDataset
   filepath: data/08_reporting/test.geojson
 ```
 

--- a/kedro-datasets/kedro_datasets/geopandas/__init__.py
+++ b/kedro-datasets/kedro_datasets/geopandas/__init__.py
@@ -6,9 +6,8 @@ from typing import Any
 import lazy_loader as lazy
 
 # https://github.com/pylint-dev/pylint/issues/4300#issuecomment-1043601901
-GeoJSONDataSet: type[GeoJSONDataset]
 GeoJSONDataset: Any
 
 __getattr__, __dir__, __all__ = lazy.attach(
-    __name__, submod_attrs={"geojson_dataset": ["GeoJSONDataSet", "GeoJSONDataset"]}
+    __name__, submod_attrs={"geojson_dataset": ["GeoJSONDataset"]}
 )

--- a/kedro-datasets/kedro_datasets/geopandas/__init__.py
+++ b/kedro-datasets/kedro_datasets/geopandas/__init__.py
@@ -1,6 +1,4 @@
 """``GeoJSONDataset`` is an ``AbstractVersionedDataset`` to save and load GeoJSON files."""
-from __future__ import annotations
-
 from typing import Any
 
 import lazy_loader as lazy

--- a/kedro-datasets/kedro_datasets/geopandas/geojson_dataset.py
+++ b/kedro-datasets/kedro_datasets/geopandas/geojson_dataset.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, Union
 import fsspec
 import geopandas as gpd
 from kedro.io.core import Version, get_filepath_str, get_protocol_and_path
+
 from kedro_datasets._io import AbstractVersionedDataset, DatasetError
 
 

--- a/kedro-datasets/kedro_datasets/geopandas/geojson_dataset.py
+++ b/kedro-datasets/kedro_datasets/geopandas/geojson_dataset.py
@@ -3,15 +3,12 @@ underlying functionality is supported by geopandas, so it supports all
 allowed geopandas (pandas) options for loading and saving geosjon files.
 """
 import copy
-import warnings
 from pathlib import PurePosixPath
 from typing import Any, Dict, Union
 
 import fsspec
 import geopandas as gpd
 from kedro.io.core import Version, get_filepath_str, get_protocol_and_path
-
-from kedro_datasets import KedroDeprecationWarning
 from kedro_datasets._io import AbstractVersionedDataset, DatasetError
 
 
@@ -155,21 +152,3 @@ class GeoJSONDataset(
         """Invalidate underlying filesystem cache."""
         filepath = get_filepath_str(self._filepath, self._protocol)
         self._fs.invalidate_cache(filepath)
-
-
-_DEPRECATED_CLASSES = {
-    "GeoJSONDataSet": GeoJSONDataset,
-}
-
-
-def __getattr__(name):
-    if name in _DEPRECATED_CLASSES:
-        alias = _DEPRECATED_CLASSES[name]
-        warnings.warn(
-            f"{repr(name)} has been renamed to {repr(alias.__name__)}, "
-            f"and the alias will be removed in Kedro-Datasets 2.0.0",
-            KedroDeprecationWarning,
-            stacklevel=2,
-        )
-        return alias
-    raise AttributeError(f"module {repr(__name__)} has no attribute {repr(name)}")

--- a/kedro-datasets/kedro_datasets/json/__init__.py
+++ b/kedro-datasets/kedro_datasets/json/__init__.py
@@ -6,9 +6,8 @@ from typing import Any
 import lazy_loader as lazy
 
 # https://github.com/pylint-dev/pylint/issues/4300#issuecomment-1043601901
-JSONDataSet: type[JSONDataset]
 JSONDataset: Any
 
 __getattr__, __dir__, __all__ = lazy.attach(
-    __name__, submod_attrs={"json_dataset": ["JSONDataSet", "JSONDataset"]}
+    __name__, submod_attrs={"json_dataset": ["JSONDataset"]}
 )

--- a/kedro-datasets/kedro_datasets/json/__init__.py
+++ b/kedro-datasets/kedro_datasets/json/__init__.py
@@ -1,6 +1,4 @@
 """``AbstractDataset`` implementation to load/save data from/to a JSON file."""
-from __future__ import annotations
-
 from typing import Any
 
 import lazy_loader as lazy

--- a/kedro-datasets/kedro_datasets/json/json_dataset.py
+++ b/kedro-datasets/kedro_datasets/json/json_dataset.py
@@ -2,15 +2,12 @@
 filesystem (e.g.: local, S3, GCS). It uses native json to handle the JSON file.
 """
 import json
-import warnings
 from copy import deepcopy
 from pathlib import PurePosixPath
 from typing import Any, Dict
 
 import fsspec
 from kedro.io.core import Version, get_filepath_str, get_protocol_and_path
-
-from kedro_datasets import KedroDeprecationWarning
 from kedro_datasets._io import AbstractVersionedDataset, DatasetError
 
 
@@ -156,21 +153,3 @@ class JSONDataset(AbstractVersionedDataset[Any, Any]):
         """Invalidate underlying filesystem caches."""
         filepath = get_filepath_str(self._filepath, self._protocol)
         self._fs.invalidate_cache(filepath)
-
-
-_DEPRECATED_CLASSES = {
-    "JSONDataSet": JSONDataset,
-}
-
-
-def __getattr__(name):
-    if name in _DEPRECATED_CLASSES:
-        alias = _DEPRECATED_CLASSES[name]
-        warnings.warn(
-            f"{repr(name)} has been renamed to {repr(alias.__name__)}, "
-            f"and the alias will be removed in Kedro-Datasets 2.0.0",
-            KedroDeprecationWarning,
-            stacklevel=2,
-        )
-        return alias
-    raise AttributeError(f"module {repr(__name__)} has no attribute {repr(name)}")

--- a/kedro-datasets/kedro_datasets/json/json_dataset.py
+++ b/kedro-datasets/kedro_datasets/json/json_dataset.py
@@ -8,6 +8,7 @@ from typing import Any, Dict
 
 import fsspec
 from kedro.io.core import Version, get_filepath_str, get_protocol_and_path
+
 from kedro_datasets._io import AbstractVersionedDataset, DatasetError
 
 

--- a/kedro-datasets/kedro_datasets/networkx/__init__.py
+++ b/kedro-datasets/kedro_datasets/networkx/__init__.py
@@ -1,7 +1,5 @@
 """``AbstractDataset`` implementation to save and load graphs in JSON,
 GraphML and GML formats using NetworkX."""
-from __future__ import annotations
-
 from typing import Any
 
 import lazy_loader as lazy

--- a/kedro-datasets/kedro_datasets/networkx/__init__.py
+++ b/kedro-datasets/kedro_datasets/networkx/__init__.py
@@ -7,18 +7,15 @@ from typing import Any
 import lazy_loader as lazy
 
 # https://github.com/pylint-dev/pylint/issues/4300#issuecomment-1043601901
-GMLDataSet: type[GMLDataset]
 GMLDataset: Any
-GraphMLDataSet: type[GraphMLDataset]
 GraphMLDataset: Any
-JSONDataSet: type[JSONDataset]
 JSONDataset: Any
 
 __getattr__, __dir__, __all__ = lazy.attach(
     __name__,
     submod_attrs={
-        "gml_dataset": ["GMLDataSet", "GMLDataset"],
-        "graphml_dataset": ["GraphMLDataSet", "GraphMLDataset"],
-        "json_dataset": ["JSONDataSet", "JSONDataset"],
+        "gml_dataset": ["GMLDataset"],
+        "graphml_dataset": ["GraphMLDataset"],
+        "json_dataset": ["JSONDataset"],
     },
 )

--- a/kedro-datasets/kedro_datasets/networkx/gml_dataset.py
+++ b/kedro-datasets/kedro_datasets/networkx/gml_dataset.py
@@ -2,7 +2,6 @@
 file using an underlying filesystem (e.g.: local, S3, GCS). NetworkX is used to
 create GML data.
 """
-import warnings
 from copy import deepcopy
 from pathlib import PurePosixPath
 from typing import Any, Dict
@@ -10,8 +9,6 @@ from typing import Any, Dict
 import fsspec
 import networkx
 from kedro.io.core import Version, get_filepath_str, get_protocol_and_path
-
-from kedro_datasets import KedroDeprecationWarning
 from kedro_datasets._io import AbstractVersionedDataset
 
 
@@ -141,21 +138,3 @@ class GMLDataset(AbstractVersionedDataset[networkx.Graph, networkx.Graph]):
         """Invalidate underlying filesystem caches."""
         filepath = get_filepath_str(self._filepath, self._protocol)
         self._fs.invalidate_cache(filepath)
-
-
-_DEPRECATED_CLASSES = {
-    "GMLDataSet": GMLDataset,
-}
-
-
-def __getattr__(name):
-    if name in _DEPRECATED_CLASSES:
-        alias = _DEPRECATED_CLASSES[name]
-        warnings.warn(
-            f"{repr(name)} has been renamed to {repr(alias.__name__)}, "
-            f"and the alias will be removed in Kedro-Datasets 2.0.0",
-            KedroDeprecationWarning,
-            stacklevel=2,
-        )
-        return alias
-    raise AttributeError(f"module {repr(__name__)} has no attribute {repr(name)}")

--- a/kedro-datasets/kedro_datasets/networkx/gml_dataset.py
+++ b/kedro-datasets/kedro_datasets/networkx/gml_dataset.py
@@ -9,6 +9,7 @@ from typing import Any, Dict
 import fsspec
 import networkx
 from kedro.io.core import Version, get_filepath_str, get_protocol_and_path
+
 from kedro_datasets._io import AbstractVersionedDataset
 
 

--- a/kedro-datasets/kedro_datasets/networkx/graphml_dataset.py
+++ b/kedro-datasets/kedro_datasets/networkx/graphml_dataset.py
@@ -8,6 +8,7 @@ from typing import Any, Dict
 import fsspec
 import networkx
 from kedro.io.core import Version, get_filepath_str, get_protocol_and_path
+
 from kedro_datasets._io import AbstractVersionedDataset
 
 

--- a/kedro-datasets/kedro_datasets/networkx/graphml_dataset.py
+++ b/kedro-datasets/kedro_datasets/networkx/graphml_dataset.py
@@ -1,7 +1,6 @@
 """NetworkX ``GraphMLDataset`` loads and saves graphs to a GraphML file using an underlying
 filesystem (e.g.: local, S3, GCS). NetworkX is used to create GraphML data.
 """
-import warnings
 from copy import deepcopy
 from pathlib import PurePosixPath
 from typing import Any, Dict
@@ -9,8 +8,6 @@ from typing import Any, Dict
 import fsspec
 import networkx
 from kedro.io.core import Version, get_filepath_str, get_protocol_and_path
-
-from kedro_datasets import KedroDeprecationWarning
 from kedro_datasets._io import AbstractVersionedDataset
 
 
@@ -139,21 +136,3 @@ class GraphMLDataset(AbstractVersionedDataset[networkx.Graph, networkx.Graph]):
         """Invalidate underlying filesystem caches."""
         filepath = get_filepath_str(self._filepath, self._protocol)
         self._fs.invalidate_cache(filepath)
-
-
-_DEPRECATED_CLASSES = {
-    "GraphMLDataSet": GraphMLDataset,
-}
-
-
-def __getattr__(name):
-    if name in _DEPRECATED_CLASSES:
-        alias = _DEPRECATED_CLASSES[name]
-        warnings.warn(
-            f"{repr(name)} has been renamed to {repr(alias.__name__)}, "
-            f"and the alias will be removed in Kedro-Datasets 2.0.0",
-            KedroDeprecationWarning,
-            stacklevel=2,
-        )
-        return alias
-    raise AttributeError(f"module {repr(__name__)} has no attribute {repr(name)}")

--- a/kedro-datasets/kedro_datasets/networkx/json_dataset.py
+++ b/kedro-datasets/kedro_datasets/networkx/json_dataset.py
@@ -9,6 +9,7 @@ from typing import Any, Dict
 import fsspec
 import networkx
 from kedro.io.core import Version, get_filepath_str, get_protocol_and_path
+
 from kedro_datasets._io import AbstractVersionedDataset
 
 

--- a/kedro-datasets/kedro_datasets/networkx/json_dataset.py
+++ b/kedro-datasets/kedro_datasets/networkx/json_dataset.py
@@ -2,7 +2,6 @@
 filesystem (e.g.: local, S3, GCS). NetworkX is used to create JSON data.
 """
 import json
-import warnings
 from copy import deepcopy
 from pathlib import PurePosixPath
 from typing import Any, Dict
@@ -10,8 +9,6 @@ from typing import Any, Dict
 import fsspec
 import networkx
 from kedro.io.core import Version, get_filepath_str, get_protocol_and_path
-
-from kedro_datasets import KedroDeprecationWarning
 from kedro_datasets._io import AbstractVersionedDataset
 
 
@@ -146,21 +143,3 @@ class JSONDataset(AbstractVersionedDataset[networkx.Graph, networkx.Graph]):
         """Invalidate underlying filesystem caches."""
         filepath = get_filepath_str(self._filepath, self._protocol)
         self._fs.invalidate_cache(filepath)
-
-
-_DEPRECATED_CLASSES = {
-    "JSONDataSet": JSONDataset,
-}
-
-
-def __getattr__(name):
-    if name in _DEPRECATED_CLASSES:
-        alias = _DEPRECATED_CLASSES[name]
-        warnings.warn(
-            f"{repr(name)} has been renamed to {repr(alias.__name__)}, "
-            f"and the alias will be removed in Kedro-Datasets 2.0.0",
-            KedroDeprecationWarning,
-            stacklevel=2,
-        )
-        return alias
-    raise AttributeError(f"module {repr(__name__)} has no attribute {repr(name)}")

--- a/kedro-datasets/kedro_datasets/pandas/__init__.py
+++ b/kedro-datasets/kedro_datasets/pandas/__init__.py
@@ -6,56 +6,39 @@ from typing import Any
 import lazy_loader as lazy
 
 # https://github.com/pylint-dev/pylint/issues/4300#issuecomment-1043601901
-CSVDataSet: type[CSVDataset]
 CSVDataset: Any
-DeltaTableDataSet: type[DeltaTableDataset]
 DeltaTableDataset: Any
-ExcelDataSet: type[ExcelDataset]
 ExcelDataset: Any
-FeatherDataSet: type[FeatherDataset]
 FeatherDataset: Any
-GBQQueryDataSet: type[GBQQueryDataset]
 GBQQueryDataset: Any
-GBQTableDataSet: type[GBQTableDataset]
 GBQTableDataset: Any
-GenericDataSet: type[GenericDataset]
 GenericDataset: Any
-HDFDataSet: type[HDFDataset]
 HDFDataset: Any
-JSONDataSet: type[JSONDataset]
 JSONDataset: Any
-ParquetDataSet: type[ParquetDataset]
 ParquetDataset: Any
-SQLQueryDataSet: type[SQLQueryDataset]
 SQLQueryDataset: Any
-SQLTableDataSet: type[SQLTableDataset]
 SQLTableDataset: Any
-XMLDataSet: type[XMLDataset]
 XMLDataset: Any
 
 __getattr__, __dir__, __all__ = lazy.attach(
     __name__,
     submod_attrs={
-        "csv_dataset": ["CSVDataSet", "CSVDataset"],
-        "deltatable_dataset": ["DeltaTableDataSet", "DeltaTableDataset"],
-        "excel_dataset": ["ExcelDataSet", "ExcelDataset"],
-        "feather_dataset": ["FeatherDataSet", "FeatherDataset"],
+        "csv_dataset": ["CSVDataset"],
+        "deltatable_dataset": ["DeltaTableDataset"],
+        "excel_dataset": ["ExcelDataset"],
+        "feather_dataset": ["FeatherDataset"],
         "gbq_dataset": [
-            "GBQQueryDataSet",
             "GBQQueryDataset",
-            "GBQTableDataSet",
             "GBQTableDataset",
         ],
-        "generic_dataset": ["GenericDataSet", "GenericDataset"],
-        "hdf_dataset": ["HDFDataSet", "HDFDataset"],
-        "json_dataset": ["JSONDataSet", "JSONDataset"],
-        "parquet_dataset": ["ParquetDataSet", "ParquetDataset"],
+        "generic_dataset": ["GenericDataset"],
+        "hdf_dataset": ["HDFDataset"],
+        "json_dataset": ["JSONDataset"],
+        "parquet_dataset": ["ParquetDataset"],
         "sql_dataset": [
-            "SQLQueryDataSet",
             "SQLQueryDataset",
-            "SQLTableDataSet",
             "SQLTableDataset",
         ],
-        "xml_dataset": ["XMLDataSet", "XMLDataset"],
+        "xml_dataset": ["XMLDataset"],
     },
 )

--- a/kedro-datasets/kedro_datasets/pandas/__init__.py
+++ b/kedro-datasets/kedro_datasets/pandas/__init__.py
@@ -1,6 +1,4 @@
 """``AbstractDataset`` implementations that produce pandas DataFrames."""
-from __future__ import annotations
-
 from typing import Any
 
 import lazy_loader as lazy

--- a/kedro-datasets/kedro_datasets/pandas/csv_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/csv_dataset.py
@@ -2,7 +2,6 @@
 filesystem (e.g.: local, S3, GCS). It uses pandas to handle the CSV file.
 """
 import logging
-import warnings
 from copy import deepcopy
 from io import BytesIO
 from pathlib import PurePosixPath
@@ -16,8 +15,6 @@ from kedro.io.core import (
     get_filepath_str,
     get_protocol_and_path,
 )
-
-from kedro_datasets import KedroDeprecationWarning
 from kedro_datasets._io import AbstractVersionedDataset, DatasetError
 
 logger = logging.getLogger(__name__)
@@ -202,21 +199,3 @@ class CSVDataset(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
         data = dataset_copy.load()
 
         return data.to_dict(orient="split")
-
-
-_DEPRECATED_CLASSES = {
-    "CSVDataSet": CSVDataset,
-}
-
-
-def __getattr__(name):
-    if name in _DEPRECATED_CLASSES:
-        alias = _DEPRECATED_CLASSES[name]
-        warnings.warn(
-            f"{repr(name)} has been renamed to {repr(alias.__name__)}, "
-            f"and the alias will be removed in Kedro-Datasets 2.0.0",
-            KedroDeprecationWarning,
-            stacklevel=2,
-        )
-        return alias
-    raise AttributeError(f"module {repr(__name__)} has no attribute {repr(name)}")

--- a/kedro-datasets/kedro_datasets/pandas/csv_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/csv_dataset.py
@@ -15,6 +15,7 @@ from kedro.io.core import (
     get_filepath_str,
     get_protocol_and_path,
 )
+
 from kedro_datasets._io import AbstractVersionedDataset, DatasetError
 
 logger = logging.getLogger(__name__)

--- a/kedro-datasets/kedro_datasets/pandas/deltatable_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/deltatable_dataset.py
@@ -2,7 +2,6 @@
 S3, GCS), Databricks unity catalog and AWS Glue catalog respectively. It handles
 load and save using a pandas dataframe.
 """
-import warnings
 from copy import deepcopy
 from typing import Any, Dict, List, Optional
 
@@ -10,8 +9,6 @@ import pandas as pd
 from deltalake import DataCatalog, DeltaTable, Metadata
 from deltalake.exceptions import TableNotFoundError
 from deltalake.writer import write_deltalake
-
-from kedro_datasets import KedroDeprecationWarning
 from kedro_datasets._io import AbstractDataset, DatasetError
 
 
@@ -260,21 +257,3 @@ class DeltaTableDataset(AbstractDataset):
             "save_args": self._save_args,
             "version": self._version,
         }
-
-
-_DEPRECATED_CLASSES = {
-    "DeltaTableDataSet": DeltaTableDataset,
-}
-
-
-def __getattr__(name):
-    if name in _DEPRECATED_CLASSES:
-        alias = _DEPRECATED_CLASSES[name]
-        warnings.warn(
-            f"{repr(name)} has been renamed to {repr(alias.__name__)}, "
-            f"and the alias will be removed in Kedro-Datasets 2.0.0",
-            KedroDeprecationWarning,
-            stacklevel=2,
-        )
-        return alias
-    raise AttributeError(f"module {repr(__name__)} has no attribute {repr(name)}")

--- a/kedro-datasets/kedro_datasets/pandas/deltatable_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/deltatable_dataset.py
@@ -9,6 +9,7 @@ import pandas as pd
 from deltalake import DataCatalog, DeltaTable, Metadata
 from deltalake.exceptions import TableNotFoundError
 from deltalake.writer import write_deltalake
+
 from kedro_datasets._io import AbstractDataset, DatasetError
 
 

--- a/kedro-datasets/kedro_datasets/pandas/excel_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/excel_dataset.py
@@ -15,6 +15,7 @@ from kedro.io.core import (
     get_filepath_str,
     get_protocol_and_path,
 )
+
 from kedro_datasets._io import AbstractVersionedDataset, DatasetError
 
 logger = logging.getLogger(__name__)

--- a/kedro-datasets/kedro_datasets/pandas/excel_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/excel_dataset.py
@@ -2,7 +2,6 @@
 filesystem (e.g.: local, S3, GCS). It uses pandas to handle the Excel file.
 """
 import logging
-import warnings
 from copy import deepcopy
 from io import BytesIO
 from pathlib import PurePosixPath
@@ -16,8 +15,6 @@ from kedro.io.core import (
     get_filepath_str,
     get_protocol_and_path,
 )
-
-from kedro_datasets import KedroDeprecationWarning
 from kedro_datasets._io import AbstractVersionedDataset, DatasetError
 
 logger = logging.getLogger(__name__)
@@ -270,21 +267,3 @@ class ExcelDataset(
         data = dataset_copy.load()
 
         return data.to_dict(orient="split")
-
-
-_DEPRECATED_CLASSES = {
-    "ExcelDataSet": ExcelDataset,
-}
-
-
-def __getattr__(name):
-    if name in _DEPRECATED_CLASSES:
-        alias = _DEPRECATED_CLASSES[name]
-        warnings.warn(
-            f"{repr(name)} has been renamed to {repr(alias.__name__)}, "
-            f"and the alias will be removed in Kedro-Datasets 2.0.0",
-            KedroDeprecationWarning,
-            stacklevel=2,
-        )
-        return alias
-    raise AttributeError(f"module {repr(__name__)} has no attribute {repr(name)}")

--- a/kedro-datasets/kedro_datasets/pandas/feather_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/feather_dataset.py
@@ -3,7 +3,6 @@ using an underlying filesystem (e.g.: local, S3, GCS). The underlying functional
 is supported by pandas, so it supports all operations the pandas supports.
 """
 import logging
-import warnings
 from copy import deepcopy
 from io import BytesIO
 from pathlib import PurePosixPath
@@ -17,8 +16,6 @@ from kedro.io.core import (
     get_filepath_str,
     get_protocol_and_path,
 )
-
-from kedro_datasets import KedroDeprecationWarning
 from kedro_datasets._io import AbstractVersionedDataset
 
 logger = logging.getLogger(__name__)
@@ -190,21 +187,3 @@ class FeatherDataset(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
         """Invalidate underlying filesystem caches."""
         filepath = get_filepath_str(self._filepath, self._protocol)
         self._fs.invalidate_cache(filepath)
-
-
-_DEPRECATED_CLASSES = {
-    "FeatherDataSet": FeatherDataset,
-}
-
-
-def __getattr__(name):
-    if name in _DEPRECATED_CLASSES:
-        alias = _DEPRECATED_CLASSES[name]
-        warnings.warn(
-            f"{repr(name)} has been renamed to {repr(alias.__name__)}, "
-            f"and the alias will be removed in Kedro-Datasets 2.0.0",
-            KedroDeprecationWarning,
-            stacklevel=2,
-        )
-        return alias
-    raise AttributeError(f"module {repr(__name__)} has no attribute {repr(name)}")

--- a/kedro-datasets/kedro_datasets/pandas/feather_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/feather_dataset.py
@@ -16,6 +16,7 @@ from kedro.io.core import (
     get_filepath_str,
     get_protocol_and_path,
 )
+
 from kedro_datasets._io import AbstractVersionedDataset
 
 logger = logging.getLogger(__name__)

--- a/kedro-datasets/kedro_datasets/pandas/gbq_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/gbq_dataset.py
@@ -15,6 +15,7 @@ from kedro.io.core import (
     get_protocol_and_path,
     validate_on_forbidden_chars,
 )
+
 from kedro_datasets._io import AbstractDataset, DatasetError
 
 

--- a/kedro-datasets/kedro_datasets/pandas/gbq_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/gbq_dataset.py
@@ -2,7 +2,6 @@
 to read and write from/to BigQuery table.
 """
 import copy
-import warnings
 from pathlib import PurePosixPath
 from typing import Any, Dict, NoReturn, Union
 
@@ -16,8 +15,6 @@ from kedro.io.core import (
     get_protocol_and_path,
     validate_on_forbidden_chars,
 )
-
-from kedro_datasets import KedroDeprecationWarning
 from kedro_datasets._io import AbstractDataset, DatasetError
 
 
@@ -315,22 +312,3 @@ class GBQQueryDataset(AbstractDataset[None, pd.DataFrame]):
 
     def _save(self, data: None) -> NoReturn:
         raise DatasetError("'save' is not supported on GBQQueryDataset")
-
-
-_DEPRECATED_CLASSES = {
-    "GBQTableDataSet": GBQTableDataset,
-    "GBQQueryDataSet": GBQQueryDataset,
-}
-
-
-def __getattr__(name):
-    if name in _DEPRECATED_CLASSES:
-        alias = _DEPRECATED_CLASSES[name]
-        warnings.warn(
-            f"{repr(name)} has been renamed to {repr(alias.__name__)}, "
-            f"and the alias will be removed in Kedro-Datasets 2.0.0",
-            KedroDeprecationWarning,
-            stacklevel=2,
-        )
-        return alias
-    raise AttributeError(f"module {repr(__name__)} has no attribute {repr(name)}")

--- a/kedro-datasets/kedro_datasets/pandas/generic_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/generic_dataset.py
@@ -2,7 +2,6 @@
 filesystem (e.g.: local, S3, GCS). It uses pandas to handle the
 type of read/write target.
 """
-import warnings
 from copy import deepcopy
 from pathlib import PurePosixPath
 from typing import Any, Dict
@@ -10,8 +9,6 @@ from typing import Any, Dict
 import fsspec
 import pandas as pd
 from kedro.io.core import Version, get_filepath_str, get_protocol_and_path
-
-from kedro_datasets import KedroDeprecationWarning
 from kedro_datasets._io import AbstractVersionedDataset, DatasetError
 
 NON_FILE_SYSTEM_TARGETS = [
@@ -240,21 +237,3 @@ class GenericDataset(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
         """Invalidate underlying filesystem caches."""
         filepath = get_filepath_str(self._filepath, self._protocol)
         self._fs.invalidate_cache(filepath)
-
-
-_DEPRECATED_CLASSES = {
-    "GenericDataSet": GenericDataset,
-}
-
-
-def __getattr__(name):
-    if name in _DEPRECATED_CLASSES:
-        alias = _DEPRECATED_CLASSES[name]
-        warnings.warn(
-            f"{repr(name)} has been renamed to {repr(alias.__name__)}, "
-            f"and the alias will be removed in Kedro-Datasets 2.0.0",
-            KedroDeprecationWarning,
-            stacklevel=2,
-        )
-        return alias
-    raise AttributeError(f"module {repr(__name__)} has no attribute {repr(name)}")

--- a/kedro-datasets/kedro_datasets/pandas/generic_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/generic_dataset.py
@@ -9,6 +9,7 @@ from typing import Any, Dict
 import fsspec
 import pandas as pd
 from kedro.io.core import Version, get_filepath_str, get_protocol_and_path
+
 from kedro_datasets._io import AbstractVersionedDataset, DatasetError
 
 NON_FILE_SYSTEM_TARGETS = [

--- a/kedro-datasets/kedro_datasets/pandas/hdf_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/hdf_dataset.py
@@ -9,6 +9,7 @@ from typing import Any, Dict
 import fsspec
 import pandas as pd
 from kedro.io.core import Version, get_filepath_str, get_protocol_and_path
+
 from kedro_datasets._io import AbstractVersionedDataset, DatasetError
 
 HDFSTORE_DRIVER = "H5FD_CORE"

--- a/kedro-datasets/kedro_datasets/pandas/hdf_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/hdf_dataset.py
@@ -1,7 +1,6 @@
 """``HDFDataset`` loads/saves data from/to a hdf file using an underlying
 filesystem (e.g.: local, S3, GCS). It uses pandas.HDFStore to handle the hdf file.
 """
-import warnings
 from copy import deepcopy
 from pathlib import PurePosixPath
 from threading import Lock
@@ -10,8 +9,6 @@ from typing import Any, Dict
 import fsspec
 import pandas as pd
 from kedro.io.core import Version, get_filepath_str, get_protocol_and_path
-
-from kedro_datasets import KedroDeprecationWarning
 from kedro_datasets._io import AbstractVersionedDataset, DatasetError
 
 HDFSTORE_DRIVER = "H5FD_CORE"
@@ -200,21 +197,3 @@ class HDFDataset(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
         """Invalidate underlying filesystem caches."""
         filepath = get_filepath_str(self._filepath, self._protocol)
         self._fs.invalidate_cache(filepath)
-
-
-_DEPRECATED_CLASSES = {
-    "HDFDataSet": HDFDataset,
-}
-
-
-def __getattr__(name):
-    if name in _DEPRECATED_CLASSES:
-        alias = _DEPRECATED_CLASSES[name]
-        warnings.warn(
-            f"{repr(name)} has been renamed to {repr(alias.__name__)}, "
-            f"and the alias will be removed in Kedro-Datasets 2.0.0",
-            KedroDeprecationWarning,
-            stacklevel=2,
-        )
-        return alias
-    raise AttributeError(f"module {repr(__name__)} has no attribute {repr(name)}")

--- a/kedro-datasets/kedro_datasets/pandas/json_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/json_dataset.py
@@ -15,6 +15,7 @@ from kedro.io.core import (
     get_filepath_str,
     get_protocol_and_path,
 )
+
 from kedro_datasets._io import AbstractVersionedDataset, DatasetError
 
 logger = logging.getLogger(__name__)

--- a/kedro-datasets/kedro_datasets/pandas/json_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/json_dataset.py
@@ -2,7 +2,6 @@
 filesystem (e.g.: local, S3, GCS). It uses pandas to handle the JSON file.
 """
 import logging
-import warnings
 from copy import deepcopy
 from io import BytesIO
 from pathlib import PurePosixPath
@@ -16,8 +15,6 @@ from kedro.io.core import (
     get_filepath_str,
     get_protocol_and_path,
 )
-
-from kedro_datasets import KedroDeprecationWarning
 from kedro_datasets._io import AbstractVersionedDataset, DatasetError
 
 logger = logging.getLogger(__name__)
@@ -188,21 +185,3 @@ class JSONDataset(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
         """Invalidate underlying filesystem caches."""
         filepath = get_filepath_str(self._filepath, self._protocol)
         self._fs.invalidate_cache(filepath)
-
-
-_DEPRECATED_CLASSES = {
-    "JSONDataSet": JSONDataset,
-}
-
-
-def __getattr__(name):
-    if name in _DEPRECATED_CLASSES:
-        alias = _DEPRECATED_CLASSES[name]
-        warnings.warn(
-            f"{repr(name)} has been renamed to {repr(alias.__name__)}, "
-            f"and the alias will be removed in Kedro-Datasets 2.0.0",
-            KedroDeprecationWarning,
-            stacklevel=2,
-        )
-        return alias
-    raise AttributeError(f"module {repr(__name__)} has no attribute {repr(name)}")

--- a/kedro-datasets/kedro_datasets/pandas/parquet_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/parquet_dataset.py
@@ -2,7 +2,6 @@
 filesystem (e.g.: local, S3, GCS). It uses pandas to handle the Parquet file.
 """
 import logging
-import warnings
 from copy import deepcopy
 from io import BytesIO
 from pathlib import Path, PurePosixPath
@@ -16,8 +15,6 @@ from kedro.io.core import (
     get_filepath_str,
     get_protocol_and_path,
 )
-
-from kedro_datasets import KedroDeprecationWarning
 from kedro_datasets._io import AbstractVersionedDataset, DatasetError
 
 logger = logging.getLogger(__name__)
@@ -214,21 +211,3 @@ class ParquetDataset(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
         """Invalidate underlying filesystem caches."""
         filepath = get_filepath_str(self._filepath, self._protocol)
         self._fs.invalidate_cache(filepath)
-
-
-_DEPRECATED_CLASSES = {
-    "ParquetDataSet": ParquetDataset,
-}
-
-
-def __getattr__(name):
-    if name in _DEPRECATED_CLASSES:
-        alias = _DEPRECATED_CLASSES[name]
-        warnings.warn(
-            f"{repr(name)} has been renamed to {repr(alias.__name__)}, "
-            f"and the alias will be removed in Kedro-Datasets 2.0.0",
-            KedroDeprecationWarning,
-            stacklevel=2,
-        )
-        return alias
-    raise AttributeError(f"module {repr(__name__)} has no attribute {repr(name)}")

--- a/kedro-datasets/kedro_datasets/pandas/parquet_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/parquet_dataset.py
@@ -15,6 +15,7 @@ from kedro.io.core import (
     get_filepath_str,
     get_protocol_and_path,
 )
+
 from kedro_datasets._io import AbstractVersionedDataset, DatasetError
 
 logger = logging.getLogger(__name__)

--- a/kedro-datasets/kedro_datasets/pandas/sql_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/sql_dataset.py
@@ -10,9 +10,10 @@ from typing import Any, NoReturn
 import fsspec
 import pandas as pd
 from kedro.io.core import get_filepath_str, get_protocol_and_path
-from kedro_datasets._io import AbstractDataset, DatasetError
 from sqlalchemy import create_engine, inspect
 from sqlalchemy.exc import NoSuchModuleError
+
+from kedro_datasets._io import AbstractDataset, DatasetError
 
 __all__ = ["SQLTableDataset", "SQLQueryDataset"]
 

--- a/kedro-datasets/kedro_datasets/pandas/sql_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/sql_dataset.py
@@ -4,18 +4,15 @@ from __future__ import annotations
 import copy
 import datetime as dt
 import re
-import warnings
 from pathlib import PurePosixPath
 from typing import Any, NoReturn
 
 import fsspec
 import pandas as pd
 from kedro.io.core import get_filepath_str, get_protocol_and_path
+from kedro_datasets._io import AbstractDataset, DatasetError
 from sqlalchemy import create_engine, inspect
 from sqlalchemy.exc import NoSuchModuleError
-
-from kedro_datasets import KedroDeprecationWarning
-from kedro_datasets._io import AbstractDataset, DatasetError
 
 __all__ = ["SQLTableDataset", "SQLQueryDataset"]
 
@@ -544,22 +541,3 @@ class SQLQueryDataset(AbstractDataset[None, pd.DataFrame]):
                 new_load_args.append(value)
         if new_load_args:
             self._load_args["params"] = new_load_args
-
-
-_DEPRECATED_CLASSES = {
-    "SQLTableDataSet": SQLTableDataset,
-    "SQLQueryDataSet": SQLQueryDataset,
-}
-
-
-def __getattr__(name):
-    if name in _DEPRECATED_CLASSES:
-        alias = _DEPRECATED_CLASSES[name]
-        warnings.warn(
-            f"{repr(name)} has been renamed to {repr(alias.__name__)}, "
-            f"and the alias will be removed in Kedro-Datasets 2.0.0",
-            KedroDeprecationWarning,
-            stacklevel=2,
-        )
-        return alias
-    raise AttributeError(f"module {repr(__name__)} has no attribute {repr(name)}")

--- a/kedro-datasets/kedro_datasets/pandas/xml_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/xml_dataset.py
@@ -2,7 +2,6 @@
 filesystem (e.g.: local, S3, GCS). It uses pandas to handle the XML file.
 """
 import logging
-import warnings
 from copy import deepcopy
 from io import BytesIO
 from pathlib import PurePosixPath
@@ -16,8 +15,6 @@ from kedro.io.core import (
     get_filepath_str,
     get_protocol_and_path,
 )
-
-from kedro_datasets import KedroDeprecationWarning
 from kedro_datasets._io import AbstractVersionedDataset, DatasetError
 
 logger = logging.getLogger(__name__)
@@ -172,21 +169,3 @@ class XMLDataset(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
         """Invalidate underlying filesystem caches."""
         filepath = get_filepath_str(self._filepath, self._protocol)
         self._fs.invalidate_cache(filepath)
-
-
-_DEPRECATED_CLASSES = {
-    "XMLDataSet": XMLDataset,
-}
-
-
-def __getattr__(name):
-    if name in _DEPRECATED_CLASSES:
-        alias = _DEPRECATED_CLASSES[name]
-        warnings.warn(
-            f"{repr(name)} has been renamed to {repr(alias.__name__)}, "
-            f"and the alias will be removed in Kedro-Datasets 2.0.0",
-            KedroDeprecationWarning,
-            stacklevel=2,
-        )
-        return alias
-    raise AttributeError(f"module {repr(__name__)} has no attribute {repr(name)}")

--- a/kedro-datasets/kedro_datasets/pandas/xml_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/xml_dataset.py
@@ -15,6 +15,7 @@ from kedro.io.core import (
     get_filepath_str,
     get_protocol_and_path,
 )
+
 from kedro_datasets._io import AbstractVersionedDataset, DatasetError
 
 logger = logging.getLogger(__name__)

--- a/kedro-datasets/kedro_datasets/partitions/__init__.py
+++ b/kedro-datasets/kedro_datasets/partitions/__init__.py
@@ -1,8 +1,6 @@
 """``AbstractDataset`` implementations to load/save data in partitions
 from/to any underlying dataset format.
 """
-from __future__ import annotations
-
 from typing import Any
 
 import lazy_loader as lazy

--- a/kedro-datasets/kedro_datasets/pickle/__init__.py
+++ b/kedro-datasets/kedro_datasets/pickle/__init__.py
@@ -6,9 +6,8 @@ from typing import Any
 import lazy_loader as lazy
 
 # https://github.com/pylint-dev/pylint/issues/4300#issuecomment-1043601901
-PickleDataSet: type[PickleDataset]
 PickleDataset: Any
 
 __getattr__, __dir__, __all__ = lazy.attach(
-    __name__, submod_attrs={"pickle_dataset": ["PickleDataSet", "PickleDataset"]}
+    __name__, submod_attrs={"pickle_dataset": ["PickleDataset"]}
 )

--- a/kedro-datasets/kedro_datasets/pickle/__init__.py
+++ b/kedro-datasets/kedro_datasets/pickle/__init__.py
@@ -1,6 +1,4 @@
 """``AbstractDataset`` implementation to load/save data from/to a Pickle file."""
-from __future__ import annotations
-
 from typing import Any
 
 import lazy_loader as lazy

--- a/kedro-datasets/kedro_datasets/pickle/pickle_dataset.py
+++ b/kedro-datasets/kedro_datasets/pickle/pickle_dataset.py
@@ -10,6 +10,7 @@ from typing import Any, Dict
 
 import fsspec
 from kedro.io.core import Version, get_filepath_str, get_protocol_and_path
+
 from kedro_datasets._io import AbstractVersionedDataset, DatasetError
 
 

--- a/kedro-datasets/kedro_datasets/pickle/pickle_dataset.py
+++ b/kedro-datasets/kedro_datasets/pickle/pickle_dataset.py
@@ -4,15 +4,12 @@ the specified backend library passed in (defaults to the ``pickle`` library), so
 supports all allowed options for loading and saving pickle files.
 """
 import importlib
-import warnings
 from copy import deepcopy
 from pathlib import PurePosixPath
 from typing import Any, Dict
 
 import fsspec
 from kedro.io.core import Version, get_filepath_str, get_protocol_and_path
-
-from kedro_datasets import KedroDeprecationWarning
 from kedro_datasets._io import AbstractVersionedDataset, DatasetError
 
 
@@ -246,21 +243,3 @@ class PickleDataset(AbstractVersionedDataset[Any, Any]):
         """Invalidate underlying filesystem caches."""
         filepath = get_filepath_str(self._filepath, self._protocol)
         self._fs.invalidate_cache(filepath)
-
-
-_DEPRECATED_CLASSES = {
-    "PickleDataSet": PickleDataset,
-}
-
-
-def __getattr__(name):
-    if name in _DEPRECATED_CLASSES:
-        alias = _DEPRECATED_CLASSES[name]
-        warnings.warn(
-            f"{repr(name)} has been renamed to {repr(alias.__name__)}, "
-            f"and the alias will be removed in Kedro-Datasets 2.0.0",
-            KedroDeprecationWarning,
-            stacklevel=2,
-        )
-        return alias
-    raise AttributeError(f"module {repr(__name__)} has no attribute {repr(name)}")

--- a/kedro-datasets/kedro_datasets/pillow/__init__.py
+++ b/kedro-datasets/kedro_datasets/pillow/__init__.py
@@ -1,4 +1,4 @@
-"""``AbstractDataSet`` implementation to load/save image data."""
+"""``AbstractDataset`` implementation to load/save image data."""
 from __future__ import annotations
 
 from typing import Any

--- a/kedro-datasets/kedro_datasets/pillow/__init__.py
+++ b/kedro-datasets/kedro_datasets/pillow/__init__.py
@@ -1,6 +1,4 @@
 """``AbstractDataset`` implementation to load/save image data."""
-from __future__ import annotations
-
 from typing import Any
 
 import lazy_loader as lazy

--- a/kedro-datasets/kedro_datasets/pillow/__init__.py
+++ b/kedro-datasets/kedro_datasets/pillow/__init__.py
@@ -6,9 +6,8 @@ from typing import Any
 import lazy_loader as lazy
 
 # https://github.com/pylint-dev/pylint/issues/4300#issuecomment-1043601901
-ImageDataSet: type[ImageDataset]
 ImageDataset: Any
 
 __getattr__, __dir__, __all__ = lazy.attach(
-    __name__, submod_attrs={"image_dataset": ["ImageDataSet", "ImageDataset"]}
+    __name__, submod_attrs={"image_dataset": ["ImageDataset"]}
 )

--- a/kedro-datasets/kedro_datasets/pillow/image_dataset.py
+++ b/kedro-datasets/kedro_datasets/pillow/image_dataset.py
@@ -6,8 +6,9 @@ from pathlib import PurePosixPath
 from typing import Any, Dict
 
 import fsspec
-from PIL import Image
 from kedro.io.core import Version, get_filepath_str, get_protocol_and_path
+from PIL import Image
+
 from kedro_datasets._io import AbstractVersionedDataset, DatasetError
 
 

--- a/kedro-datasets/kedro_datasets/pillow/image_dataset.py
+++ b/kedro-datasets/kedro_datasets/pillow/image_dataset.py
@@ -1,16 +1,13 @@
 """``ImageDataset`` loads/saves image data as `numpy` from an underlying
 filesystem (e.g.: local, S3, GCS). It uses Pillow to handle image file.
 """
-import warnings
 from copy import deepcopy
 from pathlib import PurePosixPath
 from typing import Any, Dict
 
 import fsspec
-from kedro.io.core import Version, get_filepath_str, get_protocol_and_path
 from PIL import Image
-
-from kedro_datasets import KedroDeprecationWarning
+from kedro.io.core import Version, get_filepath_str, get_protocol_and_path
 from kedro_datasets._io import AbstractVersionedDataset, DatasetError
 
 
@@ -149,21 +146,3 @@ class ImageDataset(AbstractVersionedDataset[Image.Image, Image.Image]):
         """Invalidate underlying filesystem caches."""
         filepath = get_filepath_str(self._filepath, self._protocol)
         self._fs.invalidate_cache(filepath)
-
-
-_DEPRECATED_CLASSES = {
-    "ImageDataSet": ImageDataset,
-}
-
-
-def __getattr__(name):
-    if name in _DEPRECATED_CLASSES:
-        alias = _DEPRECATED_CLASSES[name]
-        warnings.warn(
-            f"{repr(name)} has been renamed to {repr(alias.__name__)}, "
-            f"and the alias will be removed in Kedro-Datasets 2.0.0",
-            KedroDeprecationWarning,
-            stacklevel=2,
-        )
-        return alias
-    raise AttributeError(f"module {repr(__name__)} has no attribute {repr(name)}")

--- a/kedro-datasets/kedro_datasets/plotly/__init__.py
+++ b/kedro-datasets/kedro_datasets/plotly/__init__.py
@@ -1,7 +1,5 @@
 """``AbstractDataset`` implementations to load/save a plotly figure from/to a JSON
 file."""
-from __future__ import annotations
-
 from typing import Any
 
 import lazy_loader as lazy

--- a/kedro-datasets/kedro_datasets/plotly/__init__.py
+++ b/kedro-datasets/kedro_datasets/plotly/__init__.py
@@ -7,15 +7,13 @@ from typing import Any
 import lazy_loader as lazy
 
 # https://github.com/pylint-dev/pylint/issues/4300#issuecomment-1043601901
-JSONDataSet: type[JSONDataset]
 JSONDataset: Any
-PlotlyDataSet: type[PlotlyDataset]
 PlotlyDataset: Any
 
 __getattr__, __dir__, __all__ = lazy.attach(
     __name__,
     submod_attrs={
-        "json_dataset": ["JSONDataSet", "JSONDataset"],
-        "plotly_dataset": ["PlotlyDataSet", "PlotlyDataset"],
+        "json_dataset": ["JSONDataset"],
+        "plotly_dataset": ["PlotlyDataset"],
     },
 )

--- a/kedro-datasets/kedro_datasets/plotly/json_dataset.py
+++ b/kedro-datasets/kedro_datasets/plotly/json_dataset.py
@@ -8,8 +8,9 @@ from typing import Any, Dict, Union
 import fsspec
 import plotly.io as pio
 from kedro.io.core import Version, get_filepath_str, get_protocol_and_path
-from kedro_datasets._io import AbstractVersionedDataset
 from plotly import graph_objects as go
+
+from kedro_datasets._io import AbstractVersionedDataset
 
 
 class JSONDataset(

--- a/kedro-datasets/kedro_datasets/plotly/json_dataset.py
+++ b/kedro-datasets/kedro_datasets/plotly/json_dataset.py
@@ -1,7 +1,6 @@
 """``JSONDataset`` loads/saves a plotly figure from/to a JSON file using an underlying
 filesystem (e.g.: local, S3, GCS).
 """
-import warnings
 from copy import deepcopy
 from pathlib import PurePosixPath
 from typing import Any, Dict, Union
@@ -9,10 +8,8 @@ from typing import Any, Dict, Union
 import fsspec
 import plotly.io as pio
 from kedro.io.core import Version, get_filepath_str, get_protocol_and_path
-from plotly import graph_objects as go
-
-from kedro_datasets import KedroDeprecationWarning
 from kedro_datasets._io import AbstractVersionedDataset
+from plotly import graph_objects as go
 
 
 class JSONDataset(
@@ -165,21 +162,3 @@ class JSONDataset(
     def _invalidate_cache(self) -> None:
         filepath = get_filepath_str(self._filepath, self._protocol)
         self._fs.invalidate_cache(filepath)
-
-
-_DEPRECATED_CLASSES = {
-    "JSONDataSet": JSONDataset,
-}
-
-
-def __getattr__(name):
-    if name in _DEPRECATED_CLASSES:
-        alias = _DEPRECATED_CLASSES[name]
-        warnings.warn(
-            f"{repr(name)} has been renamed to {repr(alias.__name__)}, "
-            f"and the alias will be removed in Kedro-Datasets 2.0.0",
-            KedroDeprecationWarning,
-            stacklevel=2,
-        )
-        return alias
-    raise AttributeError(f"module {repr(__name__)} has no attribute {repr(name)}")

--- a/kedro-datasets/kedro_datasets/plotly/plotly_dataset.py
+++ b/kedro-datasets/kedro_datasets/plotly/plotly_dataset.py
@@ -2,17 +2,14 @@
 file using an underlying filesystem (e.g.: local, S3, GCS). It loads the JSON into a
 plotly figure.
 """
-import warnings
 from copy import deepcopy
 from typing import Any, Dict
 
 import pandas as pd
 import plotly.express as px
 from kedro.io.core import Version
-from plotly import graph_objects as go
-
-from kedro_datasets import KedroDeprecationWarning
 from kedro_datasets.plotly.json_dataset import JSONDataset
+from plotly import graph_objects as go
 
 
 class PlotlyDataset(JSONDataset):
@@ -142,21 +139,3 @@ class PlotlyDataset(JSONDataset):
         fig.update_layout(template=self._plotly_args.get("theme", "plotly"))
         fig.update_layout(self._plotly_args.get("layout", {}))
         return fig
-
-
-_DEPRECATED_CLASSES = {
-    "PlotlyDataSet": PlotlyDataset,
-}
-
-
-def __getattr__(name):
-    if name in _DEPRECATED_CLASSES:
-        alias = _DEPRECATED_CLASSES[name]
-        warnings.warn(
-            f"{repr(name)} has been renamed to {repr(alias.__name__)}, "
-            f"and the alias will be removed in Kedro-Datasets 2.0.0",
-            KedroDeprecationWarning,
-            stacklevel=2,
-        )
-        return alias
-    raise AttributeError(f"module {repr(__name__)} has no attribute {repr(name)}")

--- a/kedro-datasets/kedro_datasets/plotly/plotly_dataset.py
+++ b/kedro-datasets/kedro_datasets/plotly/plotly_dataset.py
@@ -8,8 +8,9 @@ from typing import Any, Dict
 import pandas as pd
 import plotly.express as px
 from kedro.io.core import Version
-from kedro_datasets.plotly.json_dataset import JSONDataset
 from plotly import graph_objects as go
+
+from kedro_datasets.plotly.json_dataset import JSONDataset
 
 
 class PlotlyDataset(JSONDataset):

--- a/kedro-datasets/kedro_datasets/polars/__init__.py
+++ b/kedro-datasets/kedro_datasets/polars/__init__.py
@@ -1,6 +1,4 @@
 """``AbstractDataset`` implementations that produce pandas DataFrames."""
-from __future__ import annotations
-
 from typing import Any
 
 import lazy_loader as lazy

--- a/kedro-datasets/kedro_datasets/polars/__init__.py
+++ b/kedro-datasets/kedro_datasets/polars/__init__.py
@@ -6,21 +6,16 @@ from typing import Any
 import lazy_loader as lazy
 
 # https://github.com/pylint-dev/pylint/issues/4300#issuecomment-1043601901
-CSVDataSet: type[CSVDataset]
 CSVDataset: Any
 EagerPolarsDataset: Any
-GenericDataSet: type[EagerPolarsDataset]
-GenericDataset: type[EagerPolarsDataset]
 LazyPolarsDataset: Any
 
 __getattr__, __dir__, __all__ = lazy.attach(
     __name__,
     submod_attrs={
-        "csv_dataset": ["CSVDataSet", "CSVDataset"],
+        "csv_dataset": ["CSVDataset"],
         "eager_polars_dataset": [
             "EagerPolarsDataset",
-            "GenericDataSet",
-            "GenericDataset",
         ],
         "lazy_polars_dataset": ["LazyPolarsDataset"],
     },

--- a/kedro-datasets/kedro_datasets/polars/csv_dataset.py
+++ b/kedro-datasets/kedro_datasets/polars/csv_dataset.py
@@ -2,7 +2,6 @@
 filesystem (e.g.: local, S3, GCS). It uses polars to handle the CSV file.
 """
 import logging
-import warnings
 from copy import deepcopy
 from io import BytesIO
 from pathlib import PurePosixPath
@@ -17,7 +16,6 @@ from kedro.io.core import (
     get_protocol_and_path,
 )
 
-from kedro_datasets import KedroDeprecationWarning
 from kedro_datasets._io import AbstractVersionedDataset, DatasetError
 
 logger = logging.getLogger(__name__)

--- a/kedro-datasets/kedro_datasets/polars/csv_dataset.py
+++ b/kedro-datasets/kedro_datasets/polars/csv_dataset.py
@@ -195,21 +195,3 @@ class CSVDataset(AbstractVersionedDataset[pl.DataFrame, pl.DataFrame]):
         """Invalidate underlying filesystem caches."""
         filepath = get_filepath_str(self._filepath, self._protocol)
         self._fs.invalidate_cache(filepath)
-
-
-_DEPRECATED_CLASSES = {
-    "CSVDataSet": CSVDataset,
-}
-
-
-def __getattr__(name):
-    if name in _DEPRECATED_CLASSES:
-        alias = _DEPRECATED_CLASSES[name]
-        warnings.warn(
-            f"{repr(name)} has been renamed to {repr(alias.__name__)}, "
-            f"and the alias will be removed in Kedro-Datasets 2.0.0",
-            KedroDeprecationWarning,
-            stacklevel=2,
-        )
-        return alias
-    raise AttributeError(f"module {repr(__name__)} has no attribute {repr(name)}")

--- a/kedro-datasets/kedro_datasets/polars/eager_polars_dataset.py
+++ b/kedro-datasets/kedro_datasets/polars/eager_polars_dataset.py
@@ -2,7 +2,6 @@
 filesystem (e.g.: local, S3, GCS). It uses polars to handle the
 type of read/write target.
 """
-import warnings
 from copy import deepcopy
 from io import BytesIO
 from pathlib import PurePosixPath
@@ -12,7 +11,6 @@ import fsspec
 import polars as pl
 from kedro.io.core import Version, get_filepath_str, get_protocol_and_path
 
-from kedro_datasets import KedroDeprecationWarning
 from kedro_datasets._io import AbstractVersionedDataset, DatasetError
 
 

--- a/kedro-datasets/kedro_datasets/polars/eager_polars_dataset.py
+++ b/kedro-datasets/kedro_datasets/polars/eager_polars_dataset.py
@@ -197,22 +197,3 @@ class EagerPolarsDataset(AbstractVersionedDataset[pl.DataFrame, pl.DataFrame]):
         """Invalidate underlying filesystem caches."""
         filepath = get_filepath_str(self._filepath, self._protocol)
         self._fs.invalidate_cache(filepath)
-
-
-_DEPRECATED_CLASSES = {
-    "GenericDataSet": EagerPolarsDataset,
-    "GenericDataset": EagerPolarsDataset,
-}
-
-
-def __getattr__(name):
-    if name in _DEPRECATED_CLASSES:
-        alias = _DEPRECATED_CLASSES[name]
-        warnings.warn(
-            f"{repr(name)} has been renamed to {repr(alias.__name__)}, "
-            f"and the alias will be removed in Kedro-Datasets 2.0.0",
-            KedroDeprecationWarning,
-            stacklevel=2,
-        )
-        return alias
-    raise AttributeError(f"module {repr(__name__)} has no attribute {repr(name)}")

--- a/kedro-datasets/kedro_datasets/redis/__init__.py
+++ b/kedro-datasets/kedro_datasets/redis/__init__.py
@@ -1,6 +1,4 @@
 """``AbstractDataset`` implementation to load/save data from/to a Redis database."""
-from __future__ import annotations
-
 from typing import Any
 
 import lazy_loader as lazy

--- a/kedro-datasets/kedro_datasets/redis/__init__.py
+++ b/kedro-datasets/kedro_datasets/redis/__init__.py
@@ -6,9 +6,8 @@ from typing import Any
 import lazy_loader as lazy
 
 # https://github.com/pylint-dev/pylint/issues/4300#issuecomment-1043601901
-PickleDataSet: type[PickleDataset]
 PickleDataset: Any
 
 __getattr__, __dir__, __all__ = lazy.attach(
-    __name__, submod_attrs={"redis_dataset": ["PickleDataSet", "PickleDataset"]}
+    __name__, submod_attrs={"redis_dataset": ["PickleDataset"]}
 )

--- a/kedro-datasets/kedro_datasets/redis/redis_dataset.py
+++ b/kedro-datasets/kedro_datasets/redis/redis_dataset.py
@@ -3,13 +3,10 @@ functionality is supported by the redis library, so it supports all allowed
 options for instantiating the redis app ``from_url`` and setting a value."""
 import importlib
 import os
-import warnings
 from copy import deepcopy
 from typing import Any, Dict
 
 import redis
-
-from kedro_datasets import KedroDeprecationWarning
 from kedro_datasets._io import AbstractDataset, DatasetError
 
 
@@ -195,21 +192,3 @@ class PickleDataset(AbstractDataset[Any, Any]):
             raise DatasetError(
                 f"The existence of key {self._key} could not be established due to: {exc}"
             ) from exc
-
-
-_DEPRECATED_CLASSES = {
-    "PickleDataSet": PickleDataset,
-}
-
-
-def __getattr__(name):
-    if name in _DEPRECATED_CLASSES:
-        alias = _DEPRECATED_CLASSES[name]
-        warnings.warn(
-            f"{repr(name)} has been renamed to {repr(alias.__name__)}, "
-            f"and the alias will be removed in Kedro-Datasets 2.0.0",
-            KedroDeprecationWarning,
-            stacklevel=2,
-        )
-        return alias
-    raise AttributeError(f"module {repr(__name__)} has no attribute {repr(name)}")

--- a/kedro-datasets/kedro_datasets/redis/redis_dataset.py
+++ b/kedro-datasets/kedro_datasets/redis/redis_dataset.py
@@ -7,6 +7,7 @@ from copy import deepcopy
 from typing import Any, Dict
 
 import redis
+
 from kedro_datasets._io import AbstractDataset, DatasetError
 
 

--- a/kedro-datasets/kedro_datasets/snowflake/__init__.py
+++ b/kedro-datasets/kedro_datasets/snowflake/__init__.py
@@ -6,10 +6,9 @@ from typing import Any
 import lazy_loader as lazy
 
 # https://github.com/pylint-dev/pylint/issues/4300#issuecomment-1043601901
-SnowparkTableDataSet: type[SnowparkTableDataset]
 SnowparkTableDataset: Any
 
 __getattr__, __dir__, __all__ = lazy.attach(
     __name__,
-    submod_attrs={"snowpark_dataset": ["SnowparkTableDataSet", "SnowparkTableDataset"]},
+    submod_attrs={"snowpark_dataset": ["SnowparkTableDataset"]},
 )

--- a/kedro-datasets/kedro_datasets/snowflake/__init__.py
+++ b/kedro-datasets/kedro_datasets/snowflake/__init__.py
@@ -1,6 +1,4 @@
 """Provides I/O modules for Snowflake."""
-from __future__ import annotations
-
 from typing import Any
 
 import lazy_loader as lazy

--- a/kedro-datasets/kedro_datasets/snowflake/snowpark_dataset.py
+++ b/kedro-datasets/kedro_datasets/snowflake/snowpark_dataset.py
@@ -5,6 +5,7 @@ from copy import deepcopy
 from typing import Any, Dict
 
 import snowflake.snowpark as sp
+
 from kedro_datasets._io import AbstractDataset, DatasetError
 
 logger = logging.getLogger(__name__)

--- a/kedro-datasets/kedro_datasets/snowflake/snowpark_dataset.py
+++ b/kedro-datasets/kedro_datasets/snowflake/snowpark_dataset.py
@@ -1,13 +1,10 @@
 """``AbstractDataset`` implementation to access Snowflake using Snowpark dataframes
 """
 import logging
-import warnings
 from copy import deepcopy
 from typing import Any, Dict
 
 import snowflake.snowpark as sp
-
-from kedro_datasets import KedroDeprecationWarning
 from kedro_datasets._io import AbstractDataset, DatasetError
 
 logger = logging.getLogger(__name__)
@@ -246,21 +243,3 @@ class SnowparkTableDataset(AbstractDataset):
             )
         ).collect()
         return rows[0][0] == 1
-
-
-_DEPRECATED_CLASSES = {
-    "SnowparkTableDataSet": SnowparkTableDataset,
-}
-
-
-def __getattr__(name):
-    if name in _DEPRECATED_CLASSES:
-        alias = _DEPRECATED_CLASSES[name]
-        warnings.warn(
-            f"{repr(name)} has been renamed to {repr(alias.__name__)}, "
-            f"and the alias will be removed in Kedro-Datasets 2.0.0",
-            KedroDeprecationWarning,
-            stacklevel=2,
-        )
-        return alias
-    raise AttributeError(f"module {repr(__name__)} has no attribute {repr(name)}")

--- a/kedro-datasets/kedro_datasets/spark/README.md
+++ b/kedro-datasets/kedro_datasets/spark/README.md
@@ -1,6 +1,6 @@
 # Spark Streaming
 
-``SparkStreamingDataSet`` loads and saves data to streaming DataFrames.
+``SparkStreamingDataset`` loads and saves data to streaming DataFrames.
 See [Spark Structured Streaming](https://spark.apache.org/docs/latest/structured-streaming-programming-guide.html) for details.
 
 To work with multiple streaming nodes, 2 hooks are required for:

--- a/kedro-datasets/kedro_datasets/spark/__init__.py
+++ b/kedro-datasets/kedro_datasets/spark/__init__.py
@@ -1,6 +1,4 @@
 """Provides I/O modules for Apache Spark."""
-from __future__ import annotations
-
 from typing import Any
 
 import lazy_loader as lazy

--- a/kedro-datasets/kedro_datasets/spark/__init__.py
+++ b/kedro-datasets/kedro_datasets/spark/__init__.py
@@ -6,24 +6,19 @@ from typing import Any
 import lazy_loader as lazy
 
 # https://github.com/pylint-dev/pylint/issues/4300#issuecomment-1043601901
-DeltaTableDataSet: type[DeltaTableDataset]
 DeltaTableDataset: Any
-SparkDataSet: type[SparkDataset]
 SparkDataset: Any
-SparkHiveDataSet: type[SparkHiveDataset]
 SparkHiveDataset: Any
-SparkJDBCDataSet: type[SparkJDBCDataset]
 SparkJDBCDataset: Any
-SparkStreamingDataSet: type[SparkStreamingDataset]
 SparkStreamingDataset: Any
 
 __getattr__, __dir__, __all__ = lazy.attach(
     __name__,
     submod_attrs={
-        "deltatable_dataset": ["DeltaTableDataSet", "DeltaTableDataset"],
-        "spark_dataset": ["SparkDataSet", "SparkDataset"],
-        "spark_hive_dataset": ["SparkHiveDataSet", "SparkHiveDataset"],
-        "spark_jdbc_dataset": ["SparkJDBCDataSet", "SparkJDBCDataset"],
-        "spark_streaming_dataset": ["SparkStreamingDataSet", "SparkStreamingDataset"],
+        "deltatable_dataset": ["DeltaTableDataset"],
+        "spark_dataset": ["SparkDataset"],
+        "spark_hive_dataset": ["SparkHiveDataset"],
+        "spark_jdbc_dataset": ["SparkJDBCDataset"],
+        "spark_streaming_dataset": ["SparkStreamingDataset"],
     },
 )

--- a/kedro-datasets/kedro_datasets/spark/deltatable_dataset.py
+++ b/kedro-datasets/kedro_datasets/spark/deltatable_dataset.py
@@ -5,13 +5,14 @@ from pathlib import PurePosixPath
 from typing import Any, Dict, NoReturn
 
 from delta.tables import DeltaTable
+from pyspark.sql.utils import AnalysisException
+
 from kedro_datasets._io import AbstractDataset, DatasetError
 from kedro_datasets.spark.spark_dataset import (
     _get_spark,
     _split_filepath,
     _strip_dbfs_prefix,
 )
-from pyspark.sql.utils import AnalysisException
 
 
 class DeltaTableDataset(AbstractDataset[None, DeltaTable]):

--- a/kedro-datasets/kedro_datasets/spark/deltatable_dataset.py
+++ b/kedro-datasets/kedro_datasets/spark/deltatable_dataset.py
@@ -1,20 +1,17 @@
 """``AbstractDataset`` implementation to access DeltaTables using
 ``delta-spark``.
 """
-import warnings
 from pathlib import PurePosixPath
 from typing import Any, Dict, NoReturn
 
 from delta.tables import DeltaTable
-from pyspark.sql.utils import AnalysisException
-
-from kedro_datasets import KedroDeprecationWarning
 from kedro_datasets._io import AbstractDataset, DatasetError
 from kedro_datasets.spark.spark_dataset import (
     _get_spark,
     _split_filepath,
     _strip_dbfs_prefix,
 )
+from pyspark.sql.utils import AnalysisException
 
 
 class DeltaTableDataset(AbstractDataset[None, DeltaTable]):
@@ -107,21 +104,3 @@ class DeltaTableDataset(AbstractDataset[None, DeltaTable]):
 
     def _describe(self):
         return {"filepath": str(self._filepath), "fs_prefix": self._fs_prefix}
-
-
-_DEPRECATED_CLASSES = {
-    "DeltaTableDataSet": DeltaTableDataset,
-}
-
-
-def __getattr__(name):
-    if name in _DEPRECATED_CLASSES:
-        alias = _DEPRECATED_CLASSES[name]
-        warnings.warn(
-            f"{repr(name)} has been renamed to {repr(alias.__name__)}, "
-            f"and the alias will be removed in Kedro-Datasets 2.0.0",
-            KedroDeprecationWarning,
-            stacklevel=2,
-        )
-        return alias
-    raise AttributeError(f"module {repr(__name__)} has no attribute {repr(name)}")

--- a/kedro-datasets/kedro_datasets/spark/spark_dataset.py
+++ b/kedro-datasets/kedro_datasets/spark/spark_dataset.py
@@ -19,11 +19,12 @@ from kedro.io.core import (
     get_filepath_str,
     get_protocol_and_path,
 )
-from kedro_datasets._io import AbstractVersionedDataset, DatasetError
 from pyspark.sql import DataFrame, SparkSession
 from pyspark.sql.types import StructType
 from pyspark.sql.utils import AnalysisException
 from s3fs import S3FileSystem
+
+from kedro_datasets._io import AbstractVersionedDataset, DatasetError
 
 logger = logging.getLogger(__name__)
 

--- a/kedro-datasets/kedro_datasets/spark/spark_dataset.py
+++ b/kedro-datasets/kedro_datasets/spark/spark_dataset.py
@@ -4,7 +4,6 @@
 import json
 import logging
 import os
-import warnings
 from copy import deepcopy
 from fnmatch import fnmatch
 from functools import partial
@@ -20,13 +19,11 @@ from kedro.io.core import (
     get_filepath_str,
     get_protocol_and_path,
 )
+from kedro_datasets._io import AbstractVersionedDataset, DatasetError
 from pyspark.sql import DataFrame, SparkSession
 from pyspark.sql.types import StructType
 from pyspark.sql.utils import AnalysisException
 from s3fs import S3FileSystem
-
-from kedro_datasets import KedroDeprecationWarning
-from kedro_datasets._io import AbstractVersionedDataset, DatasetError
 
 logger = logging.getLogger(__name__)
 
@@ -455,21 +452,3 @@ class SparkDataset(AbstractVersionedDataset[DataFrame, DataFrame]):
                 f"with mode '{write_mode}' on 'SparkDataset'. "
                 f"Please use 'spark.DeltaTableDataset' instead."
             )
-
-
-_DEPRECATED_CLASSES = {
-    "SparkDataSet": SparkDataset,
-}
-
-
-def __getattr__(name):
-    if name in _DEPRECATED_CLASSES:
-        alias = _DEPRECATED_CLASSES[name]
-        warnings.warn(
-            f"{repr(name)} has been renamed to {repr(alias.__name__)}, "
-            f"and the alias will be removed in Kedro-Datasets 2.0.0",
-            KedroDeprecationWarning,
-            stacklevel=2,
-        )
-        return alias
-    raise AttributeError(f"module {repr(__name__)} has no attribute {repr(name)}")

--- a/kedro-datasets/kedro_datasets/spark/spark_hive_dataset.py
+++ b/kedro-datasets/kedro_datasets/spark/spark_hive_dataset.py
@@ -5,10 +5,11 @@ import pickle
 from copy import deepcopy
 from typing import Any, Dict, List
 
-from kedro_datasets._io import AbstractDataset, DatasetError
-from kedro_datasets.spark.spark_dataset import _get_spark
 from pyspark.sql import DataFrame, Window
 from pyspark.sql.functions import col, lit, row_number
+
+from kedro_datasets._io import AbstractDataset, DatasetError
+from kedro_datasets.spark.spark_dataset import _get_spark
 
 
 class SparkHiveDataset(AbstractDataset[DataFrame, DataFrame]):

--- a/kedro-datasets/kedro_datasets/spark/spark_hive_dataset.py
+++ b/kedro-datasets/kedro_datasets/spark/spark_hive_dataset.py
@@ -2,16 +2,13 @@
 ``pyspark`` on Apache Hive.
 """
 import pickle
-import warnings
 from copy import deepcopy
 from typing import Any, Dict, List
 
-from pyspark.sql import DataFrame, Window
-from pyspark.sql.functions import col, lit, row_number
-
-from kedro_datasets import KedroDeprecationWarning
 from kedro_datasets._io import AbstractDataset, DatasetError
 from kedro_datasets.spark.spark_dataset import _get_spark
+from pyspark.sql import DataFrame, Window
+from pyspark.sql.functions import col, lit, row_number
 
 
 class SparkHiveDataset(AbstractDataset[DataFrame, DataFrame]):
@@ -210,21 +207,3 @@ class SparkHiveDataset(AbstractDataset[DataFrame, DataFrame]):
             "PySpark datasets objects cannot be pickled "
             "or serialised as Python objects."
         )
-
-
-_DEPRECATED_CLASSES = {
-    "SparkHiveDataSet": SparkHiveDataset,
-}
-
-
-def __getattr__(name):
-    if name in _DEPRECATED_CLASSES:
-        alias = _DEPRECATED_CLASSES[name]
-        warnings.warn(
-            f"{repr(name)} has been renamed to {repr(alias.__name__)}, "
-            f"and the alias will be removed in Kedro-Datasets 2.0.0",
-            KedroDeprecationWarning,
-            stacklevel=2,
-        )
-        return alias
-    raise AttributeError(f"module {repr(__name__)} has no attribute {repr(name)}")

--- a/kedro-datasets/kedro_datasets/spark/spark_jdbc_dataset.py
+++ b/kedro-datasets/kedro_datasets/spark/spark_jdbc_dataset.py
@@ -2,9 +2,10 @@
 from copy import deepcopy
 from typing import Any, Dict
 
+from pyspark.sql import DataFrame
+
 from kedro_datasets._io import AbstractDataset, DatasetError
 from kedro_datasets.spark.spark_dataset import _get_spark
-from pyspark.sql import DataFrame
 
 
 class SparkJDBCDataset(AbstractDataset[DataFrame, DataFrame]):

--- a/kedro-datasets/kedro_datasets/spark/spark_jdbc_dataset.py
+++ b/kedro-datasets/kedro_datasets/spark/spark_jdbc_dataset.py
@@ -1,13 +1,10 @@
 """SparkJDBCDataset to load and save a PySpark DataFrame via JDBC."""
-import warnings
 from copy import deepcopy
 from typing import Any, Dict
 
-from pyspark.sql import DataFrame
-
-from kedro_datasets import KedroDeprecationWarning
 from kedro_datasets._io import AbstractDataset, DatasetError
 from kedro_datasets.spark.spark_dataset import _get_spark
+from pyspark.sql import DataFrame
 
 
 class SparkJDBCDataset(AbstractDataset[DataFrame, DataFrame]):
@@ -175,21 +172,3 @@ class SparkJDBCDataset(AbstractDataset[DataFrame, DataFrame]):
 
     def _save(self, data: DataFrame) -> None:
         return data.write.jdbc(self._url, self._table, **self._save_args)
-
-
-_DEPRECATED_CLASSES = {
-    "SparkJDBCDataSet": SparkJDBCDataset,
-}
-
-
-def __getattr__(name):
-    if name in _DEPRECATED_CLASSES:
-        alias = _DEPRECATED_CLASSES[name]
-        warnings.warn(
-            f"{repr(name)} has been renamed to {repr(alias.__name__)}, "
-            f"and the alias will be removed in Kedro-Datasets 2.0.0",
-            KedroDeprecationWarning,
-            stacklevel=2,
-        )
-        return alias
-    raise AttributeError(f"module {repr(__name__)} has no attribute {repr(name)}")

--- a/kedro-datasets/kedro_datasets/spark/spark_streaming_dataset.py
+++ b/kedro-datasets/kedro_datasets/spark/spark_streaming_dataset.py
@@ -1,13 +1,8 @@
 """SparkStreamingDataset to load and save a PySpark Streaming DataFrame."""
-import warnings
 from copy import deepcopy
 from pathlib import PurePosixPath
 from typing import Any, Dict
 
-from pyspark.sql import DataFrame
-from pyspark.sql.utils import AnalysisException
-
-from kedro_datasets import KedroDeprecationWarning
 from kedro_datasets._io import AbstractDataset
 from kedro_datasets.spark.spark_dataset import (
     SparkDataset,
@@ -15,6 +10,8 @@ from kedro_datasets.spark.spark_dataset import (
     _split_filepath,
     _strip_dbfs_prefix,
 )
+from pyspark.sql import DataFrame
+from pyspark.sql.utils import AnalysisException
 
 
 class SparkStreamingDataset(AbstractDataset):
@@ -156,21 +153,3 @@ class SparkStreamingDataset(AbstractDataset):
                 return False
             raise
         return True
-
-
-_DEPRECATED_CLASSES = {
-    "SparkStreamingDataSet": SparkStreamingDataset,
-}
-
-
-def __getattr__(name):
-    if name in _DEPRECATED_CLASSES:
-        alias = _DEPRECATED_CLASSES[name]
-        warnings.warn(
-            f"{repr(name)} has been renamed to {repr(alias.__name__)}, "
-            f"and the alias will be removed in Kedro-Datasets 2.0.0",
-            KedroDeprecationWarning,
-            stacklevel=2,
-        )
-        return alias
-    raise AttributeError(f"module {repr(__name__)} has no attribute {repr(name)}")

--- a/kedro-datasets/kedro_datasets/spark/spark_streaming_dataset.py
+++ b/kedro-datasets/kedro_datasets/spark/spark_streaming_dataset.py
@@ -3,6 +3,9 @@ from copy import deepcopy
 from pathlib import PurePosixPath
 from typing import Any, Dict
 
+from pyspark.sql import DataFrame
+from pyspark.sql.utils import AnalysisException
+
 from kedro_datasets._io import AbstractDataset
 from kedro_datasets.spark.spark_dataset import (
     SparkDataset,
@@ -10,8 +13,6 @@ from kedro_datasets.spark.spark_dataset import (
     _split_filepath,
     _strip_dbfs_prefix,
 )
-from pyspark.sql import DataFrame
-from pyspark.sql.utils import AnalysisException
 
 
 class SparkStreamingDataset(AbstractDataset):

--- a/kedro-datasets/kedro_datasets/svmlight/__init__.py
+++ b/kedro-datasets/kedro_datasets/svmlight/__init__.py
@@ -1,7 +1,5 @@
 """``AbstractDataset`` implementation to load/save data from/to a
 svmlight/libsvm sparse data file."""
-from __future__ import annotations
-
 from typing import Any
 
 import lazy_loader as lazy

--- a/kedro-datasets/kedro_datasets/svmlight/__init__.py
+++ b/kedro-datasets/kedro_datasets/svmlight/__init__.py
@@ -7,9 +7,8 @@ from typing import Any
 import lazy_loader as lazy
 
 # https://github.com/pylint-dev/pylint/issues/4300#issuecomment-1043601901
-SVMLightDataSet: type[SVMLightDataset]
 SVMLightDataset: Any
 
 __getattr__, __dir__, __all__ = lazy.attach(
-    __name__, submod_attrs={"svmlight_dataset": ["SVMLightDataSet", "SVMLightDataset"]}
+    __name__, submod_attrs={"svmlight_dataset": ["SVMLightDataset"]}
 )

--- a/kedro-datasets/kedro_datasets/svmlight/svmlight_dataset.py
+++ b/kedro-datasets/kedro_datasets/svmlight/svmlight_dataset.py
@@ -8,10 +8,11 @@ from typing import Any, Dict, Optional, Tuple, Union
 
 import fsspec
 from kedro.io.core import Version, get_filepath_str, get_protocol_and_path
-from kedro_datasets._io import AbstractVersionedDataset, DatasetError
 from numpy import ndarray
 from scipy.sparse.csr import csr_matrix
 from sklearn.datasets import dump_svmlight_file, load_svmlight_file
+
+from kedro_datasets._io import AbstractVersionedDataset, DatasetError
 
 # NOTE: kedro.extras.datasets will be removed in Kedro 0.19.0.
 # Any contribution to datasets should be made in kedro-datasets

--- a/kedro-datasets/kedro_datasets/svmlight/svmlight_dataset.py
+++ b/kedro-datasets/kedro_datasets/svmlight/svmlight_dataset.py
@@ -2,19 +2,16 @@
 underlying filesystem (e.g.: local, S3, GCS). It uses sklearn functions
 ``dump_svmlight_file`` to save and ``load_svmlight_file`` to load a file.
 """
-import warnings
 from copy import deepcopy
 from pathlib import PurePosixPath
 from typing import Any, Dict, Optional, Tuple, Union
 
 import fsspec
 from kedro.io.core import Version, get_filepath_str, get_protocol_and_path
+from kedro_datasets._io import AbstractVersionedDataset, DatasetError
 from numpy import ndarray
 from scipy.sparse.csr import csr_matrix
 from sklearn.datasets import dump_svmlight_file, load_svmlight_file
-
-from kedro_datasets import KedroDeprecationWarning
-from kedro_datasets._io import AbstractVersionedDataset, DatasetError
 
 # NOTE: kedro.extras.datasets will be removed in Kedro 0.19.0.
 # Any contribution to datasets should be made in kedro-datasets
@@ -191,21 +188,3 @@ class SVMLightDataset(AbstractVersionedDataset[_DI, _DO]):
         """Invalidate underlying filesystem caches."""
         filepath = get_filepath_str(self._filepath, self._protocol)
         self._fs.invalidate_cache(filepath)
-
-
-_DEPRECATED_CLASSES = {
-    "SVMLightDataSet": SVMLightDataset,
-}
-
-
-def __getattr__(name):
-    if name in _DEPRECATED_CLASSES:
-        alias = _DEPRECATED_CLASSES[name]
-        warnings.warn(
-            f"{repr(name)} has been renamed to {repr(alias.__name__)}, "
-            f"and the alias will be removed in Kedro-Datasets 2.0.0",
-            KedroDeprecationWarning,
-            stacklevel=2,
-        )
-        return alias
-    raise AttributeError(f"module {repr(__name__)} has no attribute {repr(name)}")

--- a/kedro-datasets/kedro_datasets/tensorflow/README.md
+++ b/kedro-datasets/kedro_datasets/tensorflow/README.md
@@ -1,4 +1,4 @@
-# TensorFlowModelDataSet
+# TensorFlowModelDataset
 
 ``TensorflowModelDataset`` loads and saves TensorFlow models.
 The underlying functionality is supported by, and passes input arguments to TensorFlow 2.X load_model and save_model methods. Only TF2 is currently supported for saving and loading, V1 requires HDF5 and serialises differently.
@@ -8,9 +8,9 @@ The underlying functionality is supported by, and passes input arguments to Tens
 import numpy as np
 import tensorflow as tf
 
-from kedro_datasets.tensorflow import TensorFlowModelDataSet
+from kedro_datasets.tensorflow import TensorFlowModelDataset
 
-data_set = TensorFlowModelDataSet("tf_model_dirname")
+data_set = TensorFlowModelDataset("tf_model_dirname")
 
 model = tf.keras.Model()
 predictions = model.predict([...])
@@ -25,7 +25,7 @@ np.testing.assert_allclose(predictions, new_predictions, rtol=1e-6, atol=1e-6)
 #### Example catalog.yml:
 ```yaml
 example_tensorflow_data:
-  type: tensorflow.TensorFlowModelDataSet
+  type: tensorflow.TensorFlowModelDataset
   filepath: data/08_reporting/tf_model_dirname
   load_args:
     tf_device: "/CPU:0"  # optional

--- a/kedro-datasets/kedro_datasets/tensorflow/__init__.py
+++ b/kedro-datasets/kedro_datasets/tensorflow/__init__.py
@@ -10,7 +10,5 @@ TensorFlowModelDataset: Any
 
 __getattr__, __dir__, __all__ = lazy.attach(
     __name__,
-    submod_attrs={
-        "tensorflow_model_dataset": ["TensorFlowModelDataset"]
-    },
+    submod_attrs={"tensorflow_model_dataset": ["TensorFlowModelDataset"]},
 )

--- a/kedro-datasets/kedro_datasets/tensorflow/__init__.py
+++ b/kedro-datasets/kedro_datasets/tensorflow/__init__.py
@@ -6,12 +6,11 @@ from typing import Any
 import lazy_loader as lazy
 
 # https://github.com/pylint-dev/pylint/issues/4300#issuecomment-1043601901
-TensorFlowModelDataSet: type[TensorFlowModelDataset]
 TensorFlowModelDataset: Any
 
 __getattr__, __dir__, __all__ = lazy.attach(
     __name__,
     submod_attrs={
-        "tensorflow_model_dataset": ["TensorFlowModelDataSet", "TensorFlowModelDataset"]
+        "tensorflow_model_dataset": ["TensorFlowModelDataset"]
     },
 )

--- a/kedro-datasets/kedro_datasets/tensorflow/__init__.py
+++ b/kedro-datasets/kedro_datasets/tensorflow/__init__.py
@@ -1,6 +1,4 @@
 """Provides I/O for TensorFlow models."""
-from __future__ import annotations
-
 from typing import Any
 
 import lazy_loader as lazy

--- a/kedro-datasets/kedro_datasets/tensorflow/tensorflow_model_dataset.py
+++ b/kedro-datasets/kedro_datasets/tensorflow/tensorflow_model_dataset.py
@@ -3,15 +3,12 @@ TensorFlow models.
 """
 import copy
 import tempfile
-import warnings
 from pathlib import PurePath, PurePosixPath
 from typing import Any, Dict
 
 import fsspec
 import tensorflow as tf
 from kedro.io.core import Version, get_filepath_str, get_protocol_and_path
-
-from kedro_datasets import KedroDeprecationWarning
 from kedro_datasets._io import AbstractVersionedDataset, DatasetError
 
 TEMPORARY_H5_FILE = "tmp_tensorflow_model.h5"
@@ -189,23 +186,3 @@ class TensorFlowModelDataset(AbstractVersionedDataset[tf.keras.Model, tf.keras.M
         """Invalidate underlying filesystem caches."""
         filepath = get_filepath_str(self._filepath, self._protocol)
         self._fs.invalidate_cache(filepath)
-
-
-_DEPRECATED_CLASSES = {
-    "TensorFlowModelDataSet": TensorFlowModelDataset,
-}
-
-
-def __getattr__(name):
-    if name in _DEPRECATED_CLASSES:
-        alias = _DEPRECATED_CLASSES[name]
-        warnings.warn(
-            f"{repr(name)} has been renamed to {repr(alias.__name__)}, "
-            f"and the alias will be removed in Kedro-Datasets 2.0.0",
-            KedroDeprecationWarning,
-            stacklevel=2,
-        )
-        return alias
-    raise AttributeError(  # pragma: no cover
-        f"module {repr(__name__)} has no attribute {repr(name)}"
-    )

--- a/kedro-datasets/kedro_datasets/tensorflow/tensorflow_model_dataset.py
+++ b/kedro-datasets/kedro_datasets/tensorflow/tensorflow_model_dataset.py
@@ -9,6 +9,7 @@ from typing import Any, Dict
 import fsspec
 import tensorflow as tf
 from kedro.io.core import Version, get_filepath_str, get_protocol_and_path
+
 from kedro_datasets._io import AbstractVersionedDataset, DatasetError
 
 TEMPORARY_H5_FILE = "tmp_tensorflow_model.h5"

--- a/kedro-datasets/kedro_datasets/text/__init__.py
+++ b/kedro-datasets/kedro_datasets/text/__init__.py
@@ -1,6 +1,4 @@
 """``AbstractDataset`` implementation to load/save data from/to a text file."""
-from __future__ import annotations
-
 from typing import Any
 
 import lazy_loader as lazy

--- a/kedro-datasets/kedro_datasets/text/__init__.py
+++ b/kedro-datasets/kedro_datasets/text/__init__.py
@@ -6,9 +6,8 @@ from typing import Any
 import lazy_loader as lazy
 
 # https://github.com/pylint-dev/pylint/issues/4300#issuecomment-1043601901
-TextDataSet: type[TextDataset]
 TextDataset: Any
 
 __getattr__, __dir__, __all__ = lazy.attach(
-    __name__, submod_attrs={"text_dataset": ["TextDataSet", "TextDataset"]}
+    __name__, submod_attrs={"text_dataset": ["TextDataset"]}
 )

--- a/kedro-datasets/kedro_datasets/text/text_dataset.py
+++ b/kedro-datasets/kedro_datasets/text/text_dataset.py
@@ -7,6 +7,7 @@ from typing import Any, Dict
 
 import fsspec
 from kedro.io.core import Version, get_filepath_str, get_protocol_and_path
+
 from kedro_datasets._io import AbstractVersionedDataset, DatasetError
 
 

--- a/kedro-datasets/kedro_datasets/text/text_dataset.py
+++ b/kedro-datasets/kedro_datasets/text/text_dataset.py
@@ -1,15 +1,12 @@
 """``TextDataset`` loads/saves data from/to a text file using an underlying
 filesystem (e.g.: local, S3, GCS).
 """
-import warnings
 from copy import deepcopy
 from pathlib import PurePosixPath
 from typing import Any, Dict
 
 import fsspec
 from kedro.io.core import Version, get_filepath_str, get_protocol_and_path
-
-from kedro_datasets import KedroDeprecationWarning
 from kedro_datasets._io import AbstractVersionedDataset, DatasetError
 
 
@@ -140,21 +137,3 @@ class TextDataset(AbstractVersionedDataset[str, str]):
         """Invalidate underlying filesystem caches."""
         filepath = get_filepath_str(self._filepath, self._protocol)
         self._fs.invalidate_cache(filepath)
-
-
-_DEPRECATED_CLASSES = {
-    "TextDataSet": TextDataset,
-}
-
-
-def __getattr__(name):
-    if name in _DEPRECATED_CLASSES:
-        alias = _DEPRECATED_CLASSES[name]
-        warnings.warn(
-            f"{repr(name)} has been renamed to {repr(alias.__name__)}, "
-            f"and the alias will be removed in Kedro-Datasets 2.0.0",
-            KedroDeprecationWarning,
-            stacklevel=2,
-        )
-        return alias
-    raise AttributeError(f"module {repr(__name__)} has no attribute {repr(name)}")

--- a/kedro-datasets/kedro_datasets/tracking/__init__.py
+++ b/kedro-datasets/kedro_datasets/tracking/__init__.py
@@ -1,6 +1,4 @@
 """Dataset implementations to save data for Kedro Experiment Tracking."""
-from __future__ import annotations
-
 from typing import Any
 
 import lazy_loader as lazy

--- a/kedro-datasets/kedro_datasets/tracking/__init__.py
+++ b/kedro-datasets/kedro_datasets/tracking/__init__.py
@@ -6,15 +6,13 @@ from typing import Any
 import lazy_loader as lazy
 
 # https://github.com/pylint-dev/pylint/issues/4300#issuecomment-1043601901
-JSONDataSet: type[JSONDataset]
 JSONDataset: Any
-MetricsDataSet: type[MetricsDataset]
 MetricsDataset: Any
 
 __getattr__, __dir__, __all__ = lazy.attach(
     __name__,
     submod_attrs={
-        "json_dataset": ["JSONDataSet", "JSONDataset"],
-        "metrics_dataset": ["MetricsDataSet", "MetricsDataset"],
+        "json_dataset": ["JSONDataset"],
+        "metrics_dataset": ["MetricsDataset"],
     },
 )

--- a/kedro-datasets/kedro_datasets/tracking/json_dataset.py
+++ b/kedro-datasets/kedro_datasets/tracking/json_dataset.py
@@ -2,12 +2,9 @@
 filesystem (e.g.: local, S3, GCS). It uses native json to handle the JSON file.
 The ``JSONDataset`` is part of Kedro Experiment Tracking. The dataset is versioned by default.
 """
-import warnings
 from typing import NoReturn
 
 from kedro.io.core import DatasetError
-
-from kedro_datasets import KedroDeprecationWarning
 from kedro_datasets.json import json_dataset
 
 
@@ -46,21 +43,3 @@ class JSONDataset(json_dataset.JSONDataset):
 
     def _load(self) -> NoReturn:
         raise DatasetError(f"Loading not supported for '{self.__class__.__name__}'")
-
-
-_DEPRECATED_CLASSES = {
-    "JSONDataSet": JSONDataset,
-}
-
-
-def __getattr__(name):
-    if name in _DEPRECATED_CLASSES:
-        alias = _DEPRECATED_CLASSES[name]
-        warnings.warn(
-            f"{repr(name)} has been renamed to {repr(alias.__name__)}, "
-            f"and the alias will be removed in Kedro-Datasets 2.0.0",
-            KedroDeprecationWarning,
-            stacklevel=2,
-        )
-        return alias
-    raise AttributeError(f"module {repr(__name__)} has no attribute {repr(name)}")

--- a/kedro-datasets/kedro_datasets/tracking/json_dataset.py
+++ b/kedro-datasets/kedro_datasets/tracking/json_dataset.py
@@ -5,6 +5,7 @@ The ``JSONDataset`` is part of Kedro Experiment Tracking. The dataset is version
 from typing import NoReturn
 
 from kedro.io.core import DatasetError
+
 from kedro_datasets.json import json_dataset
 
 

--- a/kedro-datasets/kedro_datasets/tracking/metrics_dataset.py
+++ b/kedro-datasets/kedro_datasets/tracking/metrics_dataset.py
@@ -7,6 +7,7 @@ import json
 from typing import Dict, NoReturn
 
 from kedro.io.core import DatasetError, get_filepath_str
+
 from kedro_datasets.json import json_dataset
 
 

--- a/kedro-datasets/kedro_datasets/tracking/metrics_dataset.py
+++ b/kedro-datasets/kedro_datasets/tracking/metrics_dataset.py
@@ -4,12 +4,9 @@ The ``MetricsDataset`` is part of Kedro Experiment Tracking. The dataset is vers
 and only takes metrics of numeric values.
 """
 import json
-import warnings
 from typing import Dict, NoReturn
 
 from kedro.io.core import DatasetError, get_filepath_str
-
-from kedro_datasets import KedroDeprecationWarning
 from kedro_datasets.json import json_dataset
 
 
@@ -67,21 +64,3 @@ class MetricsDataset(json_dataset.JSONDataset):
             json.dump(data, fs_file, **self._save_args)
 
         self._invalidate_cache()
-
-
-_DEPRECATED_CLASSES = {
-    "MetricsDataSet": MetricsDataset,
-}
-
-
-def __getattr__(name):
-    if name in _DEPRECATED_CLASSES:
-        alias = _DEPRECATED_CLASSES[name]
-        warnings.warn(
-            f"{repr(name)} has been renamed to {repr(alias.__name__)}, "
-            f"and the alias will be removed in Kedro-Datasets 2.0.0",
-            KedroDeprecationWarning,
-            stacklevel=2,
-        )
-        return alias
-    raise AttributeError(f"module {repr(__name__)} has no attribute {repr(name)}")

--- a/kedro-datasets/kedro_datasets/video/__init__.py
+++ b/kedro-datasets/kedro_datasets/video/__init__.py
@@ -6,9 +6,8 @@ from typing import Any
 import lazy_loader as lazy
 
 # https://github.com/pylint-dev/pylint/issues/4300#issuecomment-1043601901
-VideoDataSet: type[VideoDataset]
 VideoDataset: Any
 
 __getattr__, __dir__, __all__ = lazy.attach(
-    __name__, submod_attrs={"video_dataset": ["VideoDataSet", "VideoDataset"]}
+    __name__, submod_attrs={"video_dataset": ["VideoDataset"]}
 )

--- a/kedro-datasets/kedro_datasets/video/__init__.py
+++ b/kedro-datasets/kedro_datasets/video/__init__.py
@@ -1,6 +1,4 @@
 """Dataset implementation to load/save data from/to a video file."""
-from __future__ import annotations
-
 from typing import Any
 
 import lazy_loader as lazy

--- a/kedro-datasets/kedro_datasets/video/video_dataset.py
+++ b/kedro-datasets/kedro_datasets/video/video_dataset.py
@@ -9,11 +9,12 @@ from copy import deepcopy
 from pathlib import Path, PurePosixPath
 from typing import Any, Dict, Generator, Optional, Sequence, Tuple, Union
 
-import PIL.Image
 import cv2
 import fsspec
 import numpy as np
+import PIL.Image
 from kedro.io.core import get_protocol_and_path
+
 from kedro_datasets._io import AbstractDataset
 
 

--- a/kedro-datasets/kedro_datasets/video/video_dataset.py
+++ b/kedro-datasets/kedro_datasets/video/video_dataset.py
@@ -4,19 +4,16 @@ and decode videos and OpenCV VideoWriter to encode and write video.
 """
 import itertools
 import tempfile
-import warnings
 from collections import abc
 from copy import deepcopy
 from pathlib import Path, PurePosixPath
 from typing import Any, Dict, Generator, Optional, Sequence, Tuple, Union
 
+import PIL.Image
 import cv2
 import fsspec
 import numpy as np
-import PIL.Image
 from kedro.io.core import get_protocol_and_path
-
-from kedro_datasets import KedroDeprecationWarning
 from kedro_datasets._io import AbstractDataset
 
 
@@ -367,21 +364,3 @@ class VideoDataset(AbstractDataset[AbstractVideo, AbstractVideo]):
 
     def _exists(self) -> bool:
         return self._fs.exists(self._filepath)
-
-
-_DEPRECATED_CLASSES = {
-    "VideoDataSet": VideoDataset,
-}
-
-
-def __getattr__(name):
-    if name in _DEPRECATED_CLASSES:
-        alias = _DEPRECATED_CLASSES[name]
-        warnings.warn(
-            f"{repr(name)} has been renamed to {repr(alias.__name__)}, "
-            f"and the alias will be removed in Kedro-Datasets 2.0.0",
-            KedroDeprecationWarning,
-            stacklevel=2,
-        )
-        return alias
-    raise AttributeError(f"module {repr(__name__)} has no attribute {repr(name)}")

--- a/kedro-datasets/kedro_datasets/yaml/__init__.py
+++ b/kedro-datasets/kedro_datasets/yaml/__init__.py
@@ -6,9 +6,8 @@ from typing import Any
 import lazy_loader as lazy
 
 # https://github.com/pylint-dev/pylint/issues/4300#issuecomment-1043601901
-YAMLDataSet: type[YAMLDataset]
 YAMLDataset: Any
 
 __getattr__, __dir__, __all__ = lazy.attach(
-    __name__, submod_attrs={"yaml_dataset": ["YAMLDataSet", "YAMLDataset"]}
+    __name__, submod_attrs={"yaml_dataset": ["YAMLDataset"]}
 )

--- a/kedro-datasets/kedro_datasets/yaml/__init__.py
+++ b/kedro-datasets/kedro_datasets/yaml/__init__.py
@@ -1,6 +1,4 @@
 """``AbstractDataset`` implementation to load/save data from/to a YAML file."""
-from __future__ import annotations
-
 from typing import Any
 
 import lazy_loader as lazy

--- a/kedro-datasets/kedro_datasets/yaml/yaml_dataset.py
+++ b/kedro-datasets/kedro_datasets/yaml/yaml_dataset.py
@@ -8,6 +8,7 @@ from typing import Any, Dict
 import fsspec
 import yaml
 from kedro.io.core import Version, get_filepath_str, get_protocol_and_path
+
 from kedro_datasets._io import AbstractVersionedDataset, DatasetError
 
 

--- a/kedro-datasets/kedro_datasets/yaml/yaml_dataset.py
+++ b/kedro-datasets/kedro_datasets/yaml/yaml_dataset.py
@@ -1,7 +1,6 @@
 """``YAMLDataset`` loads/saves data from/to a YAML file using an underlying
 filesystem (e.g.: local, S3, GCS). It uses PyYAML to handle the YAML file.
 """
-import warnings
 from copy import deepcopy
 from pathlib import PurePosixPath
 from typing import Any, Dict
@@ -9,8 +8,6 @@ from typing import Any, Dict
 import fsspec
 import yaml
 from kedro.io.core import Version, get_filepath_str, get_protocol_and_path
-
-from kedro_datasets import KedroDeprecationWarning
 from kedro_datasets._io import AbstractVersionedDataset, DatasetError
 
 
@@ -152,21 +149,3 @@ class YAMLDataset(AbstractVersionedDataset[Dict, Dict]):
         """Invalidate underlying filesystem caches."""
         filepath = get_filepath_str(self._filepath, self._protocol)
         self._fs.invalidate_cache(filepath)
-
-
-_DEPRECATED_CLASSES = {
-    "YAMLDataSet": YAMLDataset,
-}
-
-
-def __getattr__(name):
-    if name in _DEPRECATED_CLASSES:
-        alias = _DEPRECATED_CLASSES[name]
-        warnings.warn(
-            f"{repr(name)} has been renamed to {repr(alias.__name__)}, "
-            f"and the alias will be removed in Kedro-Datasets 2.0.0",
-            KedroDeprecationWarning,
-            stacklevel=2,
-        )
-        return alias
-    raise AttributeError(f"module {repr(__name__)} has no attribute {repr(name)}")

--- a/kedro-datasets/setup.py
+++ b/kedro-datasets/setup.py
@@ -2,7 +2,7 @@ from itertools import chain
 
 from setuptools import setup
 
-# at least 1.3 to be able to use XMLDataSet and pandas integration with fsspec
+# at least 1.3 to be able to use XMLDataset and pandas integration with fsspec
 PANDAS = "pandas>=1.3, <3.0"
 SPARK = "pyspark>=2.2, <4.0"
 HDFS = "hdfs>=2.5.8, <3.0"
@@ -15,14 +15,14 @@ def _collect_requirements(requires):
     return sorted(set(chain.from_iterable(requires.values())))
 
 
-api_require = {"api.APIDataSet": ["requests~=2.20"]}
-biosequence_require = {"biosequence.BioSequenceDataSet": ["biopython~=1.73"]}
+api_require = {"api.APIDataset": ["requests~=2.20"]}
+biosequence_require = {"biosequence.BioSequenceDataset": ["biopython~=1.73"]}
 dask_require = {
-    "dask.ParquetDataSet": ["dask[complete]>=2021.10", "triad>=0.6.7, <1.0"]
+    "dask.ParquetDataset": ["dask[complete]>=2021.10", "triad>=0.6.7, <1.0"]
 }
-databricks_require = {"databricks.ManagedTableDataSet": [SPARK, PANDAS, DELTA]}
+databricks_require = {"databricks.ManagedTableDataset": [SPARK, PANDAS, DELTA]}
 geopandas_require = {
-    "geopandas.GeoJSONDataSet": ["geopandas>=0.6.0, <1.0", "pyproj~=3.0"]
+    "geopandas.GeoJSONDataset": ["geopandas>=0.6.0, <1.0", "pyproj~=3.0"]
 }
 holoviews_require = {"holoviews.HoloviewsWriter": ["holoviews~=1.13.0"]}
 huggingface_require = {
@@ -30,39 +30,35 @@ huggingface_require = {
     "huggingface.HFTransformerPipelineDataset": ["transformers"],
 }
 matplotlib_require = {"matplotlib.MatplotlibWriter": ["matplotlib>=3.0.3, <4.0"]}
-networkx_require = {"networkx.NetworkXDataSet": ["networkx~=2.4"]}
+networkx_require = {"networkx.NetworkXDataset": ["networkx~=2.4"]}
 pandas_require = {
-    "pandas.CSVDataSet": [PANDAS],
-    "pandas.ExcelDataSet": [PANDAS, "openpyxl>=3.0.6, <4.0"],
-    "pandas.DeltaTableDataSet": [PANDAS, "deltalake>=0.10.0"],
-    "pandas.FeatherDataSet": [PANDAS],
-    "pandas.GBQTableDataSet": [PANDAS, "pandas-gbq>=0.12.0, <0.18.0"],
-    "pandas.GBQQueryDataSet": [PANDAS, "pandas-gbq>=0.12.0, <0.18.0"],
-    "pandas.HDFDataSet": [
+    "pandas.CSVDataset": [PANDAS],
+    "pandas.ExcelDataset": [PANDAS, "openpyxl>=3.0.6, <4.0"],
+    "pandas.DeltaTableDataset": [PANDAS, "deltalake>=0.10.0"],
+    "pandas.FeatherDataset": [PANDAS],
+    "pandas.GBQTableDataset": [PANDAS, "pandas-gbq>=0.12.0, <0.18.0"],
+    "pandas.GBQQueryDataset": [PANDAS, "pandas-gbq>=0.12.0, <0.18.0"],
+    "pandas.HDFDataset": [
         PANDAS,
         "tables~=3.6.0; platform_system == 'Windows'",
         "tables~=3.6, <3.9; platform_system != 'Windows' and python_version<'3.9'",
         "tables~=3.6; platform_system != 'Windows' and python_version>='3.9'",
     ],
-    "pandas.JSONDataSet": [PANDAS],
-    "pandas.ParquetDataSet": [PANDAS, "pyarrow>=6.0"],
-    "pandas.SQLTableDataSet": [PANDAS, "SQLAlchemy>=1.4, <3.0"],
-    "pandas.SQLQueryDataSet": [PANDAS, "SQLAlchemy>=1.4, <3.0", "pyodbc~=4.0"],
-    "pandas.XMLDataSet": [PANDAS, "lxml~=4.6"],
-    "pandas.GenericDataSet": [PANDAS],
+    "pandas.JSONDataset": [PANDAS],
+    "pandas.ParquetDataset": [PANDAS, "pyarrow>=6.0"],
+    "pandas.SQLTableDataset": [PANDAS, "SQLAlchemy>=1.4, <3.0"],
+    "pandas.SQLQueryDataset": [PANDAS, "SQLAlchemy>=1.4, <3.0", "pyodbc~=4.0"],
+    "pandas.XMLDataset": [PANDAS, "lxml~=4.6"],
+    "pandas.GenericDataset": [PANDAS],
 }
-pickle_require = {"pickle.PickleDataSet": ["compress-pickle[lz4]~=2.1.0"]}
-pillow_require = {"pillow.ImageDataSet": ["Pillow~=9.0"]}
+pickle_require = {"pickle.PickleDataset": ["compress-pickle[lz4]~=2.1.0"]}
+pillow_require = {"pillow.ImageDataset": ["Pillow~=9.0"]}
 plotly_require = {
-    "plotly.PlotlyDataSet": [PANDAS, "plotly>=4.8.0, <6.0"],
-    "plotly.JSONDataSet": ["plotly>=4.8.0, <6.0"],
+    "plotly.PlotlyDataset": [PANDAS, "plotly>=4.8.0, <6.0"],
+    "plotly.JSONDataset": ["plotly>=4.8.0, <6.0"],
 }
 polars_require = {
-    "polars.CSVDataSet": [POLARS],
-    "polars.GenericDataSet":
-    [
-        POLARS, "pyarrow>=4.0", "xlsx2csv>=0.8.0", "deltalake >= 0.6.2"
-    ],
+    "polars.CSVDataset": [POLARS],
     "polars.EagerPolarsDataset":
     [
         POLARS, "pyarrow>=4.0", "xlsx2csv>=0.8.0", "deltalake >= 0.6.2"
@@ -73,22 +69,22 @@ polars_require = {
         POLARS, "pyarrow>=4.0", "deltalake >= 0.6.2"
     ],
 }
-redis_require = {"redis.PickleDataSet": ["redis~=4.1"]}
+redis_require = {"redis.PickleDataset": ["redis~=4.1"]}
 snowflake_require = {
-    "snowflake.SnowparkTableDataSet": [
+    "snowflake.SnowparkTableDataset": [
         "snowflake-snowpark-python~=1.0.0",
         "pyarrow~=8.0",
     ]
 }
 spark_require = {
-    "spark.SparkDataSet": [SPARK, HDFS, S3FS],
-    "spark.SparkHiveDataSet": [SPARK, HDFS, S3FS],
-    "spark.SparkJDBCDataSet": [SPARK, HDFS, S3FS],
-    "spark.DeltaTableDataSet": [SPARK, HDFS, S3FS, "delta-spark>=1.0, <3.0"],
+    "spark.SparkDataset": [SPARK, HDFS, S3FS],
+    "spark.SparkHiveDataset": [SPARK, HDFS, S3FS],
+    "spark.SparkJDBCDataset": [SPARK, HDFS, S3FS],
+    "spark.DeltaTableDataset": [SPARK, HDFS, S3FS, "delta-spark>=1.0, <3.0"],
 }
-svmlight_require = {"svmlight.SVMLightDataSet": ["scikit-learn~=1.0.2", "scipy~=1.7.3"]}
+svmlight_require = {"svmlight.SVMLightDataset": ["scikit-learn~=1.0.2", "scipy~=1.7.3"]}
 tensorflow_require = {
-    "tensorflow.TensorFlowModelDataSet": [
+    "tensorflow.TensorFlowModelDataset": [
         # currently only TensorFlow V2 supported for saving and loading.
         # V1 requires HDF5 and serialises differently
         "tensorflow~=2.0; platform_system != 'Darwin' or platform_machine != 'arm64'",
@@ -96,8 +92,8 @@ tensorflow_require = {
         "tensorflow-macos~=2.0; platform_system == 'Darwin' and platform_machine == 'arm64'",
     ]
 }
-video_require = {"video.VideoDataSet": ["opencv-python~=4.5.5.64"]}
-yaml_require = {"yaml.YAMLDataSet": [PANDAS, "PyYAML>=4.2, <7.0"]}
+video_require = {"video.VideoDataset": ["opencv-python~=4.5.5.64"]}
+yaml_require = {"yaml.YAMLDataset": [PANDAS, "PyYAML>=4.2, <7.0"]}
 
 extras_require = {
     "api": _collect_requirements(api_require),

--- a/kedro-datasets/tests/api/test_api_dataset.py
+++ b/kedro-datasets/tests/api/test_api_dataset.py
@@ -1,5 +1,4 @@
 import base64
-import importlib
 import json
 import socket
 from typing import Any
@@ -8,10 +7,8 @@ import pytest
 import requests
 from requests.auth import HTTPBasicAuth
 
-from kedro_datasets import KedroDeprecationWarning
 from kedro_datasets._io import DatasetError
 from kedro_datasets.api import APIDataset
-from kedro_datasets.api.api_dataset import _DEPRECATED_CLASSES
 
 POSSIBLE_METHODS = ["GET", "OPTIONS", "HEAD", "POST", "PUT", "PATCH", "DELETE"]
 SAVE_METHODS = ["POST", "PUT"]
@@ -27,17 +24,6 @@ TEST_METHOD = "GET"
 TEST_HEADERS = {"key": "value"}
 
 TEST_SAVE_DATA = [{"key1": "info1", "key2": "info2"}]
-
-
-@pytest.mark.parametrize(
-    "module_name", ["kedro_datasets.api", "kedro_datasets.api.api_dataset"]
-)
-@pytest.mark.parametrize("class_name", _DEPRECATED_CLASSES)
-def test_deprecation(module_name, class_name):
-    with pytest.warns(
-        KedroDeprecationWarning, match=f"{repr(class_name)} has been renamed"
-    ):
-        getattr(importlib.import_module(module_name), class_name)
 
 
 class TestAPIDataset:

--- a/kedro-datasets/tests/biosequence/test_biosequence_dataset.py
+++ b/kedro-datasets/tests/biosequence/test_biosequence_dataset.py
@@ -1,4 +1,3 @@
-import importlib
 from io import StringIO
 from pathlib import PurePosixPath
 
@@ -10,10 +9,8 @@ from gcsfs import GCSFileSystem
 from kedro.io.core import PROTOCOL_DELIMITER
 from s3fs.core import S3FileSystem
 
-from kedro_datasets import KedroDeprecationWarning
 from kedro_datasets._io import DatasetError
 from kedro_datasets.biosequence import BioSequenceDataset
-from kedro_datasets.biosequence.biosequence_dataset import _DEPRECATED_CLASSES
 
 LOAD_ARGS = {"format": "fasta"}
 SAVE_ARGS = {"format": "fasta"}
@@ -38,18 +35,6 @@ def biosequence_dataset(filepath_biosequence, fs_args):
 def dummy_data():
     data = ">Alpha\nACCGGATGTA\n>Beta\nAGGCTCGGTTA\n"
     return list(SeqIO.parse(StringIO(data), "fasta"))
-
-
-@pytest.mark.parametrize(
-    "module_name",
-    ["kedro_datasets.biosequence", "kedro_datasets.biosequence.biosequence_dataset"],
-)
-@pytest.mark.parametrize("class_name", _DEPRECATED_CLASSES)
-def test_deprecation(module_name, class_name):
-    with pytest.warns(
-        KedroDeprecationWarning, match=f"{repr(class_name)} has been renamed"
-    ):
-        getattr(importlib.import_module(module_name), class_name)
 
 
 class TestBioSequenceDataset:

--- a/kedro-datasets/tests/dask/test_parquet_dataset.py
+++ b/kedro-datasets/tests/dask/test_parquet_dataset.py
@@ -1,5 +1,3 @@
-import importlib
-
 import boto3
 import dask.dataframe as dd
 import pandas as pd
@@ -10,10 +8,8 @@ from moto import mock_s3
 from pandas.testing import assert_frame_equal
 from s3fs import S3FileSystem
 
-from kedro_datasets import KedroDeprecationWarning
 from kedro_datasets._io import DatasetError
 from kedro_datasets.dask import ParquetDataset
-from kedro_datasets.dask.parquet_dataset import _DEPRECATED_CLASSES
 
 FILE_NAME = "test.parquet"
 BUCKET_NAME = "test_bucket"
@@ -73,17 +69,6 @@ def s3fs_cleanup():
     # clear cache so we get a clean slate every time we instantiate a S3FileSystem
     yield
     S3FileSystem.cachable = False
-
-
-@pytest.mark.parametrize(
-    "module_name", ["kedro_datasets.dask", "kedro_datasets.dask.parquet_dataset"]
-)
-@pytest.mark.parametrize("class_name", _DEPRECATED_CLASSES)
-def test_deprecation(module_name, class_name):
-    with pytest.warns(
-        KedroDeprecationWarning, match=f"{repr(class_name)} has been renamed"
-    ):
-        getattr(importlib.import_module(module_name), class_name)
 
 
 @pytest.mark.usefixtures("s3fs_cleanup")

--- a/kedro-datasets/tests/databricks/test_managed_table_dataset.py
+++ b/kedro-datasets/tests/databricks/test_managed_table_dataset.py
@@ -1,15 +1,11 @@
-import importlib
-
 import pandas as pd
 import pytest
 from kedro.io.core import Version, VersionNotFoundError
 from pyspark.sql import DataFrame, SparkSession
 from pyspark.sql.types import IntegerType, StringType, StructField, StructType
 
-from kedro_datasets import KedroDeprecationWarning
 from kedro_datasets._io import DatasetError
 from kedro_datasets.databricks import ManagedTableDataset
-from kedro_datasets.databricks.managed_table_dataset import _DEPRECATED_CLASSES
 
 
 @pytest.fixture
@@ -172,18 +168,6 @@ def expected_upsert_multiple_primary_spark_df(spark_session: SparkSession):
     ]
 
     return spark_session.createDataFrame(data, schema)
-
-
-@pytest.mark.parametrize(
-    "module_name",
-    ["kedro_datasets.databricks", "kedro_datasets.databricks.managed_table_dataset"],
-)
-@pytest.mark.parametrize("class_name", _DEPRECATED_CLASSES)
-def test_deprecation(module_name, class_name):
-    with pytest.warns(
-        KedroDeprecationWarning, match=f"{repr(class_name)} has been renamed"
-    ):
-        getattr(importlib.import_module(module_name), class_name)
 
 
 class TestManagedTableDataset:

--- a/kedro-datasets/tests/email/test_message_dataset.py
+++ b/kedro-datasets/tests/email/test_message_dataset.py
@@ -1,4 +1,3 @@
-import importlib
 from email.message import EmailMessage
 from email.policy import default
 from pathlib import Path, PurePosixPath
@@ -10,10 +9,8 @@ from gcsfs import GCSFileSystem
 from kedro.io.core import PROTOCOL_DELIMITER, Version
 from s3fs.core import S3FileSystem
 
-from kedro_datasets import KedroDeprecationWarning
 from kedro_datasets._io import DatasetError
 from kedro_datasets.email import EmailMessageDataset
-from kedro_datasets.email.message_dataset import _DEPRECATED_CLASSES
 
 
 @pytest.fixture
@@ -50,17 +47,6 @@ def dummy_msg():
     msg["To"] = '"strong bad"'
 
     return msg
-
-
-@pytest.mark.parametrize(
-    "module_name", ["kedro_datasets.email", "kedro_datasets.email.message_dataset"]
-)
-@pytest.mark.parametrize("class_name", _DEPRECATED_CLASSES)
-def test_deprecation(module_name, class_name):
-    with pytest.warns(
-        KedroDeprecationWarning, match=f"{repr(class_name)} has been renamed"
-    ):
-        getattr(importlib.import_module(module_name), class_name)
 
 
 class TestEmailMessageDataset:

--- a/kedro-datasets/tests/geopandas/test_geojson_dataset.py
+++ b/kedro-datasets/tests/geopandas/test_geojson_dataset.py
@@ -1,4 +1,3 @@
-import importlib
 from pathlib import Path, PurePosixPath
 
 import geopandas as gpd
@@ -11,10 +10,8 @@ from pandas.testing import assert_frame_equal
 from s3fs import S3FileSystem
 from shapely.geometry import Point
 
-from kedro_datasets import KedroDeprecationWarning
 from kedro_datasets._io import DatasetError
 from kedro_datasets.geopandas import GeoJSONDataset
-from kedro_datasets.geopandas.geojson_dataset import _DEPRECATED_CLASSES
 
 
 @pytest.fixture(params=[None])
@@ -62,18 +59,6 @@ def versioned_geojson_dataset(filepath, load_version, save_version):
     return GeoJSONDataset(
         filepath=filepath, version=Version(load_version, save_version)
     )
-
-
-@pytest.mark.parametrize(
-    "module_name",
-    ["kedro_datasets.geopandas", "kedro_datasets.geopandas.geojson_dataset"],
-)
-@pytest.mark.parametrize("class_name", _DEPRECATED_CLASSES)
-def test_deprecation(module_name, class_name):
-    with pytest.warns(
-        KedroDeprecationWarning, match=f"{repr(class_name)} has been renamed"
-    ):
-        getattr(importlib.import_module(module_name), class_name)
 
 
 class TestGeoJSONDataset:

--- a/kedro-datasets/tests/json/test_json_dataset.py
+++ b/kedro-datasets/tests/json/test_json_dataset.py
@@ -1,4 +1,3 @@
-import importlib
 from pathlib import Path, PurePosixPath
 
 import pytest
@@ -8,10 +7,8 @@ from gcsfs import GCSFileSystem
 from kedro.io.core import PROTOCOL_DELIMITER, Version
 from s3fs.core import S3FileSystem
 
-from kedro_datasets import KedroDeprecationWarning
 from kedro_datasets._io import DatasetError
 from kedro_datasets.json import JSONDataset
-from kedro_datasets.json.json_dataset import _DEPRECATED_CLASSES
 
 
 @pytest.fixture
@@ -34,17 +31,6 @@ def versioned_json_dataset(filepath_json, load_version, save_version):
 @pytest.fixture
 def dummy_data():
     return {"col1": 1, "col2": 2, "col3": 3}
-
-
-@pytest.mark.parametrize(
-    "module_name", ["kedro_datasets.json", "kedro_datasets.json.json_dataset"]
-)
-@pytest.mark.parametrize("class_name", _DEPRECATED_CLASSES)
-def test_deprecation(module_name, class_name):
-    with pytest.warns(
-        KedroDeprecationWarning, match=f"{repr(class_name)} has been renamed"
-    ):
-        getattr(importlib.import_module(module_name), class_name)
 
 
 class TestJSONDataset:

--- a/kedro-datasets/tests/networkx/test_gml_dataset.py
+++ b/kedro-datasets/tests/networkx/test_gml_dataset.py
@@ -1,4 +1,3 @@
-import importlib
 from pathlib import Path, PurePosixPath
 
 import networkx
@@ -10,10 +9,8 @@ from kedro.io import Version
 from kedro.io.core import PROTOCOL_DELIMITER
 from s3fs.core import S3FileSystem
 
-from kedro_datasets import KedroDeprecationWarning
 from kedro_datasets._io import DatasetError
 from kedro_datasets.networkx import GMLDataset
-from kedro_datasets.networkx.gml_dataset import _DEPRECATED_CLASSES
 
 ATTRS = {
     "source": "from",
@@ -51,17 +48,6 @@ def versioned_gml_dataset(filepath_gml, load_version, save_version):
 @pytest.fixture()
 def dummy_graph_data():
     return networkx.complete_graph(3)
-
-
-@pytest.mark.parametrize(
-    "module_name", ["kedro_datasets.networkx", "kedro_datasets.networkx.gml_dataset"]
-)
-@pytest.mark.parametrize("class_name", _DEPRECATED_CLASSES)
-def test_deprecation(module_name, class_name):
-    with pytest.warns(
-        KedroDeprecationWarning, match=f"{repr(class_name)} has been renamed"
-    ):
-        getattr(importlib.import_module(module_name), class_name)
 
 
 class TestGMLDataset:

--- a/kedro-datasets/tests/networkx/test_graphml_dataset.py
+++ b/kedro-datasets/tests/networkx/test_graphml_dataset.py
@@ -1,4 +1,3 @@
-import importlib
 from pathlib import Path, PurePosixPath
 
 import networkx
@@ -10,10 +9,8 @@ from kedro.io import Version
 from kedro.io.core import PROTOCOL_DELIMITER
 from s3fs.core import S3FileSystem
 
-from kedro_datasets import KedroDeprecationWarning
 from kedro_datasets._io import DatasetError
 from kedro_datasets.networkx import GraphMLDataset
-from kedro_datasets.networkx.graphml_dataset import _DEPRECATED_CLASSES
 
 ATTRS = {
     "source": "from",
@@ -51,18 +48,6 @@ def versioned_graphml_dataset(filepath_graphml, load_version, save_version):
 @pytest.fixture()
 def dummy_graph_data():
     return networkx.complete_graph(3)
-
-
-@pytest.mark.parametrize(
-    "module_name",
-    ["kedro_datasets.networkx", "kedro_datasets.networkx.graphml_dataset"],
-)
-@pytest.mark.parametrize("class_name", _DEPRECATED_CLASSES)
-def test_deprecation(module_name, class_name):
-    with pytest.warns(
-        KedroDeprecationWarning, match=f"{repr(class_name)} has been renamed"
-    ):
-        getattr(importlib.import_module(module_name), class_name)
 
 
 class TestGraphMLDataset:

--- a/kedro-datasets/tests/networkx/test_json_dataset.py
+++ b/kedro-datasets/tests/networkx/test_json_dataset.py
@@ -1,4 +1,3 @@
-import importlib
 from pathlib import Path, PurePosixPath
 
 import networkx
@@ -10,10 +9,8 @@ from kedro.io import Version
 from kedro.io.core import PROTOCOL_DELIMITER
 from s3fs.core import S3FileSystem
 
-from kedro_datasets import KedroDeprecationWarning
 from kedro_datasets._io import DatasetError
 from kedro_datasets.networkx import JSONDataset
-from kedro_datasets.networkx.json_dataset import _DEPRECATED_CLASSES
 
 ATTRS = {
     "source": "from",
@@ -51,17 +48,6 @@ def json_dataset_args(filepath_json):
 @pytest.fixture()
 def dummy_graph_data():
     return networkx.complete_graph(3)
-
-
-@pytest.mark.parametrize(
-    "module_name", ["kedro_datasets.networkx", "kedro_datasets.networkx.json_dataset"]
-)
-@pytest.mark.parametrize("class_name", _DEPRECATED_CLASSES)
-def test_deprecation(module_name, class_name):
-    with pytest.warns(
-        KedroDeprecationWarning, match=f"{repr(class_name)} has been renamed"
-    ):
-        getattr(importlib.import_module(module_name), class_name)
 
 
 class TestJSONDataset:

--- a/kedro-datasets/tests/pandas/test_csv_dataset.py
+++ b/kedro-datasets/tests/pandas/test_csv_dataset.py
@@ -1,4 +1,3 @@
-import importlib
 import os
 import sys
 from pathlib import Path, PurePosixPath
@@ -16,10 +15,8 @@ from moto import mock_s3
 from pandas.testing import assert_frame_equal
 from s3fs.core import S3FileSystem
 
-from kedro_datasets import KedroDeprecationWarning
 from kedro_datasets._io import DatasetError
 from kedro_datasets.pandas import CSVDataset
-from kedro_datasets.pandas.csv_dataset import _DEPRECATED_CLASSES
 
 BUCKET_NAME = "test_bucket"
 FILE_NAME = "test.csv"
@@ -86,17 +83,6 @@ def mocked_csv_in_s3(mocked_s3_bucket, mocked_dataframe):
         Body=mocked_dataframe.to_csv(index=False),
     )
     return f"s3://{BUCKET_NAME}/{FILE_NAME}"
-
-
-@pytest.mark.parametrize(
-    "module_name", ["kedro_datasets.pandas", "kedro_datasets.pandas.csv_dataset"]
-)
-@pytest.mark.parametrize("class_name", _DEPRECATED_CLASSES)
-def test_deprecation(module_name, class_name):
-    with pytest.warns(
-        KedroDeprecationWarning, match=f"{repr(class_name)} has been renamed"
-    ):
-        getattr(importlib.import_module(module_name), class_name)
 
 
 class TestCSVDataset:

--- a/kedro-datasets/tests/pandas/test_deltatable_dataset.py
+++ b/kedro-datasets/tests/pandas/test_deltatable_dataset.py
@@ -1,14 +1,10 @@
-import importlib
-
 import pandas as pd
 import pytest
 from deltalake import DataCatalog, Metadata
 from pandas.testing import assert_frame_equal
 
-from kedro_datasets import KedroDeprecationWarning
 from kedro_datasets._io import DatasetError
 from kedro_datasets.pandas import DeltaTableDataset
-from kedro_datasets.pandas.deltatable_dataset import _DEPRECATED_CLASSES
 
 
 @pytest.fixture
@@ -29,17 +25,6 @@ def deltatable_dataset_from_path(filepath, load_args, save_args, fs_args):
         save_args=save_args,
         fs_args=fs_args,
     )
-
-
-@pytest.mark.parametrize(
-    "module_name", ["kedro_datasets.pandas", "kedro_datasets.pandas.deltatable_dataset"]
-)
-@pytest.mark.parametrize("class_name", _DEPRECATED_CLASSES)
-def test_deprecation(module_name, class_name):
-    with pytest.warns(
-        KedroDeprecationWarning, match=f"{repr(class_name)} has been renamed"
-    ):
-        getattr(importlib.import_module(module_name), class_name)
 
 
 class TestDeltaTableDataset:

--- a/kedro-datasets/tests/pandas/test_excel_dataset.py
+++ b/kedro-datasets/tests/pandas/test_excel_dataset.py
@@ -1,4 +1,3 @@
-import importlib
 from pathlib import Path, PurePosixPath
 
 import pandas as pd
@@ -10,10 +9,8 @@ from kedro.io.core import PROTOCOL_DELIMITER, Version
 from pandas.testing import assert_frame_equal
 from s3fs.core import S3FileSystem
 
-from kedro_datasets import KedroDeprecationWarning
 from kedro_datasets._io import DatasetError
 from kedro_datasets.pandas import ExcelDataset
-from kedro_datasets.pandas.excel_dataset import _DEPRECATED_CLASSES
 
 
 @pytest.fixture
@@ -57,17 +54,6 @@ def dummy_dataframe():
 @pytest.fixture
 def another_dummy_dataframe():
     return pd.DataFrame({"x": [10, 20], "y": ["hello", "world"]})
-
-
-@pytest.mark.parametrize(
-    "module_name", ["kedro_datasets.pandas", "kedro_datasets.pandas.excel_dataset"]
-)
-@pytest.mark.parametrize("class_name", _DEPRECATED_CLASSES)
-def test_deprecation(module_name, class_name):
-    with pytest.warns(
-        KedroDeprecationWarning, match=f"{repr(class_name)} has been renamed"
-    ):
-        getattr(importlib.import_module(module_name), class_name)
 
 
 class TestExcelDataset:

--- a/kedro-datasets/tests/pandas/test_feather_dataset.py
+++ b/kedro-datasets/tests/pandas/test_feather_dataset.py
@@ -1,4 +1,3 @@
-import importlib
 from pathlib import Path, PurePosixPath
 
 import pandas as pd
@@ -10,10 +9,8 @@ from kedro.io.core import PROTOCOL_DELIMITER, Version
 from pandas.testing import assert_frame_equal
 from s3fs.core import S3FileSystem
 
-from kedro_datasets import KedroDeprecationWarning
 from kedro_datasets._io import DatasetError
 from kedro_datasets.pandas import FeatherDataset
-from kedro_datasets.pandas.feather_dataset import _DEPRECATED_CLASSES
 
 
 @pytest.fixture
@@ -38,17 +35,6 @@ def versioned_feather_dataset(filepath_feather, load_version, save_version):
 @pytest.fixture
 def dummy_dataframe():
     return pd.DataFrame({"col1": [1, 2], "col2": [4, 5], "col3": [5, 6]})
-
-
-@pytest.mark.parametrize(
-    "module_name", ["kedro_datasets.pandas", "kedro_datasets.pandas.feather_dataset"]
-)
-@pytest.mark.parametrize("class_name", _DEPRECATED_CLASSES)
-def test_deprecation(module_name, class_name):
-    with pytest.warns(
-        KedroDeprecationWarning, match=f"{repr(class_name)} has been renamed"
-    ):
-        getattr(importlib.import_module(module_name), class_name)
 
 
 class TestFeatherDataset:

--- a/kedro-datasets/tests/pandas/test_gbq_dataset.py
+++ b/kedro-datasets/tests/pandas/test_gbq_dataset.py
@@ -1,4 +1,3 @@
-import importlib
 from pathlib import PosixPath
 
 import pandas as pd
@@ -6,10 +5,8 @@ import pytest
 from google.cloud.exceptions import NotFound
 from pandas.testing import assert_frame_equal
 
-from kedro_datasets import KedroDeprecationWarning
 from kedro_datasets._io import DatasetError
 from kedro_datasets.pandas import GBQQueryDataset, GBQTableDataset
-from kedro_datasets.pandas.gbq_dataset import _DEPRECATED_CLASSES
 
 DATASET = "dataset"
 TABLE_NAME = "table_name"
@@ -65,17 +62,6 @@ def gbq_sql_file_dataset(load_args, sql_file, mock_bigquery_client):
         credentials=None,
         load_args=load_args,
     )
-
-
-@pytest.mark.parametrize(
-    "module_name", ["kedro_datasets.pandas", "kedro_datasets.pandas.gbq_dataset"]
-)
-@pytest.mark.parametrize("class_name", _DEPRECATED_CLASSES)
-def test_deprecation(module_name, class_name):
-    with pytest.warns(
-        KedroDeprecationWarning, match=f"{repr(class_name)} has been renamed"
-    ):
-        getattr(importlib.import_module(module_name), class_name)
 
 
 class TestGBQDataset:

--- a/kedro-datasets/tests/pandas/test_generic_dataset.py
+++ b/kedro-datasets/tests/pandas/test_generic_dataset.py
@@ -1,4 +1,3 @@
-import importlib
 from pathlib import Path, PurePosixPath
 from time import sleep
 
@@ -13,10 +12,8 @@ from kedro.io.core import PROTOCOL_DELIMITER, generate_timestamp
 from pandas._testing import assert_frame_equal
 from s3fs import S3FileSystem
 
-from kedro_datasets import KedroDeprecationWarning
 from kedro_datasets._io import DatasetError
 from kedro_datasets.pandas import GenericDataset
-from kedro_datasets.pandas.generic_dataset import _DEPRECATED_CLASSES
 
 
 @pytest.fixture
@@ -91,17 +88,6 @@ def csv_dataset(filepath_csv):
 @pytest.fixture
 def dummy_dataframe():
     return pd.DataFrame({"col1": [1, 2], "col2": [4, 5], "col3": [5, 6]})
-
-
-@pytest.mark.parametrize(
-    "module_name", ["kedro_datasets.pandas", "kedro_datasets.pandas.generic_dataset"]
-)
-@pytest.mark.parametrize("class_name", _DEPRECATED_CLASSES)
-def test_deprecation(module_name, class_name):
-    with pytest.warns(
-        KedroDeprecationWarning, match=f"{repr(class_name)} has been renamed"
-    ):
-        getattr(importlib.import_module(module_name), class_name)
 
 
 class TestGenericSASDataset:

--- a/kedro-datasets/tests/pandas/test_hdf_dataset.py
+++ b/kedro-datasets/tests/pandas/test_hdf_dataset.py
@@ -1,4 +1,3 @@
-import importlib
 from pathlib import Path, PurePosixPath
 
 import pandas as pd
@@ -10,10 +9,8 @@ from kedro.io.core import PROTOCOL_DELIMITER, Version
 from pandas.testing import assert_frame_equal
 from s3fs.core import S3FileSystem
 
-from kedro_datasets import KedroDeprecationWarning
 from kedro_datasets._io import DatasetError
 from kedro_datasets.pandas import HDFDataset
-from kedro_datasets.pandas.hdf_dataset import _DEPRECATED_CLASSES
 
 HDF_KEY = "data"
 
@@ -45,17 +42,6 @@ def versioned_hdf_dataset(filepath_hdf, load_version, save_version):
 @pytest.fixture
 def dummy_dataframe():
     return pd.DataFrame({"col1": [1, 2], "col2": [4, 5], "col3": [5, 6]})
-
-
-@pytest.mark.parametrize(
-    "module_name", ["kedro_datasets.pandas", "kedro_datasets.pandas.hdf_dataset"]
-)
-@pytest.mark.parametrize("class_name", _DEPRECATED_CLASSES)
-def test_deprecation(module_name, class_name):
-    with pytest.warns(
-        KedroDeprecationWarning, match=f"{repr(class_name)} has been renamed"
-    ):
-        getattr(importlib.import_module(module_name), class_name)
 
 
 class TestHDFDataset:

--- a/kedro-datasets/tests/pandas/test_json_dataset.py
+++ b/kedro-datasets/tests/pandas/test_json_dataset.py
@@ -1,4 +1,3 @@
-import importlib
 from pathlib import Path, PurePosixPath
 
 import pandas as pd
@@ -11,10 +10,8 @@ from kedro.io.core import PROTOCOL_DELIMITER, Version
 from pandas.testing import assert_frame_equal
 from s3fs.core import S3FileSystem
 
-from kedro_datasets import KedroDeprecationWarning
 from kedro_datasets._io import DatasetError
 from kedro_datasets.pandas import JSONDataset
-from kedro_datasets.pandas.json_dataset import _DEPRECATED_CLASSES
 
 
 @pytest.fixture
@@ -42,17 +39,6 @@ def versioned_json_dataset(filepath_json, load_version, save_version):
 @pytest.fixture
 def dummy_dataframe():
     return pd.DataFrame({"col1": [1, 2], "col2": [4, 5], "col3": [5, 6]})
-
-
-@pytest.mark.parametrize(
-    "module_name", ["kedro_datasets.pandas", "kedro_datasets.pandas.json_dataset"]
-)
-@pytest.mark.parametrize("class_name", _DEPRECATED_CLASSES)
-def test_deprecation(module_name, class_name):
-    with pytest.warns(
-        KedroDeprecationWarning, match=f"{repr(class_name)} has been renamed"
-    ):
-        getattr(importlib.import_module(module_name), class_name)
 
 
 class TestJSONDataset:

--- a/kedro-datasets/tests/pandas/test_parquet_dataset.py
+++ b/kedro-datasets/tests/pandas/test_parquet_dataset.py
@@ -1,4 +1,3 @@
-import importlib
 from pathlib import Path, PurePosixPath
 
 import pandas as pd
@@ -11,10 +10,8 @@ from pandas.testing import assert_frame_equal
 from pyarrow.fs import FSSpecHandler, PyFileSystem
 from s3fs.core import S3FileSystem
 
-from kedro_datasets import KedroDeprecationWarning
 from kedro_datasets._io import DatasetError
 from kedro_datasets.pandas import ParquetDataset
-from kedro_datasets.pandas.parquet_dataset import _DEPRECATED_CLASSES
 
 FILENAME = "test.parquet"
 
@@ -44,17 +41,6 @@ def versioned_parquet_dataset(filepath_parquet, load_version, save_version):
 @pytest.fixture
 def dummy_dataframe():
     return pd.DataFrame({"col1": [1, 2], "col2": [4, 5], "col3": [5, 6]})
-
-
-@pytest.mark.parametrize(
-    "module_name", ["kedro_datasets.pandas", "kedro_datasets.pandas.parquet_dataset"]
-)
-@pytest.mark.parametrize("class_name", _DEPRECATED_CLASSES)
-def test_deprecation(module_name, class_name):
-    with pytest.warns(
-        KedroDeprecationWarning, match=f"{repr(class_name)} has been renamed"
-    ):
-        getattr(importlib.import_module(module_name), class_name)
 
 
 class TestParquetDataset:

--- a/kedro-datasets/tests/pandas/test_sql_dataset.py
+++ b/kedro-datasets/tests/pandas/test_sql_dataset.py
@@ -1,4 +1,3 @@
-import importlib
 from pathlib import PosixPath
 from unittest.mock import ANY
 
@@ -6,10 +5,8 @@ import pandas as pd
 import pytest
 import sqlalchemy
 
-from kedro_datasets import KedroDeprecationWarning
 from kedro_datasets._io import DatasetError
 from kedro_datasets.pandas import SQLQueryDataset, SQLTableDataset
-from kedro_datasets.pandas.sql_dataset import _DEPRECATED_CLASSES
 
 TABLE_NAME = "table_a"
 CONNECTION = "sqlite:///kedro.db"
@@ -60,17 +57,6 @@ def query_file_dataset(request, sql_file):
     kwargs = {"filepath": sql_file, "credentials": {"con": CONNECTION}}
     kwargs.update(request.param)
     return SQLQueryDataset(**kwargs)
-
-
-@pytest.mark.parametrize(
-    "module_name", ["kedro_datasets.pandas", "kedro_datasets.pandas.sql_dataset"]
-)
-@pytest.mark.parametrize("class_name", _DEPRECATED_CLASSES)
-def test_deprecation(module_name, class_name):
-    with pytest.warns(
-        KedroDeprecationWarning, match=f"{repr(class_name)} has been renamed"
-    ):
-        getattr(importlib.import_module(module_name), class_name)
 
 
 class TestSQLTableDataset:

--- a/kedro-datasets/tests/pandas/test_xml_dataset.py
+++ b/kedro-datasets/tests/pandas/test_xml_dataset.py
@@ -1,4 +1,3 @@
-import importlib
 from pathlib import Path, PurePosixPath
 
 import pandas as pd
@@ -11,10 +10,8 @@ from kedro.io.core import PROTOCOL_DELIMITER, Version
 from pandas.testing import assert_frame_equal
 from s3fs.core import S3FileSystem
 
-from kedro_datasets import KedroDeprecationWarning
 from kedro_datasets._io import DatasetError
 from kedro_datasets.pandas import XMLDataset
-from kedro_datasets.pandas.xml_dataset import _DEPRECATED_CLASSES
 
 
 @pytest.fixture
@@ -42,17 +39,6 @@ def versioned_xml_dataset(filepath_xml, load_version, save_version):
 @pytest.fixture
 def dummy_dataframe():
     return pd.DataFrame({"col1": [1, 2], "col2": [4, 5], "col3": [5, 6]})
-
-
-@pytest.mark.parametrize(
-    "module_name", ["kedro_datasets.pandas", "kedro_datasets.pandas.xml_dataset"]
-)
-@pytest.mark.parametrize("class_name", _DEPRECATED_CLASSES)
-def test_deprecation(module_name, class_name):
-    with pytest.warns(
-        KedroDeprecationWarning, match=f"{repr(class_name)} has been renamed"
-    ):
-        getattr(importlib.import_module(module_name), class_name)
 
 
 class TestXMLDataset:

--- a/kedro-datasets/tests/pickle/test_pickle_dataset.py
+++ b/kedro-datasets/tests/pickle/test_pickle_dataset.py
@@ -1,4 +1,3 @@
-import importlib
 import pickle
 from pathlib import Path, PurePosixPath
 
@@ -11,10 +10,8 @@ from kedro.io.core import PROTOCOL_DELIMITER, Version
 from pandas.testing import assert_frame_equal
 from s3fs.core import S3FileSystem
 
-from kedro_datasets import KedroDeprecationWarning
 from kedro_datasets._io import DatasetError
 from kedro_datasets.pickle import PickleDataset
-from kedro_datasets.pickle.pickle_dataset import _DEPRECATED_CLASSES
 
 
 @pytest.fixture
@@ -48,17 +45,6 @@ def versioned_pickle_dataset(filepath_pickle, load_version, save_version):
 @pytest.fixture
 def dummy_dataframe():
     return pd.DataFrame({"col1": [1, 2], "col2": [4, 5], "col3": [5, 6]})
-
-
-@pytest.mark.parametrize(
-    "module_name", ["kedro_datasets.pickle", "kedro_datasets.pickle.pickle_dataset"]
-)
-@pytest.mark.parametrize("class_name", _DEPRECATED_CLASSES)
-def test_deprecation(module_name, class_name):
-    with pytest.warns(
-        KedroDeprecationWarning, match=f"{repr(class_name)} has been renamed"
-    ):
-        getattr(importlib.import_module(module_name), class_name)
 
 
 class TestPickleDataset:

--- a/kedro-datasets/tests/pillow/test_image_dataset.py
+++ b/kedro-datasets/tests/pillow/test_image_dataset.py
@@ -1,4 +1,3 @@
-import importlib
 from pathlib import Path, PurePosixPath
 from time import sleep
 
@@ -9,10 +8,8 @@ from kedro.io.core import PROTOCOL_DELIMITER, Version, generate_timestamp
 from PIL import Image, ImageChops
 from s3fs.core import S3FileSystem
 
-from kedro_datasets import KedroDeprecationWarning
 from kedro_datasets._io import DatasetError
 from kedro_datasets.pillow import ImageDataset
-from kedro_datasets.pillow.image_dataset import _DEPRECATED_CLASSES
 
 
 @pytest.fixture
@@ -41,17 +38,6 @@ def image_object():
 def images_equal(image_1, image_2):
     diff = ImageChops.difference(image_1, image_2)
     return not diff.getbbox()
-
-
-@pytest.mark.parametrize(
-    "module_name", ["kedro_datasets.pillow", "kedro_datasets.pillow.image_dataset"]
-)
-@pytest.mark.parametrize("class_name", _DEPRECATED_CLASSES)
-def test_deprecation(module_name, class_name):
-    with pytest.warns(
-        KedroDeprecationWarning, match=f"{repr(class_name)} has been renamed"
-    ):
-        getattr(importlib.import_module(module_name), class_name)
 
 
 class TestImageDataset:

--- a/kedro-datasets/tests/plotly/test_json_dataset.py
+++ b/kedro-datasets/tests/plotly/test_json_dataset.py
@@ -1,4 +1,3 @@
-import importlib
 from pathlib import PurePosixPath
 
 import plotly.express as px
@@ -10,10 +9,8 @@ from gcsfs import GCSFileSystem
 from kedro.io.core import PROTOCOL_DELIMITER
 from s3fs.core import S3FileSystem
 
-from kedro_datasets import KedroDeprecationWarning
 from kedro_datasets._io import DatasetError
 from kedro_datasets.plotly import JSONDataset
-from kedro_datasets.plotly.json_dataset import _DEPRECATED_CLASSES
 
 
 @pytest.fixture
@@ -34,17 +31,6 @@ def json_dataset(filepath_json, load_args, save_args, fs_args):
 @pytest.fixture
 def dummy_plot():
     return px.scatter(x=[1, 2, 3], y=[1, 3, 2], title="Test")
-
-
-@pytest.mark.parametrize(
-    "module_name", ["kedro_datasets.plotly", "kedro_datasets.plotly.json_dataset"]
-)
-@pytest.mark.parametrize("class_name", _DEPRECATED_CLASSES)
-def test_deprecation(module_name, class_name):
-    with pytest.warns(
-        KedroDeprecationWarning, match=f"{repr(class_name)} has been renamed"
-    ):
-        getattr(importlib.import_module(module_name), class_name)
 
 
 class TestJSONDataset:

--- a/kedro-datasets/tests/plotly/test_plotly_dataset.py
+++ b/kedro-datasets/tests/plotly/test_plotly_dataset.py
@@ -1,4 +1,3 @@
-import importlib
 from pathlib import PurePosixPath
 
 import pandas as pd
@@ -12,10 +11,8 @@ from plotly import graph_objects
 from plotly.graph_objs import Scatter
 from s3fs.core import S3FileSystem
 
-from kedro_datasets import KedroDeprecationWarning
 from kedro_datasets._io import DatasetError
 from kedro_datasets.plotly import PlotlyDataset
-from kedro_datasets.plotly.plotly_dataset import _DEPRECATED_CLASSES
 
 
 @pytest.fixture
@@ -46,17 +43,6 @@ def plotly_args():
 @pytest.fixture
 def dummy_dataframe():
     return pd.DataFrame({"col1": [1, 2], "col2": [4, 5], "col3": [5, 6]})
-
-
-@pytest.mark.parametrize(
-    "module_name", ["kedro_datasets.plotly", "kedro_datasets.plotly.plotly_dataset"]
-)
-@pytest.mark.parametrize("class_name", _DEPRECATED_CLASSES)
-def test_deprecation(module_name, class_name):
-    with pytest.warns(
-        KedroDeprecationWarning, match=f"{repr(class_name)} has been renamed"
-    ):
-        getattr(importlib.import_module(module_name), class_name)
 
 
 class TestPlotlyDataset:

--- a/kedro-datasets/tests/polars/test_csv_dataset.py
+++ b/kedro-datasets/tests/polars/test_csv_dataset.py
@@ -1,4 +1,3 @@
-import importlib
 import os
 import sys
 from pathlib import Path, PurePosixPath
@@ -16,10 +15,8 @@ from moto import mock_s3
 from polars.testing import assert_frame_equal
 from s3fs.core import S3FileSystem
 
-from kedro_datasets import KedroDeprecationWarning
 from kedro_datasets._io import DatasetError
 from kedro_datasets.polars import CSVDataset
-from kedro_datasets.polars.csv_dataset import _DEPRECATED_CLASSES
 
 BUCKET_NAME = "test_bucket"
 FILE_NAME = "test.csv"
@@ -89,17 +86,6 @@ def mocked_csv_in_s3(mocked_s3_bucket, mocked_dataframe: pl.DataFrame):
     )
 
     return f"s3://{BUCKET_NAME}/{FILE_NAME}"
-
-
-@pytest.mark.parametrize(
-    "module_name", ["kedro_datasets.polars", "kedro_datasets.polars.csv_dataset"]
-)
-@pytest.mark.parametrize("class_name", _DEPRECATED_CLASSES)
-def test_deprecation(module_name, class_name):
-    with pytest.warns(
-        KedroDeprecationWarning, match=f"{repr(class_name)} has been renamed"
-    ):
-        getattr(importlib.import_module(module_name), class_name)
 
 
 class TestCSVDataset:

--- a/kedro-datasets/tests/polars/test_eager_polars_dataset.py
+++ b/kedro-datasets/tests/polars/test_eager_polars_dataset.py
@@ -1,4 +1,3 @@
-import importlib
 from pathlib import Path, PurePosixPath
 from time import sleep
 
@@ -14,10 +13,8 @@ from kedro.io.core import PROTOCOL_DELIMITER, generate_timestamp
 from polars.testing import assert_frame_equal
 from s3fs import S3FileSystem
 
-from kedro_datasets import KedroDeprecationWarning
 from kedro_datasets._io import DatasetError
 from kedro_datasets.polars import EagerPolarsDataset
-from kedro_datasets.polars.eager_polars_dataset import _DEPRECATED_CLASSES
 
 
 @pytest.fixture
@@ -103,18 +100,6 @@ def excel_dataset(dummy_dataframe: pl.DataFrame, filepath_excel):
         filepath=filepath_excel.as_posix(),
         file_format="excel",
     )
-
-
-@pytest.mark.parametrize(
-    "module_name",
-    ["kedro_datasets.polars", "kedro_datasets.polars.eager_polars_dataset"],
-)
-@pytest.mark.parametrize("class_name", _DEPRECATED_CLASSES)
-def test_deprecation(module_name, class_name):
-    with pytest.warns(
-        KedroDeprecationWarning, match=f"{repr(class_name)} has been renamed"
-    ):
-        getattr(importlib.import_module(module_name), class_name)
 
 
 class TestEagerExcelDataset:

--- a/kedro-datasets/tests/redis/test_redis_dataset.py
+++ b/kedro-datasets/tests/redis/test_redis_dataset.py
@@ -8,10 +8,8 @@ import pytest
 import redis
 from pandas.testing import assert_frame_equal
 
-from kedro_datasets import KedroDeprecationWarning
 from kedro_datasets._io import DatasetError
 from kedro_datasets.redis import PickleDataset
-from kedro_datasets.redis.redis_dataset import _DEPRECATED_CLASSES
 
 
 @pytest.fixture(params=["pickle"])
@@ -57,17 +55,6 @@ def pickle_data_set(mocker, key, backend, load_args, save_args, redis_args):
         save_args=save_args,
         redis_args=redis_args,
     )
-
-
-@pytest.mark.parametrize(
-    "module_name", ["kedro_datasets.redis", "kedro_datasets.redis.redis_dataset"]
-)
-@pytest.mark.parametrize("class_name", _DEPRECATED_CLASSES)
-def test_deprecation(module_name, class_name):
-    with pytest.warns(
-        KedroDeprecationWarning, match=f"{repr(class_name)} has been renamed"
-    ):
-        getattr(importlib.import_module(module_name), class_name)
 
 
 class TestPickleDataset:

--- a/kedro-datasets/tests/snowflake/test_snowpark_dataset.py
+++ b/kedro-datasets/tests/snowflake/test_snowpark_dataset.py
@@ -1,20 +1,16 @@
 import datetime
-import importlib
 import os
 
 import pytest
 
-from kedro_datasets import KedroDeprecationWarning
 from kedro_datasets._io import DatasetError
 
 try:
     import snowflake.snowpark as sp
 
     from kedro_datasets.snowflake import SnowparkTableDataset as spds
-    from kedro_datasets.snowflake.snowpark_dataset import _DEPRECATED_CLASSES
 except ImportError:
-    # this is only for test discovery to succeed on Python <> 3.8
-    _DEPRECATED_CLASSES = ["SnowparkTableDataSet"]
+    pass  # this is only for test discovery to succeed on Python <> 3.8
 
 
 def get_connection():
@@ -139,19 +135,6 @@ def sf_session():
     yield sf_session
     sf_db_cleanup(sf_session)
     sf_session.close()
-
-
-@pytest.mark.parametrize(
-    "module_name",
-    ["kedro_datasets.snowflake", "kedro_datasets.snowflake.snowpark_dataset"],
-)
-@pytest.mark.parametrize("class_name", _DEPRECATED_CLASSES)
-@pytest.mark.snowflake
-def test_deprecation(module_name, class_name):
-    with pytest.warns(
-        KedroDeprecationWarning, match=f"{repr(class_name)} has been renamed"
-    ):
-        getattr(importlib.import_module(module_name), class_name)
 
 
 class TestSnowparkTableDataset:

--- a/kedro-datasets/tests/spark/test_deltatable_dataset.py
+++ b/kedro-datasets/tests/spark/test_deltatable_dataset.py
@@ -1,5 +1,3 @@
-import importlib
-
 import pytest
 from delta import DeltaTable
 from kedro.io import DataCatalog
@@ -12,10 +10,8 @@ from pyspark.sql import SparkSession
 from pyspark.sql.types import IntegerType, StringType, StructField, StructType
 from pyspark.sql.utils import AnalysisException
 
-from kedro_datasets import KedroDeprecationWarning
 from kedro_datasets._io import DatasetError
 from kedro_datasets.spark import DeltaTableDataset, SparkDataset
-from kedro_datasets.spark.deltatable_dataset import _DEPRECATED_CLASSES
 
 SPARK_VERSION = Version(__version__)
 
@@ -32,17 +28,6 @@ def sample_spark_df():
     data = [("Alex", 31), ("Bob", 12), ("Clarke", 65), ("Dave", 29)]
 
     return SparkSession.builder.getOrCreate().createDataFrame(data, schema)
-
-
-@pytest.mark.parametrize(
-    "module_name", ["kedro_datasets.spark", "kedro_datasets.spark.deltatable_dataset"]
-)
-@pytest.mark.parametrize("class_name", _DEPRECATED_CLASSES)
-def test_deprecation(module_name, class_name):
-    with pytest.warns(
-        KedroDeprecationWarning, match=f"{repr(class_name)} has been renamed"
-    ):
-        getattr(importlib.import_module(module_name), class_name)
 
 
 class TestDeltaTableDataset:

--- a/kedro-datasets/tests/spark/test_spark_dataset.py
+++ b/kedro-datasets/tests/spark/test_spark_dataset.py
@@ -1,4 +1,3 @@
-import importlib
 import re
 import sys
 import tempfile
@@ -26,13 +25,11 @@ from pyspark.sql.types import (
 )
 from pyspark.sql.utils import AnalysisException
 
-from kedro_datasets import KedroDeprecationWarning
 from kedro_datasets._io import DatasetError
 from kedro_datasets.pandas import CSVDataset, ParquetDataset
 from kedro_datasets.pickle import PickleDataset
 from kedro_datasets.spark import SparkDataset
 from kedro_datasets.spark.spark_dataset import (
-    _DEPRECATED_CLASSES,
     _dbfs_exists,
     _dbfs_glob,
     _get_dbutils,
@@ -171,17 +168,6 @@ class FileInfo:
 
     def isDir(self):
         return "." not in self.path.split("/")[-1]
-
-
-@pytest.mark.parametrize(
-    "module_name", ["kedro_datasets.spark", "kedro_datasets.spark.spark_dataset"]
-)
-@pytest.mark.parametrize("class_name", _DEPRECATED_CLASSES)
-def test_deprecation(module_name, class_name):
-    with pytest.warns(
-        KedroDeprecationWarning, match=f"{repr(class_name)} has been renamed"
-    ):
-        getattr(importlib.import_module(module_name), class_name)
 
 
 class TestSparkDataset:

--- a/kedro-datasets/tests/spark/test_spark_hive_dataset.py
+++ b/kedro-datasets/tests/spark/test_spark_hive_dataset.py
@@ -1,5 +1,4 @@
 import gc
-import importlib
 import re
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -10,10 +9,8 @@ from pyspark import SparkContext
 from pyspark.sql import SparkSession
 from pyspark.sql.types import IntegerType, StringType, StructField, StructType
 
-from kedro_datasets import KedroDeprecationWarning
 from kedro_datasets._io import DatasetError
 from kedro_datasets.spark import SparkHiveDataset
-from kedro_datasets.spark.spark_hive_dataset import _DEPRECATED_CLASSES
 
 TESTSPARKDIR = "test_spark_dir"
 
@@ -134,17 +131,6 @@ def _generate_spark_df_upsert_expected():
     )
     data = [("Alex", 99), ("Bob", 12), ("Clarke", 65), ("Dave", 29), ("Jeremy", 55)]
     return SparkSession.builder.getOrCreate().createDataFrame(data, schema).coalesce(1)
-
-
-@pytest.mark.parametrize(
-    "module_name", ["kedro_datasets.spark", "kedro_datasets.spark.spark_hive_dataset"]
-)
-@pytest.mark.parametrize("class_name", _DEPRECATED_CLASSES)
-def test_deprecation(module_name, class_name):
-    with pytest.warns(
-        KedroDeprecationWarning, match=f"{repr(class_name)} has been renamed"
-    ):
-        getattr(importlib.import_module(module_name), class_name)
 
 
 class TestSparkHiveDataset:

--- a/kedro-datasets/tests/spark/test_spark_jdbc_dataset.py
+++ b/kedro-datasets/tests/spark/test_spark_jdbc_dataset.py
@@ -1,11 +1,7 @@
-import importlib
-
 import pytest
 
-from kedro_datasets import KedroDeprecationWarning
 from kedro_datasets._io import DatasetError
 from kedro_datasets.spark import SparkJDBCDataset
-from kedro_datasets.spark.spark_jdbc_dataset import _DEPRECATED_CLASSES
 
 
 @pytest.fixture
@@ -35,17 +31,6 @@ def spark_jdbc_args_save_load(spark_jdbc_args):
         {"save_args": connection_properties, "load_args": connection_properties}
     )
     return args
-
-
-@pytest.mark.parametrize(
-    "module_name", ["kedro_datasets.spark", "kedro_datasets.spark.spark_jdbc_dataset"]
-)
-@pytest.mark.parametrize("class_name", _DEPRECATED_CLASSES)
-def test_deprecation(module_name, class_name):
-    with pytest.warns(
-        KedroDeprecationWarning, match=f"{repr(class_name)} has been renamed"
-    ):
-        getattr(importlib.import_module(module_name), class_name)
 
 
 def test_missing_url():

--- a/kedro-datasets/tests/spark/test_spark_streaming_dataset.py
+++ b/kedro-datasets/tests/spark/test_spark_streaming_dataset.py
@@ -1,4 +1,3 @@
-import importlib
 import json
 
 import boto3
@@ -10,10 +9,8 @@ from pyspark.sql import SparkSession
 from pyspark.sql.types import IntegerType, StringType, StructField, StructType
 from pyspark.sql.utils import AnalysisException
 
-from kedro_datasets import KedroDeprecationWarning
 from kedro_datasets._io import DatasetError
 from kedro_datasets.spark import SparkDataset, SparkStreamingDataset
-from kedro_datasets.spark.spark_streaming_dataset import _DEPRECATED_CLASSES
 
 SCHEMA_FILE_NAME = "schema.json"
 BUCKET_NAME = "test_bucket"
@@ -89,18 +86,6 @@ def mocked_s3_schema(tmp_path, mocked_s3_bucket, sample_spark_df_schema: StructT
         Bucket=BUCKET_NAME, Key=SCHEMA_FILE_NAME, Body=temporary_path.read_bytes()
     )
     return mocked_s3_bucket
-
-
-@pytest.mark.parametrize(
-    "module_name",
-    ["kedro_datasets.spark", "kedro_datasets.spark.spark_streaming_dataset"],
-)
-@pytest.mark.parametrize("class_name", _DEPRECATED_CLASSES)
-def test_deprecation(module_name, class_name):
-    with pytest.warns(
-        KedroDeprecationWarning, match=f"{repr(class_name)} has been renamed"
-    ):
-        getattr(importlib.import_module(module_name), class_name)
 
 
 class TestSparkStreamingDataset:

--- a/kedro-datasets/tests/svmlight/test_svmlight_dataset.py
+++ b/kedro-datasets/tests/svmlight/test_svmlight_dataset.py
@@ -1,4 +1,3 @@
-import importlib
 from pathlib import Path, PurePosixPath
 
 import numpy as np
@@ -9,10 +8,8 @@ from gcsfs import GCSFileSystem
 from kedro.io.core import PROTOCOL_DELIMITER, Version
 from s3fs.core import S3FileSystem
 
-from kedro_datasets import KedroDeprecationWarning
 from kedro_datasets._io import DatasetError
 from kedro_datasets.svmlight import SVMLightDataset
-from kedro_datasets.svmlight.svmlight_dataset import _DEPRECATED_CLASSES
 
 
 @pytest.fixture
@@ -39,18 +36,6 @@ def dummy_data():
     features = np.array([[1, 2, 10], [1, 0.4, 3.2], [0, 0, 0]])
     label = np.array([1, 0, 3])
     return features, label
-
-
-@pytest.mark.parametrize(
-    "module_name",
-    ["kedro_datasets.svmlight", "kedro_datasets.svmlight.svmlight_dataset"],
-)
-@pytest.mark.parametrize("class_name", _DEPRECATED_CLASSES)
-def test_deprecation(module_name, class_name):
-    with pytest.warns(
-        KedroDeprecationWarning, match=f"{repr(class_name)} has been renamed"
-    ):
-        getattr(importlib.import_module(module_name), class_name)
 
 
 class TestSVMLightDataset:

--- a/kedro-datasets/tests/tensorflow/test_tensorflow_model_dataset.py
+++ b/kedro-datasets/tests/tensorflow/test_tensorflow_model_dataset.py
@@ -146,7 +146,7 @@ def dummy_tf_subclassed_model(dummy_x_train, dummy_y_train, tf):
     "module_name",
     ["kedro_datasets.tensorflow", "kedro_datasets.tensorflow.tensorflow_model_dataset"],
 )
-@pytest.mark.parametrize("class_name", ["TensorFlowModelDataSet"])
+@pytest.mark.parametrize("class_name", ["TensorFlowModelDataset"])
 def test_deprecation(module_name, class_name):
     with pytest.warns(
         KedroDeprecationWarning, match=f"{repr(class_name)} has been renamed"

--- a/kedro-datasets/tests/tensorflow/test_tensorflow_model_dataset.py
+++ b/kedro-datasets/tests/tensorflow/test_tensorflow_model_dataset.py
@@ -1,4 +1,3 @@
-import importlib
 import sys
 from pathlib import PurePosixPath
 
@@ -10,7 +9,6 @@ from gcsfs import GCSFileSystem
 from kedro.io.core import PROTOCOL_DELIMITER, Version
 from s3fs import S3FileSystem
 
-from kedro_datasets import KedroDeprecationWarning
 from kedro_datasets._io import DatasetError
 
 if sys.platform == "win32":
@@ -140,18 +138,6 @@ def dummy_tf_subclassed_model(dummy_x_train, dummy_y_train, tf):
     model.compile("rmsprop", "mse")
     model.fit(dummy_x_train, dummy_y_train, batch_size=64, epochs=1)
     return model
-
-
-@pytest.mark.parametrize(
-    "module_name",
-    ["kedro_datasets.tensorflow", "kedro_datasets.tensorflow.tensorflow_model_dataset"],
-)
-@pytest.mark.parametrize("class_name", ["TensorFlowModelDataset"])
-def test_deprecation(module_name, class_name):
-    with pytest.warns(
-        KedroDeprecationWarning, match=f"{repr(class_name)} has been renamed"
-    ):
-        getattr(importlib.import_module(module_name), class_name)
 
 
 class TestTensorFlowModelDataset:

--- a/kedro-datasets/tests/text/test_text_dataset.py
+++ b/kedro-datasets/tests/text/test_text_dataset.py
@@ -1,4 +1,3 @@
-import importlib
 from pathlib import Path, PurePosixPath
 
 import pytest
@@ -8,10 +7,8 @@ from gcsfs import GCSFileSystem
 from kedro.io.core import PROTOCOL_DELIMITER, Version
 from s3fs.core import S3FileSystem
 
-from kedro_datasets import KedroDeprecationWarning
 from kedro_datasets._io import DatasetError
 from kedro_datasets.text import TextDataset
-from kedro_datasets.text.text_dataset import _DEPRECATED_CLASSES
 
 STRING = "Write to text file."
 
@@ -31,17 +28,6 @@ def versioned_txt_dataset(filepath_txt, load_version, save_version):
     return TextDataset(
         filepath=filepath_txt, version=Version(load_version, save_version)
     )
-
-
-@pytest.mark.parametrize(
-    "module_name", ["kedro_datasets.text", "kedro_datasets.text.text_dataset"]
-)
-@pytest.mark.parametrize("class_name", _DEPRECATED_CLASSES)
-def test_deprecation(module_name, class_name):
-    with pytest.warns(
-        KedroDeprecationWarning, match=f"{repr(class_name)} has been renamed"
-    ):
-        getattr(importlib.import_module(module_name), class_name)
 
 
 class TestTextDataset:

--- a/kedro-datasets/tests/tracking/test_json_dataset.py
+++ b/kedro-datasets/tests/tracking/test_json_dataset.py
@@ -1,4 +1,3 @@
-import importlib
 import json
 from pathlib import Path, PurePosixPath
 
@@ -8,10 +7,8 @@ from gcsfs import GCSFileSystem
 from kedro.io.core import PROTOCOL_DELIMITER, Version
 from s3fs.core import S3FileSystem
 
-from kedro_datasets import KedroDeprecationWarning
 from kedro_datasets._io import DatasetError
 from kedro_datasets.tracking import JSONDataset
-from kedro_datasets.tracking.json_dataset import _DEPRECATED_CLASSES
 
 
 @pytest.fixture
@@ -34,17 +31,6 @@ def explicit_versioned_json_dataset(filepath_json, load_version, save_version):
 @pytest.fixture
 def dummy_data():
     return {"col1": 1, "col2": 2, "col3": "mystring"}
-
-
-@pytest.mark.parametrize(
-    "module_name", ["kedro_datasets.tracking", "kedro_datasets.tracking.json_dataset"]
-)
-@pytest.mark.parametrize("class_name", _DEPRECATED_CLASSES)
-def test_deprecation(module_name, class_name):
-    with pytest.warns(
-        KedroDeprecationWarning, match=f"{repr(class_name)} has been renamed"
-    ):
-        getattr(importlib.import_module(module_name), class_name)
 
 
 class TestJSONDataset:

--- a/kedro-datasets/tests/tracking/test_metrics_dataset.py
+++ b/kedro-datasets/tests/tracking/test_metrics_dataset.py
@@ -1,4 +1,3 @@
-import importlib
 import json
 from pathlib import Path, PurePosixPath
 
@@ -8,10 +7,8 @@ from gcsfs import GCSFileSystem
 from kedro.io.core import PROTOCOL_DELIMITER, Version
 from s3fs.core import S3FileSystem
 
-from kedro_datasets import KedroDeprecationWarning
 from kedro_datasets._io import DatasetError
 from kedro_datasets.tracking import MetricsDataset
-from kedro_datasets.tracking.metrics_dataset import _DEPRECATED_CLASSES
 
 
 @pytest.fixture
@@ -34,18 +31,6 @@ def explicit_versioned_metrics_dataset(filepath_json, load_version, save_version
 @pytest.fixture
 def dummy_data():
     return {"col1": 1, "col2": 2, "col3": 3}
-
-
-@pytest.mark.parametrize(
-    "module_name",
-    ["kedro_datasets.tracking", "kedro_datasets.tracking.metrics_dataset"],
-)
-@pytest.mark.parametrize("class_name", _DEPRECATED_CLASSES)
-def test_deprecation(module_name, class_name):
-    with pytest.warns(
-        KedroDeprecationWarning, match=f"{repr(class_name)} has been renamed"
-    ):
-        getattr(importlib.import_module(module_name), class_name)
 
 
 class TestMetricsDataset:

--- a/kedro-datasets/tests/video/test_video_dataset.py
+++ b/kedro-datasets/tests/video/test_video_dataset.py
@@ -1,15 +1,11 @@
-import importlib
-
 import boto3
 import pytest
 from moto import mock_s3
 from utils import TEST_FPS, assert_videos_equal
 
-from kedro_datasets import KedroDeprecationWarning
 from kedro_datasets._io import DatasetError
 from kedro_datasets.video import VideoDataset
 from kedro_datasets.video.video_dataset import (
-    _DEPRECATED_CLASSES,
     FileVideo,
     SequenceVideo,
 )
@@ -52,17 +48,6 @@ def mocked_s3_bucket():
         )
         conn.create_bucket(Bucket=S3_BUCKET_NAME)
         yield conn
-
-
-@pytest.mark.parametrize(
-    "module_name", ["kedro_datasets.video", "kedro_datasets.video.video_dataset"]
-)
-@pytest.mark.parametrize("class_name", _DEPRECATED_CLASSES)
-def test_deprecation(module_name, class_name):
-    with pytest.warns(
-        KedroDeprecationWarning, match=f"{repr(class_name)} has been renamed"
-    ):
-        getattr(importlib.import_module(module_name), class_name)
 
 
 class TestVideoDataset:

--- a/kedro-datasets/tests/yaml/test_yaml_dataset.py
+++ b/kedro-datasets/tests/yaml/test_yaml_dataset.py
@@ -1,4 +1,3 @@
-import importlib
 from pathlib import Path, PurePosixPath
 
 import pandas as pd
@@ -10,10 +9,8 @@ from kedro.io.core import PROTOCOL_DELIMITER, Version
 from pandas.testing import assert_frame_equal
 from s3fs.core import S3FileSystem
 
-from kedro_datasets import KedroDeprecationWarning
 from kedro_datasets._io import DatasetError
 from kedro_datasets.yaml import YAMLDataset
-from kedro_datasets.yaml.yaml_dataset import _DEPRECATED_CLASSES
 
 
 @pytest.fixture
@@ -36,17 +33,6 @@ def versioned_yaml_dataset(filepath_yaml, load_version, save_version):
 @pytest.fixture
 def dummy_data():
     return {"col1": 1, "col2": 2, "col3": 3}
-
-
-@pytest.mark.parametrize(
-    "module_name", ["kedro_datasets.yaml", "kedro_datasets.yaml.yaml_dataset"]
-)
-@pytest.mark.parametrize("class_name", _DEPRECATED_CLASSES)
-def test_deprecation(module_name, class_name):
-    with pytest.warns(
-        KedroDeprecationWarning, match=f"{repr(class_name)} has been renamed"
-    ):
-        getattr(importlib.import_module(module_name), class_name)
 
 
 class TestYAMLDataset:

--- a/kedro-docker/README.md
+++ b/kedro-docker/README.md
@@ -187,3 +187,6 @@ Yes! Want to help build Kedro-Docker? Check out our guide to [contributing](http
 ## What licence do you use?
 
 Kedro-Docker is licensed under the [Apache 2.0](https://github.com/kedro-org/kedro-plugins/blob/main/LICENSE.md) License.
+
+## Python version support policy
+* The [Kedro-Docker](https://github.com/kedro-org/kedro-plugins/tree/main/kedro-docker) supports all Python versions that are actively maintained by the CPython core team. When a [Python version reaches end of life](https://devguide.python.org/versions/#versions), support for that version is dropped from `kedro-docker`. This is not considered a breaking change.

--- a/kedro-telemetry/README.md
+++ b/kedro-telemetry/README.md
@@ -78,3 +78,11 @@ Kedro-Telemetry is installed, but you have opted out of sharing usage analytics 
 ## How is the data collected
 
 Kedro-Telemetry uses [`pluggy`](https://pypi.org/project/pluggy/) hooks and [`requests`](https://pypi.org/project/requests/) to send data to [Heap Analytics](https://heap.io/). Project maintainers have access to the data and can create dashboards that show adoption and feature usage.
+
+## What licence do you use?
+
+Kedro-Telemetry is licensed under the [Apache 2.0](https://github.com/kedro-org/kedro-plugins/blob/main/LICENSE.md) License.
+
+## Python version support policy
+
+* The [Kedro-Telemetry](https://github.com/kedro-org/kedro-plugins/tree/main/kedro-telemetry) supports all Python versions that are actively maintained by the CPython core team. When a [Python version reaches end of life](https://devguide.python.org/versions/#versions), support for that version is dropped from `kedro-telemetry`. This is not considered a breaking change.


### PR DESCRIPTION
## Description
Closes [Remove all old DataSet classes#3159](https://github.com/kedro-org/kedro/issues/3159)

## Development notes
- Removed all aliases from `DataSet` to `Dataset`
- Renamed all remaining mentions of `DataSet` to `Dataset`
- Removed mentions of `polars.GenericDataset` which is replaced by `polars.EagerPolarsDataset`

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
