### PR TITLE
fix(datasets): Debug and fix `kedro-datasets` nightly build failures

### DIFF
--- a/kedro-datasets/setup.py
+++ b/kedro-datasets/setup.py
@@ -70,19 +70,19 @@ polars_require = {
         POLARS,
         "pyarrow>=4.0",
         "xlsx2csv>=0.8.0",
-        "deltalake >= 0.6.2",
+        "lake >= 0.6.2",
     ],
     "polars.EagerPolarsDataset": [
         POLARS,
         "pyarrow>=4.0",
         "xlsx2csv>=0.8.0",
-        "deltalake >= 0.6.2",
+        "lake >= 0.6.2",
     ],
     "polars.LazyPolarsDataset": [
         # Note: there is no Lazy read Excel option, so we exclude xlsx2csv here.
         POLARS,
         "pyarrow>=4.0",
-        "deltalake >= 0.6.2",
+        "lake >= 0.6.2",
     ],
 }
 redis_require = {"redis.PickleDataset": ["redis~=4.1"]}
@@ -96,7 +96,7 @@ spark_require = {
     "spark.SparkDataset": [SPARK, HDFS, S3FS],
     "spark.SparkHiveDataset": [SPARK, HDFS, S3FS],
     "spark.SparkJDBCDataset": [SPARK, HDFS, S3FS],
-    "spark.DeltaTableDataset": [SPARK, HDFS, S3FS, "delta-spark>=1.0, <3.0"],
+    "spark.TableDataset": [SPARK, HDFS, S3FS, "-spark>=1.0, <3.0"],
 }
 svmlight_require = {"svmlight.SVMLightDataset": ["scikit-learn>=1.0.2", "scipy~=1.7.3"]}
 tensorflow_require = {
@@ -184,7 +184,7 @@ extras_require["test"] = [
     "coverage[toml]",
     "dask[complete]>=2021.10",
     "delta-spark>=1.0, <3.0",
-    "deltalake>=0.10.0, !=0.15.2",
+    "deltalake>=0.10.0, <0.15.2",
     "dill~=0.3.1",
     "filelock>=3.4.0, <4.0",
     "gcsfs>=2023.1, <2023.3",

--- a/kedro-datasets/setup.py
+++ b/kedro-datasets/setup.py
@@ -70,19 +70,19 @@ polars_require = {
         POLARS,
         "pyarrow>=4.0",
         "xlsx2csv>=0.8.0",
-        "lake >= 0.6.2",
+        "deltalake >= 0.6.2",
     ],
     "polars.EagerPolarsDataset": [
         POLARS,
         "pyarrow>=4.0",
         "xlsx2csv>=0.8.0",
-        "lake >= 0.6.2",
+        "deltalake >= 0.6.2",
     ],
     "polars.LazyPolarsDataset": [
         # Note: there is no Lazy read Excel option, so we exclude xlsx2csv here.
         POLARS,
         "pyarrow>=4.0",
-        "lake >= 0.6.2",
+        "deltalake >= 0.6.2",
     ],
 }
 redis_require = {"redis.PickleDataset": ["redis~=4.1"]}
@@ -96,7 +96,7 @@ spark_require = {
     "spark.SparkDataset": [SPARK, HDFS, S3FS],
     "spark.SparkHiveDataset": [SPARK, HDFS, S3FS],
     "spark.SparkJDBCDataset": [SPARK, HDFS, S3FS],
-    "spark.TableDataset": [SPARK, HDFS, S3FS, "-spark>=1.0, <3.0"],
+    "spark.DeltaTableDataset": [SPARK, HDFS, S3FS, "delta-spark>=1.0, <3.0"],
 }
 svmlight_require = {"svmlight.SVMLightDataset": ["scikit-learn>=1.0.2", "scipy~=1.7.3"]}
 tensorflow_require = {
@@ -184,7 +184,7 @@ extras_require["test"] = [
     "coverage[toml]",
     "dask[complete]>=2021.10",
     "delta-spark>=1.0, <3.0",
-    "deltalake>=0.10.0, <0.15.2",
+    "deltalake>=0.10.0",
     "dill~=0.3.1",
     "filelock>=3.4.0, <4.0",
     "gcsfs>=2023.1, <2023.3",

--- a/kedro-datasets/setup.py
+++ b/kedro-datasets/setup.py
@@ -184,7 +184,7 @@ extras_require["test"] = [
     "coverage[toml]",
     "dask[complete]>=2021.10",
     "delta-spark>=1.0, <3.0",
-    "deltalake>=0.10.0, <0.15.2",
+    "deltalake>=0.10.0, !=0.15.2",
     "dill~=0.3.1",
     "filelock>=3.4.0, <4.0",
     "gcsfs>=2023.1, <2023.3",

--- a/kedro-datasets/setup.py
+++ b/kedro-datasets/setup.py
@@ -184,7 +184,7 @@ extras_require["test"] = [
     "coverage[toml]",
     "dask[complete]>=2021.10",
     "delta-spark>=1.0, <3.0",
-    "deltalake>=0.10.0, <0.15.2",
+    "deltalake>=0.10.0, <0.15.2",  # temporary pin as 0.15.2 breaks some of our tests
     "dill~=0.3.1",
     "filelock>=3.4.0, <4.0",
     "gcsfs>=2023.1, <2023.3",

--- a/kedro-datasets/setup.py
+++ b/kedro-datasets/setup.py
@@ -184,7 +184,7 @@ extras_require["test"] = [
     "coverage[toml]",
     "dask[complete]>=2021.10",
     "delta-spark>=1.0, <3.0",
-    "deltalake>=0.10.0",
+    "deltalake>=0.10.0, <0.15.2",
     "dill~=0.3.1",
     "filelock>=3.4.0, <4.0",
     "gcsfs>=2023.1, <2023.3",

--- a/kedro-datasets/tests/pandas/test_deltatable_dataset.py
+++ b/kedro-datasets/tests/pandas/test_deltatable_dataset.py
@@ -69,11 +69,7 @@ class TestDeltaTableDataset:
         appended = pd.concat([dummy_df, new_df], ignore_index=True)
         deltatable_dataset_from_path.save(new_df)
         reloaded = deltatable_dataset_from_path.load()
-        appended.sort_values(by=["col1"], inplace=True)
-        reloaded.sort_values(by=["col1"], inplace=True)
-        assert_frame_equal(
-            appended.reset_index(drop=True), reloaded.reset_index(drop=True)
-        )
+        assert_frame_equal(appended, reloaded)
 
     def test_versioning(self, filepath, dummy_df):
         """Test loading different versions."""

--- a/kedro-datasets/tests/pandas/test_deltatable_dataset.py
+++ b/kedro-datasets/tests/pandas/test_deltatable_dataset.py
@@ -69,10 +69,11 @@ class TestDeltaTableDataset:
         appended = pd.concat([dummy_df, new_df], ignore_index=True)
         deltatable_dataset_from_path.save(new_df)
         reloaded = deltatable_dataset_from_path.load()
-        appended.sort_values(by=['col1'], inplace=True)
-        reloaded.sort_values(by=['col1'], inplace=True)
-        assert_frame_equal(appended.reset_index(drop=True), reloaded.reset_index(drop=True))
-
+        appended.sort_values(by=["col1"], inplace=True)
+        reloaded.sort_values(by=["col1"], inplace=True)
+        assert_frame_equal(
+            appended.reset_index(drop=True), reloaded.reset_index(drop=True)
+        )
 
     def test_versioning(self, filepath, dummy_df):
         """Test loading different versions."""

--- a/kedro-datasets/tests/pandas/test_deltatable_dataset.py
+++ b/kedro-datasets/tests/pandas/test_deltatable_dataset.py
@@ -69,7 +69,10 @@ class TestDeltaTableDataset:
         appended = pd.concat([dummy_df, new_df], ignore_index=True)
         deltatable_dataset_from_path.save(new_df)
         reloaded = deltatable_dataset_from_path.load()
-        assert_frame_equal(appended, reloaded)
+        appended.sort_values(by=['col1'], inplace=True)
+        reloaded.sort_values(by=['col1'], inplace=True)
+        assert_frame_equal(appended.reset_index(drop=True), reloaded.reset_index(drop=True))
+
 
     def test_versioning(self, filepath, dummy_df):
         """Test loading different versions."""


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
Related to: https://github.com/kedro-org/kedro-plugins/issues/540

The latest release of `deltalake 0.15.2` broke one our tests after digging into their [changes](https://github.com/delta-io/delta-rs/releases/tag/python-v0.15.2), I believe some changes in their Rust code has altered the way data is appended and retrieved from the Delta table which is causing different order of rows in the DataFrame. If we aren't to fussed about the ordering I added sorting before comparing the DataFrames in our tests.


## Development notes
<!-- What have you changed, and how has this been tested? -->

Added sorting to the DF before comparison.

## Checklist

- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [x] Added tests to cover my changes
