### PR TITLE
fix: kedro-telemetry masking

### DIFF
--- a/kedro-telemetry/kedro_telemetry/masking.py
+++ b/kedro-telemetry/kedro_telemetry/masking.py
@@ -44,6 +44,10 @@ def _recurse_cli(
                 io_dict[element_name],
                 get_help,
             )
+        nested_parameter_list = [option.opts for option in cli_element.get_params(ctx)]
+        for item in (item for sublist in nested_parameter_list for item in sublist):
+            if item not in io_dict[element_name]:
+                io_dict[element_name][item] = None
 
     elif isinstance(cli_element, click.Command):
         if get_help:  # gets formatted CLI help incl params for printing
@@ -89,7 +93,7 @@ def _mask_kedro_cli(cli_struct: Dict[str, Any], command_args: List[str]) -> List
         current_CLI = current_CLI[command_args[arg_index]]
         arg_index += 1
 
-    # Mask everything except recognized parameter keywords
+    # Mask everything except parameter keywords
     for arg in command_args[arg_index:]:
         if arg.startswith("-"):
             if "=" in arg:

--- a/kedro-telemetry/kedro_telemetry/masking.py
+++ b/kedro-telemetry/kedro_telemetry/masking.py
@@ -44,10 +44,13 @@ def _recurse_cli(
                 io_dict[element_name],
                 get_help,
             )
-        nested_parameter_list = [option.opts for option in cli_element.get_params(ctx)]
-        for item in (item for sublist in nested_parameter_list for item in sublist):
-            if item not in io_dict[element_name]:
-                io_dict[element_name][item] = None
+        if not get_help:
+            nested_parameter_list = [
+                option.opts for option in cli_element.get_params(ctx)
+            ]
+            for item in (item for sublist in nested_parameter_list for item in sublist):
+                if item not in io_dict[element_name]:
+                    io_dict[element_name][item] = None
 
     elif isinstance(cli_element, click.Command):
         if get_help:  # gets formatted CLI help incl params for printing

--- a/kedro-telemetry/kedro_telemetry/masking.py
+++ b/kedro-telemetry/kedro_telemetry/masking.py
@@ -1,5 +1,5 @@
 """Module containing command masking functionality."""
-from typing import Any, Dict, Iterator, List, Set, Union
+from typing import Any, Dict, Iterator, List, Union
 
 import click
 

--- a/kedro-telemetry/kedro_telemetry/plugin.py
+++ b/kedro-telemetry/kedro_telemetry/plugin.py
@@ -60,13 +60,6 @@ class KedroTelemetryCLIHooks:
     ):
         """Hook implementation to send command run data to Heap"""
         try:
-            # get KedroCLI and its structure from actual project root
-            cli = KedroCLI(project_path=Path.cwd())
-            cli_struct = _get_cli_structure(cli_obj=cli, get_help=False)
-            masked_command_args = _mask_kedro_cli(
-                cli_struct=cli_struct, command_args=command_args
-            )
-            main_command = masked_command_args[0] if masked_command_args else "kedro"
             if not project_metadata:  # in package mode
                 return
 
@@ -77,6 +70,14 @@ class KedroTelemetryCLIHooks:
                     "sharing usage analytics so none will be collected.",
                 )
                 return
+
+            # get KedroCLI and its structure from actual project root
+            cli = KedroCLI(project_path=Path.cwd())
+            cli_struct = _get_cli_structure(cli_obj=cli, get_help=False)
+            masked_command_args = _mask_kedro_cli(
+                cli_struct=cli_struct, command_args=command_args
+            )
+            main_command = masked_command_args[0] if masked_command_args else "kedro"
 
             logger.debug("You have opted into product usage analytics.")
             hashed_username = _get_hashed_username()

--- a/kedro-telemetry/tests/test_masking.py
+++ b/kedro-telemetry/tests/test_masking.py
@@ -28,6 +28,9 @@ DEFAULT_KEDRO_COMMANDS = [
     "registry",
     "run",
     "starter",
+    "--version",
+    "-V",
+    "--help",
 ]
 
 
@@ -143,10 +146,6 @@ class TestCLIMasking:
                     )
             elif isinstance(v, str):
                 assert v.startswith("Usage:  [OPTIONS]")
-
-        assert sorted(list(help_cli_structure["kedro"])) == sorted(
-            DEFAULT_KEDRO_COMMANDS
-        )
 
     @pytest.mark.parametrize(
         "input_dict, expected_output_count",

--- a/kedro-telemetry/tests/test_masking.py
+++ b/kedro-telemetry/tests/test_masking.py
@@ -11,7 +11,6 @@ from kedro.framework.startup import ProjectMetadata
 from kedro_telemetry.masking import (
     MASK,
     _get_cli_structure,
-    _get_vocabulary,
     _mask_kedro_cli,
     _recursive_items,
 )
@@ -174,9 +173,6 @@ class TestCLIMasking:
 
     def test_recursive_items_empty(self):
         assert len(list(_recursive_items({}))) == 0
-
-    def test_get_vocabulary_empty(self):
-        assert _get_vocabulary({}) == {"-h", "--version"}
 
     @pytest.mark.parametrize(
         "input_cli_structure, input_command_args, expected_masked_args",

--- a/kedro-telemetry/tests/test_masking.py
+++ b/kedro-telemetry/tests/test_masking.py
@@ -230,8 +230,8 @@ class TestCLIMasking:
                         "command_b": None,
                     }
                 },
-                ["none", "of", "this", "should", "be", "seen", "except", "command_a"],
-                [MASK, MASK, MASK, MASK, MASK, MASK, MASK, "command_a"],
+                ["command_a", "should", "be", "seen", "only"],
+                ["command_a", MASK, MASK, MASK, MASK],
             ),
         ],
     )

--- a/kedro-telemetry/tests/test_masking.py
+++ b/kedro-telemetry/tests/test_masking.py
@@ -28,6 +28,9 @@ DEFAULT_KEDRO_COMMANDS = [
     "registry",
     "run",
     "starter",
+    "--version",
+    "-V",
+    "--help",
 ]
 
 
@@ -74,7 +77,6 @@ class TestCLIMasking:
 
         for k, v in raw_cli_structure["kedro"].items():
             assert isinstance(k, str)
-            assert isinstance(v, dict)
 
         assert sorted(list(raw_cli_structure["kedro"])) == sorted(
             DEFAULT_KEDRO_COMMANDS

--- a/kedro-telemetry/tests/test_masking.py
+++ b/kedro-telemetry/tests/test_masking.py
@@ -28,9 +28,6 @@ DEFAULT_KEDRO_COMMANDS = [
     "registry",
     "run",
     "starter",
-    "--version",
-    "-V",
-    "--help",
 ]
 
 


### PR DESCRIPTION
## Description
This PR modifies the algorithm for masking CLI inputs:

1. It retains the initial segment of the command, permitting only commands from the Kedro CLI, up until the point where parameter sections start.
2. It masks all inputs except for the permitted parameter keywords specific to that Kedro CLI command.

Additionally, the sequence of operations in KedroTelemetryCLIHooks has been altered: we now first check for the user's consent. If it has not been provided, we take no further action. Previously, we would parse the Kedro CLI structure first, which consumed time unnecessarily.

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
