### PR TITLE
chore(datasets): fix accidental reference to NumPy

### DIFF
--- a/kedro-datasets/kedro_datasets/conftest.py
+++ b/kedro-datasets/kedro_datasets/conftest.py
@@ -2,5 +2,5 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
-def add_np(doctest_namespace, tmp_path):
+def add_tmp_path(doctest_namespace, tmp_path):
     doctest_namespace["tmp_path"] = tmp_path


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
When I copy-pasted the example from pytest docs, I forgot to change `add_np` to something else. Oops.

## Development notes
<!-- What have you changed, and how has this been tested? -->
No actual effect, but `add_np` doesn't make sense.

## Checklist

- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
