### PR TITLE
fix(datasets): Drop pyarrow constraint when using snowpark

### DIFF
--- a/kedro-datasets/setup.py
+++ b/kedro-datasets/setup.py
@@ -87,10 +87,7 @@ polars_require = {
 }
 redis_require = {"redis.PickleDataset": ["redis~=4.1"]}
 snowflake_require = {
-    "snowflake.SnowparkTableDataset": [
-        "snowflake-snowpark-python~=1.0",
-        "pyarrow~=8.0",
-    ]
+    "snowflake.SnowparkTableDataset": ["snowflake-snowpark-python~=1.0"]
 }
 spark_require = {
     "spark.SparkDataset": [SPARK, HDFS, S3FS],

--- a/kedro-datasets/tests/pandas/test_deltatable_dataset.py
+++ b/kedro-datasets/tests/pandas/test_deltatable_dataset.py
@@ -66,7 +66,7 @@ class TestDeltaTableDataset:
         """Test saving by appending new data."""
         deltatable_dataset_from_path.save(dummy_df)
         new_df = pd.DataFrame({"col1": [0, 0], "col2": [1, 1], "col3": [2, 2]})
-        appended = pd.concat([dummy_df, new_df], ignore_index=True)
+        appended = pd.concat([new_df, dummy_df], ignore_index=True)
         deltatable_dataset_from_path.save(new_df)
         reloaded = deltatable_dataset_from_path.load()
         assert_frame_equal(appended, reloaded)

--- a/kedro-datasets/tests/pandas/test_deltatable_dataset.py
+++ b/kedro-datasets/tests/pandas/test_deltatable_dataset.py
@@ -66,7 +66,7 @@ class TestDeltaTableDataset:
         """Test saving by appending new data."""
         deltatable_dataset_from_path.save(dummy_df)
         new_df = pd.DataFrame({"col1": [0, 0], "col2": [1, 1], "col3": [2, 2]})
-        appended = pd.concat([new_df, dummy_df], ignore_index=True)
+        appended = pd.concat([dummy_df, new_df], ignore_index=True)
         deltatable_dataset_from_path.save(new_df)
         reloaded = deltatable_dataset_from_path.load()
         assert_frame_equal(appended, reloaded)


### PR DESCRIPTION
## Description
Fix Snowflake dataset cannot installed with latest pyarrow 14.0.1 #453 

## Development notes
I believe the contraint was put there when snowpark was not available for python 3.11. Nor snowpark nor the dataset needs pyarrow as dependency.

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
