### PR TITLE
fix: (docker) failing notebook e2e tests

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install dependencies
         run: |
           cd ${{ inputs.plugin }}
-          pip install kedro
+          pip install git+https://github.com/kedro-org/kedro@main
           pip install ".[test]"
       - name: pip freeze
         run: pip freeze

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install dependencies
         run: |
           cd ${{ inputs.plugin }}
-          pip install git+https://github.com/kedro-org/kedro@main
+          pip install kedro
           pip install ".[test]"
       - name: pip freeze
         run: pip freeze

--- a/kedro-docker/features/docker.feature
+++ b/kedro-docker/features/docker.feature
@@ -26,7 +26,8 @@ Feature: Docker commands in new projects
     And I should get a message including "Python"
 
   Scenario: Execute docker run target successfully
-    Given I have executed the kedro command "docker build"
+    Given I have installed the project dependencies
+    And I have executed the kedro command "docker build"
     When I execute the kedro command "docker run"
     Then I should get a successful exit code
     And I should get a message including "Pipeline execution completed"

--- a/kedro-docker/features/docker.feature
+++ b/kedro-docker/features/docker.feature
@@ -26,8 +26,7 @@ Feature: Docker commands in new projects
     And I should get a message including "Python"
 
   Scenario: Execute docker run target successfully
-    Given I have installed the project dependencies
-    And I have executed the kedro command "docker build"
+    Given I have executed the kedro command "docker build"
     When I execute the kedro command "docker run"
     Then I should get a successful exit code
     And I should get a message including "Pipeline execution completed"

--- a/kedro-docker/features/docker.feature
+++ b/kedro-docker/features/docker.feature
@@ -52,12 +52,12 @@ Feature: Docker commands in new projects
   Scenario: Execute docker jupyter notebook target
     Given I have executed the kedro command "docker build"
     When I execute the kedro command "docker jupyter notebook"
-    Then Jupyter Notebook should run on port 8888
+    Then Jupyter Server should run on port 8888
 
   Scenario: Execute docker jupyter notebook target on custom port
     Given I have executed the kedro command "docker build"
     When I execute the kedro command "docker jupyter notebook --port 8899"
-    Then Jupyter Notebook should run on port 8899
+    Then Jupyter Server should run on port 8899
 
   Scenario: Execute docker jupyter lab target
     Given I have executed the kedro command "docker build"

--- a/kedro-docker/features/environment.py
+++ b/kedro-docker/features/environment.py
@@ -39,13 +39,10 @@ def before_all(context):
             "pip",
             "install",
             "-U",
-            # Temporarily pin pip to fix https://github.com/jazzband/pip-tools/issues/1503
-            # This can be removed when Kedro 0.17.6 is released, because pip-tools is upgraded
-            # for that version.
-            "pip>=20.0,<21.3",
+            "pip>=20.0",
             "setuptools>=38.0",
             "wheel",
-            ".",
+            ".[test]",
         ],
         env=context.env,
     )

--- a/kedro-docker/features/environment.py
+++ b/kedro-docker/features/environment.py
@@ -42,7 +42,7 @@ def before_all(context):
             "pip>=20.0",
             "setuptools>=38.0",
             "wheel",
-            ".[test]",
+            ".",
         ],
         env=context.env,
     )

--- a/kedro-docker/pyproject.toml
+++ b/kedro-docker/pyproject.toml
@@ -36,7 +36,7 @@ test = [
     "pytest-xdist[psutil]~=2.2.1",
     "PyYAML>=5.1, <7.0",
     "trufflehog>=2.0.99, <3.0",
-    "ruamel.yaml<0.18.6"
+    "ruamel.yaml<0.18.6",
     "ruff~=0.0.290",
     "wheel==0.32.2"
 ]

--- a/kedro-docker/pyproject.toml
+++ b/kedro-docker/pyproject.toml
@@ -28,15 +28,16 @@ test = [
     "behave",
     "black~=22.0",
     "docker",
+    "openpxyl",
     "pre-commit>=2.9.2",
     "psutil",
+    "pyarrow",
     "pytest",
     "pytest-cov",
     "pytest-mock",
     "pytest-xdist[psutil]~=2.2.1",
     "PyYAML>=5.1, <7.0",
     "trufflehog>=2.0.99, <3.0",
-    "ruamel.yaml<0.18.6",
     "ruff~=0.0.290",
     "wheel==0.32.2"
 ]

--- a/kedro-docker/pyproject.toml
+++ b/kedro-docker/pyproject.toml
@@ -28,16 +28,15 @@ test = [
     "behave",
     "black~=22.0",
     "docker",
-    "openpyxl",
     "pre-commit>=2.9.2",
     "psutil",
-    "pyarrow",
     "pytest",
     "pytest-cov",
     "pytest-mock",
     "pytest-xdist[psutil]~=2.2.1",
     "PyYAML>=5.1, <7.0",
     "trufflehog>=2.0.99, <3.0",
+    "ruamel.yaml>0.18.0",
     "ruff~=0.0.290",
     "wheel==0.32.2"
 ]

--- a/kedro-docker/pyproject.toml
+++ b/kedro-docker/pyproject.toml
@@ -28,7 +28,7 @@ test = [
     "behave",
     "black~=22.0",
     "docker",
-    "openpxyl",
+    "openpyxl",
     "pre-commit>=2.9.2",
     "psutil",
     "pyarrow",

--- a/kedro-docker/pyproject.toml
+++ b/kedro-docker/pyproject.toml
@@ -36,6 +36,7 @@ test = [
     "pytest-xdist[psutil]~=2.2.1",
     "PyYAML>=5.1, <7.0",
     "trufflehog>=2.0.99, <3.0",
+    "ruamel.yaml<0.18.6"
     "ruff~=0.0.290",
     "wheel==0.32.2"
 ]

--- a/kedro-docker/pyproject.toml
+++ b/kedro-docker/pyproject.toml
@@ -36,7 +36,7 @@ test = [
     "pytest-xdist[psutil]~=2.2.1",
     "PyYAML>=5.1, <7.0",
     "trufflehog>=2.0.99, <3.0",
-    "ruamel.yaml>0.18.0",
+    "ruamel.yaml<0.18.0",
     "ruff~=0.0.290",
     "wheel==0.32.2"
 ]


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
Resolves #523 

The tests were failing because they were looking for the string `"Jupyter Notebook"` in the launched html. The update updates the string being searched to `"Jupyter Server"`.

Jupyter Notebook has migrated from using the old notebook server to `jupyter-server`. I couldn't track down why the tests failed at the specific time that we did, but given [the introduction of this dependency on Framework](https://github.com/kedro-org/kedro/pull/3510/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R108) - we can expect to be using `jupyter-server` consistently, and as such, I have updated the tests.

## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
