### PR TITLE
chore(datasets): Fix `pandas.GenericDataset` doctest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,6 @@ dataset-doctests:
 	  --ignore kedro_datasets/matplotlib/matplotlib_writer.py \
 	  --ignore kedro_datasets/pandas/deltatable_dataset.py \
 	  --ignore kedro_datasets/pandas/gbq_dataset.py \
-	  --ignore kedro_datasets/pandas/generic_dataset.py \
 	  --ignore kedro_datasets/pandas/sql_dataset.py \
 	  --ignore kedro_datasets/partitions/incremental_dataset.py \
 	  --ignore kedro_datasets/partitions/partitioned_dataset.py \

--- a/kedro-datasets/kedro_datasets/pandas/generic_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/generic_dataset.py
@@ -70,7 +70,9 @@ class GenericDataset(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
         >>>
         >>> data = pd.DataFrame({"col1": [1, 2], "col2": [4, 5], "col3": [5, 6]})
         >>>
-        >>> dataset = GenericDataset(filepath="test.csv", file_format="csv")
+        >>> dataset = GenericDataset(
+        ...     filepath="test.csv", file_format="csv", save_args={"index": False}
+        ... )
         >>> dataset.save(data)
         >>> reloaded = dataset.load()
         >>> assert data.equals(reloaded)


### PR DESCRIPTION
## Description
Part of https://github.com/kedro-org/kedro/issues/2287

## Development notes
In `pandas.CSVDataset` the save_args are set by default to `DEFAULT_SAVE_ARGS: Dict[str, Any] = {"index": False}` in `pandas.GenericDataset` they're not so the index was being saved in the example leading to the expected and real result not matching.

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
