### PR TITLE
chore(airflow): Bump `apache-airflow` version

### DIFF
--- a/kedro-airflow/features/airflow.feature
+++ b/kedro-airflow/features/airflow.feature
@@ -11,8 +11,8 @@ Feature: Airflow
     When I execute the airflow command "tasks list project-dummy"
     Then I should get a successful exit code
     And I should get a message including "split"
-    And I should get a message including "make-predictions"
-    And I should get a message including "report-accuracy"
+    And I should get a message including "train"
+    And I should get a message including "predict"
 
   Scenario: Run Airflow task locally with latest Kedro
     Given I have installed kedro version "latest"
@@ -22,4 +22,4 @@ Feature: Airflow
     And I have installed the kedro project package
     When I execute the airflow command "tasks test project-dummy split"
     Then I should get a successful exit code
-    And I should get a message including "Loading data from companies"
+    And I should get a message including "Loading data from example_iris_data"

--- a/kedro-airflow/features/airflow.feature
+++ b/kedro-airflow/features/airflow.feature
@@ -10,9 +10,9 @@ Feature: Airflow
     And I have executed the kedro command "airflow create -t ../airflow/dags/"
     When I execute the airflow command "tasks list project-dummy"
     Then I should get a successful exit code
-    And I should get a message including "create-model-input-table-node"
-    And I should get a message including "preprocess-companies-node"
-    And I should get a message including "preprocess-shuttles-node"
+    And I should get a message including "split"
+    And I should get a message including "make-predictions"
+    And I should get a message including "report-accuracy"
 
   Scenario: Run Airflow task locally with latest Kedro
     Given I have installed kedro version "latest"
@@ -20,6 +20,6 @@ Feature: Airflow
     And I have run a non-interactive kedro new
     And I have executed the kedro command "airflow create -t ../airflow/dags/"
     And I have installed the kedro project package
-    When I execute the airflow command "tasks test project-dummy preprocess-companies-node"
+    When I execute the airflow command "tasks test project-dummy split"
     Then I should get a successful exit code
     And I should get a message including "Loading data from companies"

--- a/kedro-airflow/features/airflow.feature
+++ b/kedro-airflow/features/airflow.feature
@@ -22,4 +22,4 @@ Feature: Airflow
     And I have installed the kedro project package
     When I execute the airflow command "tasks test project-dummy split"
     Then I should get a successful exit code
-    And I should get a message including "Loading data from example_iris_data"
+    And I should get a message including "Loading data"

--- a/kedro-airflow/features/steps/cli_steps.py
+++ b/kedro-airflow/features/steps/cli_steps.py
@@ -93,7 +93,7 @@ def create_project_from_config_file(context):
             "-c",
             str(context.config_file),
             "--starter",
-            "spaceflights-pandas",
+            "astro-airflow-iris",
         ],
         env=context.env,
         cwd=str(context.temp_dir),

--- a/kedro-airflow/pyproject.toml
+++ b/kedro-airflow/pyproject.toml
@@ -24,13 +24,12 @@ Tracker = "https://github.com/kedro-org/kedro-plugins/issues"
 
 [project.optional-dependencies]
 test = [
-    "apache-airflow<2.7.0", # TODO: Temporary fix, to be reverted
+    "apache-airflow<3.0",
     "bandit",
     "behave",
     "black~=22.0",
     "connexion<3.0.0", # TODO: Temporary fix, connexion has changed their API, but airflow hasn't caught up yet
     "kedro-datasets",
-    "pendulum<3.0.0", # TODO: Also to be removed
     "pre-commit>=2.9.2",
     "pytest",
     "pytest-cov",


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
Fix #315 

## Development notes
<!-- What have you changed, and how has this been tested? -->
- Unpin `apache-airflow` in test requirements
- Changed the starter used in e2e tests to `spaceflights-pandas` to `astro-airflow-iris`

This is because `apache-airflow` has moved to `pydantic v2` in 2.8.0. The spaceflights starters have `kedro-viz` in their requirements and `kedro-viz` still uses `pydantic v1`. So, in the e2e-tests, the installation of the kedro project, which also installs `kedro-viz` was downgrading pydantic to v1 which was causing failures. `astro-airflow-iris` doesn't have `kedro-viz` in the requirements. 


## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
