### PR TITLE
chore(datasets): Fix more doctest issues 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,6 @@ dataset-doctests:
 	  --ignore kedro_datasets/pandas/gbq_dataset.py \
 	  --ignore kedro_datasets/pandas/sql_dataset.py \
 	  --ignore kedro_datasets/partitions/partitioned_dataset.py \
-	  --ignore kedro_datasets/pillow/image_dataset.py \
 	  --ignore kedro_datasets/polars/lazy_polars_dataset.py \
 	  --ignore kedro_datasets/redis/redis_dataset.py \
 	  --ignore kedro_datasets/snowflake/snowpark_dataset.py \

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,6 @@ dataset-doctests:
 	  --ignore kedro_datasets/matplotlib/matplotlib_writer.py \
 	  --ignore kedro_datasets/pandas/deltatable_dataset.py \
 	  --ignore kedro_datasets/pandas/gbq_dataset.py \
-	  --ignore kedro_datasets/pandas/generic_dataset.py \
 	  --ignore kedro_datasets/pandas/sql_dataset.py \
 	  --ignore kedro_datasets/partitions/incremental_dataset.py \
 	  --ignore kedro_datasets/partitions/partitioned_dataset.py \

--- a/Makefile
+++ b/Makefile
@@ -40,8 +40,7 @@ dataset-doctests:
 	  --ignore kedro_datasets/spark/deltatable_dataset.py \
 	  --ignore kedro_datasets/spark/spark_hive_dataset.py \
 	  --ignore kedro_datasets/spark/spark_jdbc_dataset.py \
-	  --ignore kedro_datasets/tensorflow/tensorflow_model_dataset.py \
-	  --ignore kedro_datasets/video/video_dataset.py
+	  --ignore kedro_datasets/tensorflow/tensorflow_model_dataset.py
 
 test-sequential:
 	cd $(plugin) && pytest tests --cov-config pyproject.toml

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ dataset-doctests:
 	  --ignore kedro_datasets/pandas/deltatable_dataset.py \
 	  --ignore kedro_datasets/pandas/gbq_dataset.py \
 	  --ignore kedro_datasets/pandas/sql_dataset.py \
+	  --ignore kedro_datasets/partitions/incremental_dataset.py \
 	  --ignore kedro_datasets/partitions/partitioned_dataset.py \
 	  --ignore kedro_datasets/polars/lazy_polars_dataset.py \
 	  --ignore kedro_datasets/redis/redis_dataset.py \

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,6 @@ dataset-doctests:
 	  --ignore kedro_datasets/pandas/deltatable_dataset.py \
 	  --ignore kedro_datasets/pandas/gbq_dataset.py \
 	  --ignore kedro_datasets/pandas/sql_dataset.py \
-	  --ignore kedro_datasets/partitions/incremental_dataset.py \
 	  --ignore kedro_datasets/partitions/partitioned_dataset.py \
 	  --ignore kedro_datasets/pillow/image_dataset.py \
 	  --ignore kedro_datasets/polars/lazy_polars_dataset.py \

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,6 @@ dataset-doctests:
 	  --ignore kedro_datasets/redis/redis_dataset.py \
 	  --ignore kedro_datasets/snowflake/snowpark_dataset.py \
 	  --ignore kedro_datasets/spark/deltatable_dataset.py \
-	  --ignore kedro_datasets/spark/spark_dataset.py \
 	  --ignore kedro_datasets/spark/spark_hive_dataset.py \
 	  --ignore kedro_datasets/spark/spark_jdbc_dataset.py \
 	  --ignore kedro_datasets/tensorflow/tensorflow_model_dataset.py \

