### PR TITLE
ci(datasets): Update pyproject.toml to pin Kedro 0.19 for kedro-datasets

### DIFF
--- a/kedro-datasets/pyproject.toml
+++ b/kedro-datasets/pyproject.toml
@@ -11,7 +11,7 @@ description = "Kedro-Datasets is where you can find all of Kedro's data connecto
 requires-python = ">=3.9"
 license = {text = "Apache Software License (Apache 2.0)"}
 dependencies = [
-    "kedro>=0.16",
+    "kedro>=0.19",
     "lazy_loader",
 ]
 dynamic = ["readme", "version", "optional-dependencies"]


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
kedro-datasets 2.0 requires `AbstractDataset` which is not compatible with kedro < 0.19. This should reflect in the pyproject.toml


## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
