### PR TITLE
ci(datasets): Unpin dask

### DIFF
--- a/kedro-datasets/kedro_datasets/dask/parquet_dataset.py
+++ b/kedro-datasets/kedro_datasets/dask/parquet_dataset.py
@@ -41,7 +41,7 @@ class ParquetDataset(AbstractDataset[dd.DataFrame, dd.DataFrame]):
         >>> from kedro_datasets.dask import ParquetDataset
         >>> from pandas.testing import assert_frame_equal
         >>>
-        >>> data = pd.DataFrame({"col1": [1, 2], "col2": [4, 5], "col3": [[5, 6], [7, 8]]})
+        >>> data = pd.DataFrame({"col1": [1, 2], "col2": [4, 5], "col3": [6, 7]})
         >>> ddf = dd.from_pandas(data, npartitions=2)
         >>>
         >>> dataset = ParquetDataset(

--- a/kedro-datasets/kedro_datasets/dask/parquet_dataset.py
+++ b/kedro-datasets/kedro_datasets/dask/parquet_dataset.py
@@ -39,7 +39,7 @@ class ParquetDataset(AbstractDataset[dd.DataFrame, dd.DataFrame]):
         >>> import dask.dataframe as dd
         >>> import pandas as pd
         >>> from kedro_datasets.dask import ParquetDataset
-        >>> from pandas.testing import assert_frame_equal
+        >>> import numpy as np
         >>>
         >>> data = pd.DataFrame({"col1": [1, 2], "col2": [4, 5], "col3": [6, 7]})
         >>> ddf = dd.from_pandas(data, npartitions=2)
@@ -50,7 +50,7 @@ class ParquetDataset(AbstractDataset[dd.DataFrame, dd.DataFrame]):
         >>> dataset.save(ddf)
         >>> reloaded = dataset.load()
         >>>
-        >>> assert_frame_equal(ddf.compute(), reloaded.compute())
+        >>> assert np.array_equal(ddf.compute(), reloaded.compute())
 
     The output schema can also be explicitly specified using
     `Triad <https://triad.readthedocs.io/en/latest/api/\
@@ -145,7 +145,9 @@ class ParquetDataset(AbstractDataset[dd.DataFrame, dd.DataFrame]):
 
     def _save(self, data: dd.DataFrame) -> None:
         self._process_schema()
-        data.to_parquet(self._filepath, storage_options=self.fs_args, **self._save_args)
+        data.to_parquet(
+            path=self._filepath, storage_options=self.fs_args, **self._save_args
+        )
 
     def _process_schema(self) -> None:
         """This method processes the schema in the catalog.yml or the API, if provided.

--- a/kedro-datasets/setup.py
+++ b/kedro-datasets/setup.py
@@ -180,7 +180,7 @@ extras_require["test"] = [
     "cloudpickle<=2.0.0",
     "compress-pickle[lz4]~=2.1.0",
     "coverage[toml]",
-    "dask[complete]~=2024.1.0",
+    "dask[complete]>=2021.10",
     "delta-spark>=1.0, <3.0",
     "deltalake>=0.10.0",
     "dill~=0.3.1",

--- a/kedro-datasets/setup.py
+++ b/kedro-datasets/setup.py
@@ -180,7 +180,7 @@ extras_require["test"] = [
     "cloudpickle<=2.0.0",
     "compress-pickle[lz4]~=2.1.0",
     "coverage[toml]",
-    "dask[complete]~=2021.10",  # pinned by Snyk to avoid a vulnerability
+    "dask[complete]~=2024.1.0",
     "delta-spark>=1.0, <3.0",
     "deltalake>=0.10.0",
     "dill~=0.3.1",


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
Fix https://github.com/kedro-org/kedro-plugins/issues/520

## Development notes
<!-- What have you changed, and how has this been tested? -->
I think the tests on `kedro-datasets` were failing because there was a new release of `pyarrow` recently. The `dask` version was pinned to a 2021 version for a while. I've bumped the dask version in the test requirements and changed the code snippet in the doc string to get the doc test running.


## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