--- a/kedro-datasets/kedro_datasets/pandas/generic_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/generic_dataset.py
@@ -70,7 +70,9 @@ class GenericDataset(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
         >>>
         >>> data = pd.DataFrame({"col1": [1, 2], "col2": [4, 5], "col3": [5, 6]})
         >>>
-        >>> dataset = GenericDataset(filepath="test.csv", file_format="csv")
+        >>> dataset = GenericDataset(
+        ...     filepath="test.csv", file_format="csv", save_args={"index": False}
+        ... )
         >>> dataset.save(data)
         >>> reloaded = dataset.load()
         >>> assert data.equals(reloaded)

--- a/kedro-datasets/kedro_datasets/partitions/incremental_dataset.py
+++ b/kedro-datasets/kedro_datasets/partitions/incremental_dataset.py
@@ -40,14 +40,8 @@ class IncrementalDataset(PartitionedDataset):
 
         >>> from kedro_datasets.partitions import IncrementalDataset
         >>>
-        >>> # these credentials will be passed to:
-        >>> # a) 'fsspec.filesystem()' call,
-        >>> # b) the dataset initializer,
-        >>> # c) the checkpoint initializer
-        >>> credentials = {"key1": "secret1", "key2": "secret2"}
-        >>>
         >>> dataset = IncrementalDataset(
-        ...     path=tmp_path / "path/to/folder",
+        ...     path="path/to/folder",
         ...     dataset="pandas.CSVDataset",
         ... )
         >>> loaded = dataset.load()  # loads all available partitions
@@ -58,7 +52,7 @@ class IncrementalDataset(PartitionedDataset):
         >>>
         >>> dataset.release()  # clears load cache
         >>> # returns an empty dictionary as no new partitions were added
-        >>> dataset.load()
+        >>> assert dataset.load() == {}
     """
 
     DEFAULT_CHECKPOINT_TYPE = "kedro_datasets.text.TextDataset"

--- a/kedro-datasets/kedro_datasets/partitions/incremental_dataset.py
+++ b/kedro-datasets/kedro_datasets/partitions/incremental_dataset.py
@@ -47,9 +47,8 @@ class IncrementalDataset(PartitionedDataset):
         >>> credentials = {"key1": "secret1", "key2": "secret2"}
         >>>
         >>> dataset = IncrementalDataset(
-        ...     path="s3://bucket-name/path/to/folder",
+        ...     path=tmp_path / "path/to/folder",
         ...     dataset="pandas.CSVDataset",
-        ...     credentials=credentials,
         ... )
         >>> loaded = dataset.load()  # loads all available partitions
         >>> # assert isinstance(loaded, dict)

--- a/kedro-datasets/kedro_datasets/partitions/incremental_dataset.py
+++ b/kedro-datasets/kedro_datasets/partitions/incremental_dataset.py
@@ -40,9 +40,16 @@ class IncrementalDataset(PartitionedDataset):
 
         >>> from kedro_datasets.partitions import IncrementalDataset
         >>>
+        >>> # these credentials will be passed to:
+        >>> # a) 'fsspec.filesystem()' call,
+        >>> # b) the dataset initializer,
+        >>> # c) the checkpoint initializer
+        >>> credentials = {"key1": "secret1", "key2": "secret2"}
+        >>>
         >>> dataset = IncrementalDataset(
-        ...     path=tmp_path / "path/to/folder",
+        ...     path="s3://bucket-name/path/to/folder",
         ...     dataset="pandas.CSVDataset",
+        ...     credentials=credentials,
         ... )
         >>> loaded = dataset.load()  # loads all available partitions
         >>> # assert isinstance(loaded, dict)

--- a/kedro-datasets/kedro_datasets/partitions/incremental_dataset.py
+++ b/kedro-datasets/kedro_datasets/partitions/incremental_dataset.py
@@ -41,7 +41,7 @@ class IncrementalDataset(PartitionedDataset):
         >>> from kedro_datasets.partitions import IncrementalDataset
         >>>
         >>> dataset = IncrementalDataset(
-        ...     path="path/to/folder",
+        ...     path=tmp_path / "path/to/folder",
         ...     dataset="pandas.CSVDataset",
         ... )
         >>> loaded = dataset.load()  # loads all available partitions

--- a/kedro-datasets/kedro_datasets/pillow/image_dataset.py
+++ b/kedro-datasets/kedro_datasets/pillow/image_dataset.py
@@ -24,7 +24,7 @@ class ImageDataset(AbstractVersionedDataset[Image.Image, Image.Image]):
 
         >>> from kedro_datasets.pillow import ImageDataset
         >>>
-        >>> dataset = ImageDataset(filepath="test.png")
+        >>> dataset = ImageDataset(filepath="https://storage.googleapis.com/gtv-videos-bucket/sample/images/ForBiggerBlazes.jpg")
         >>> image = dataset.load()
         >>> image.show()
 

--- a/kedro-datasets/kedro_datasets/spark/spark_dataset.py
+++ b/kedro-datasets/kedro_datasets/spark/spark_dataset.py
@@ -233,7 +233,7 @@ class SparkDataset(AbstractVersionedDataset[DataFrame, DataFrame]):
     .. code-block:: pycon
 
         >>> from pyspark.sql import SparkSession
-        >>> from pyspark.sql.types import StructField, StringType, IntegerType, StructType, Row
+        >>> from pyspark.sql.types import IntegerType, Row, StructField, StructType
         >>>
         >>> from kedro_datasets.spark import SparkDataset
         >>>

--- a/kedro-datasets/kedro_datasets/spark/spark_dataset.py
+++ b/kedro-datasets/kedro_datasets/spark/spark_dataset.py
@@ -233,7 +233,7 @@ class SparkDataset(AbstractVersionedDataset[DataFrame, DataFrame]):
     .. code-block:: pycon
 
         >>> from pyspark.sql import SparkSession
-        >>> from pyspark.sql.types import IntegerType, Row, StructField, StructType
+        >>> from pyspark.sql.types import IntegerType, Row, StringType, StructField, StructType
         >>>
         >>> from kedro_datasets.spark import SparkDataset
         >>>

--- a/kedro-datasets/kedro_datasets/spark/spark_dataset.py
+++ b/kedro-datasets/kedro_datasets/spark/spark_dataset.py
@@ -233,7 +233,7 @@ class SparkDataset(AbstractVersionedDataset[DataFrame, DataFrame]):
     .. code-block:: pycon
 
         >>> from pyspark.sql import SparkSession
-        >>> from pyspark.sql.types import StructField, StringType, IntegerType, StructType
+        >>> from pyspark.sql.types import StructField, StringType, IntegerType, StructType, Row
         >>>
         >>> from kedro_datasets.spark import SparkDataset
         >>>
@@ -249,7 +249,7 @@ class SparkDataset(AbstractVersionedDataset[DataFrame, DataFrame]):
         >>> dataset.save(spark_df)
         >>> reloaded = dataset.load()
         >>>
-        >>> reloaded.take(4)
+        >>> assert Row(name='Bob', age=12) in reloaded.take(4)
     """
 
     # this dataset cannot be used with ``ParallelRunner``,

--- a/kedro-datasets/kedro_datasets/spark/spark_jdbc_dataset.py
+++ b/kedro-datasets/kedro_datasets/spark/spark_jdbc_dataset.py
@@ -40,7 +40,7 @@ class SparkJDBCDataset(AbstractDataset[DataFrame, DataFrame]):
     .. code-block:: pycon
 
         >>> import pandas as pd
-        >>> from kedro_datasets import SparkJBDCDataset
+        >>> from kedro_datasets.spark import SparkJBDCDataset
         >>> from pyspark.sql import SparkSession
         >>>
         >>> spark = SparkSession.builder.getOrCreate()

--- a/kedro-datasets/kedro_datasets/video/video_dataset.py
+++ b/kedro-datasets/kedro_datasets/video/video_dataset.py
@@ -225,9 +225,11 @@ class VideoDataset(AbstractDataset[AbstractVideo, AbstractVideo]):
         >>> from kedro_datasets.video import VideoDataset
         >>> import numpy as np
         >>>
-        >>> video = VideoDataset(filepath="/video/file/path.mp4").load()
+        >>> video = VideoDataset(
+        ...     filepath="https://storage.googleapis.com/gtv-videos-bucket/sample/ForBiggerBlazes.mp4"
+        ... ).load()
         >>> frame = video[0]
-        >>> np.sum(np.asarray(frame))
+        >>> assert isinstance(np.sum(np.asarray(frame)), np.uint64)
 
 
     Example creating a video from numpy frames using Python API:
@@ -244,7 +246,7 @@ class VideoDataset(AbstractDataset[AbstractVideo, AbstractVideo]):
         ...     imgs.append(Image.fromarray(frame))
         ...     frame -= 1
         ...
-        >>> video = VideoDataset("my_video.mp4")
+        >>> video = VideoDataset(filepath="my_video.mp4")
         >>> video.save(SequenceVideo(imgs, fps=25))
 
 
@@ -262,7 +264,7 @@ class VideoDataset(AbstractDataset[AbstractVideo, AbstractVideo]):
         ...         yield Image.fromarray(frame)
         ...         frame -= 1
         ...
-        >>> video = VideoDataset("my_video.mp4")
+        >>> video = VideoDataset(filepath="my_video.mp4")
         >>> video.save(GeneratorVideo(gen(), fps=25, length=None))
 
     """


### PR DESCRIPTION
## Description
Part of [Make sure all example code blocks for datasets are runnable#2287](https://github.com/kedro-org/kedro/issues/2287)

## Development notes

- The "fix" for `IncrementalDataset` maybe isn't really a fix, but rather changing the example to not use S3. I think it's fine, but would like to hear what others think. **Edit: reverted these changes now because it didn't fix the issue.**
- Fixed the import of `spark.SparkJDBCDataset`, but it needs more changes to work. 
- Fixed the `pillow.ImageDataset` and `video.VideoDataset` by linking to sample video and image data.

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
