### PR TITLE
chore: bump actions versions

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -9,9 +9,9 @@ jobs:
   check-version:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: '3.10'
     - name: Install dependencies
@@ -60,9 +60,9 @@ jobs:
       needs.check-version.outputs.new_release == 'true'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: '3.10'
     - name: Install dependencies

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -18,13 +18,13 @@ jobs:
     runs-on: ${{ inputs.os }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python ${{inputs.python-version}}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: ${{inputs.python-version}}
       - name: Cache python packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: ${{inputs.plugin}}-${{inputs.os}}-python-${{inputs.python-version}}

--- a/.github/workflows/kedro-datasets.yml
+++ b/.github/workflows/kedro-datasets.yml
@@ -53,7 +53,7 @@ jobs:
           restore-keys: kedro-datasets
       - name: Install dependencies
         run: |
-          python -m pip install -U "pip>=21.2"
+          python -m pip install -U pip
           cd kedro-datasets
           pip install ".[docs,test]"
       - name: RTD build for kedro-datasets

--- a/.github/workflows/kedro-datasets.yml
+++ b/.github/workflows/kedro-datasets.yml
@@ -40,20 +40,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python 3.9
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: "3.9"
       - name: Cache python packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: kedro-datasets-ubuntu-latest-python-"3.9"
           restore-keys: kedro-datasets
       - name: Install dependencies
         run: |
-          python -m pip install -U "pip>=21.2,<23.2" # Temporary fix
+          python -m pip install -U "pip>=21.2"
           cd kedro-datasets
           pip install ".[docs,test]"
       - name: RTD build for kedro-datasets

--- a/.github/workflows/kedro-datasets.yml
+++ b/.github/workflows/kedro-datasets.yml
@@ -53,7 +53,7 @@ jobs:
           restore-keys: kedro-datasets
       - name: Install dependencies
         run: |
-          python -m pip install -U pip
+          python -m pip install -U "pip>=21.2,<23.2" # Temporary fix
           cd kedro-datasets
           pip install ".[docs,test]"
       - name: RTD build for kedro-datasets

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install dependencies
         run: |
             cd ${{ inputs.plugin }}
-            python -m pip install -U "pip>=21.2"
+            python -m pip install -U pip
             pip install git+https://github.com/kedro-org/kedro@main
             pip install ".[test]"
             pip freeze

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,13 +18,13 @@ jobs:
     runs-on: ${{ inputs.os }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ inputs.python-version }}
       - name: Cache python packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: ${{inputs.plugin}}-${{inputs.os}}-python-${{inputs.python-version}}
@@ -32,7 +32,7 @@ jobs:
       - name: Install dependencies
         run: |
             cd ${{ inputs.plugin }}
-            python -m pip install -U "pip>=21.2,<23.2" # Temporary fix
+            python -m pip install -U "pip>=21.2"
             pip install git+https://github.com/kedro-org/kedro@main
             pip install ".[test]"
             pip freeze

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install dependencies
         run: |
             cd ${{ inputs.plugin }}
-            python -m pip install -U pip
+            python -m pip install -U "pip>=21.2,<23.2" # Temporary fix
             pip install git+https://github.com/kedro-org/kedro@main
             pip install ".[test]"
             pip freeze

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Install dependencies
         run: |
           cd ${{ inputs.plugin }}
-          python -m pip install -U "pip>=21.2"
+          python -m pip install -U pip
           pip install ".[test]"
       - name: pip freeze
         run: pip freeze

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -19,21 +19,21 @@ jobs:
         shell: bash
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python ${{inputs.python-version}}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: ${{inputs.python-version}}
       - name: Cache python packages for Linux
         if: inputs.os == 'ubuntu-latest'
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: ${{inputs.plugin}}-${{inputs.os}}-python-${{inputs.python-version}}
           restore-keys: ${{inputs.plugin}}
       - name: Cache python packages for Windows
         if: inputs.os == 'windows-latest'
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~\AppData\Local\pip\Cache
           key: ${{inputs.plugin}}-${{inputs.os}}-python-${{inputs.python-version}}
@@ -42,11 +42,11 @@ jobs:
         run: pip install git+https://github.com/kedro-org/kedro@main
       - name: Add MSBuild to PATH
         if: inputs.os == 'windows-latest'
-        uses: microsoft/setup-msbuild@v1
+        uses: microsoft/setup-msbuild@v2
       - name: Install dependencies
         run: |
           cd ${{ inputs.plugin }}
-          python -m pip install -U "pip>=21.2,<23.2" # Temporary fix
+          python -m pip install -U "pip>=21.2"
           pip install ".[test]"
       - name: pip freeze
         run: pip freeze

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Install dependencies
         run: |
           cd ${{ inputs.plugin }}
-          python -m pip install -U pip
+          python -m pip install -U "pip>=21.2,<23.2" # Temporary fix
           pip install ".[test]"
       - name: pip freeze
         run: pip freeze


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
Bump actions to versions that use node 20 instead of node 16, which have been deprecated.


## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
