### PR TITLE
feat(datasets): allow additional parameters for sqlalchemy engine when using sql dataset

### DIFF
--- a/kedro-datasets/RELEASE.md
+++ b/kedro-datasets/RELEASE.md
@@ -2,6 +2,7 @@
 ## Major features and improvements
 * Added `MatlabDataset` which uses `scipy` to save and load `.mat` files.
 * Extend preview feature for matplotlib, plotly and tracking datasets.
+* Allow additional parameters for sqlalchemy engine when using sql datasets.
 
 ## Bug fixes and other changes
 * Removed Windows specific conditions in `pandas.HDFDataset` extra dependencies

--- a/kedro-datasets/kedro_datasets/pandas/sql_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/sql_dataset.py
@@ -126,6 +126,7 @@ class SQLTableDataset(AbstractDataset[pd.DataFrame, pd.DataFrame]):
 
         db_credentials:
           con: postgresql://scott:tiger@localhost/test
+          pool_size: 10 # additional parameters
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
@@ -174,6 +175,8 @@ class SQLTableDataset(AbstractDataset[pd.DataFrame, pd.DataFrame]):
                 through credentials.
                 To find all supported connection string formats, see here:
                 https://docs.sqlalchemy.org/core/engines.html#database-urls
+                Additional parameters for the sqlalchemy engine can be provided
+                alongside the 'con' parameter.
             load_args: Provided to underlying pandas ``read_sql_table``
                 function along with the connection string.
                 To find all supported arguments, see here:
@@ -215,17 +218,20 @@ class SQLTableDataset(AbstractDataset[pd.DataFrame, pd.DataFrame]):
         self._save_args["name"] = table_name
 
         self._connection_str = credentials["con"]
+        self._connection_args = {
+            k: credentials[k] for k in credentials.keys() if k != "con"
+        }
 
         self.metadata = metadata
 
     @classmethod
-    def create_connection(cls, connection_str: str) -> None:
+    def create_connection(cls, connection_str: str, connection_args: dict) -> None:
         """Given a connection string, create singleton connection
         to be used across all instances of ``SQLTableDataset`` that
         need to connect to the same source.
         """
         try:
-            engine = create_engine(connection_str)
+            engine = create_engine(connection_str, **connection_args)
         except ImportError as import_error:
             raise _get_missing_module_error(import_error) from import_error
         except NoSuchModuleError as exc:
@@ -239,7 +245,7 @@ class SQLTableDataset(AbstractDataset[pd.DataFrame, pd.DataFrame]):
         cls = type(self)
 
         if self._connection_str not in cls.engines:
-            self.create_connection(self._connection_str)
+            self.create_connection(self._connection_str, self._connection_args)
 
         return cls.engines[self._connection_str]
 
@@ -309,6 +315,7 @@ class SQLQueryDataset(AbstractDataset[None, pd.DataFrame]):
 
         db_credentials:
           con: postgresql://scott:tiger@localhost/test
+          pool_size: 10 # additional parameters
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
@@ -412,6 +419,8 @@ class SQLQueryDataset(AbstractDataset[None, pd.DataFrame]):
                 ``load_args`` and ``save_args`` in case it is provided. To find
                 all supported connection string formats, see here:
                 https://docs.sqlalchemy.org/core/engines.html#database-urls
+                Additional parameters for the sqlalchemy engine can be provided
+                alongside the 'con' parameter.
             load_args: Provided to underlying pandas ``read_sql_query``
                 function along with the connection string.
                 To find all supported arguments, see here:
@@ -480,18 +489,21 @@ class SQLQueryDataset(AbstractDataset[None, pd.DataFrame]):
             self._fs = fsspec.filesystem(self._protocol, **_fs_credentials, **_fs_args)
             self._filepath = path
         self._connection_str = credentials["con"]
+        self._connection_args = {
+            k: credentials[k] for k in credentials.keys() if k != "con"
+        }
         self._execution_options = execution_options or {}
         if "mssql" in self._connection_str:
             self.adapt_mssql_date_params()
 
     @classmethod
-    def create_connection(cls, connection_str: str) -> None:
+    def create_connection(cls, connection_str: str, connection_args: dict) -> None:
         """Given a connection string, create singleton connection
         to be used across all instances of `SQLQueryDataset` that
         need to connect to the same source.
         """
         try:
-            engine = create_engine(connection_str)
+            engine = create_engine(connection_str, **connection_args)
         except ImportError as import_error:
             raise _get_missing_module_error(import_error) from import_error
         except NoSuchModuleError as exc:
@@ -505,7 +517,7 @@ class SQLQueryDataset(AbstractDataset[None, pd.DataFrame]):
         cls = type(self)
 
         if self._connection_str not in cls.engines:
-            self.create_connection(self._connection_str)
+            self.create_connection(self._connection_str, self._connection_args)
 
         return cls.engines[self._connection_str]
 

--- a/kedro-datasets/tests/pandas/test_sql_dataset.py
+++ b/kedro-datasets/tests/pandas/test_sql_dataset.py
@@ -6,6 +6,7 @@ import pytest
 import sqlalchemy
 from kedro.io.core import DatasetError
 
+import kedro_datasets
 from kedro_datasets.pandas import SQLQueryDataset, SQLTableDataset
 
 TABLE_NAME = "table_a"
@@ -196,6 +197,18 @@ class TestSQLTableDataset:
         table_dataset.save(dummy_dataframe)
         dummy_dataframe.to_sql.assert_called_once_with(
             name=TABLE_NAME, con=table_dataset.engines[CONNECTION], index=False
+        )
+
+    def test_additional_params(self, mocker):
+        """Check additional parametes are sent to engine"""
+        mocker.patch(
+            "kedro_datasets.pandas.sql_dataset.create_engine",
+        )
+        additional_params = {"param1": "1", "param2": "2"}
+        credentials = {"con": CONNECTION, **additional_params}
+        SQLTableDataset(table_name=TABLE_NAME, credentials=credentials).engine
+        kedro_datasets.pandas.sql_dataset.create_engine.assert_called_once_with(
+            CONNECTION, **additional_params
         )
 
 
@@ -500,3 +513,15 @@ class TestSQLQueryDataset:
                 credentials={"con": MSSQL_CONNECTION},
                 load_args=load_args,
             )
+
+    def test_additional_params(self, mocker):
+        """Check additional parametes are sent to engine"""
+        mocker.patch(
+            "kedro_datasets.pandas.sql_dataset.create_engine",
+        )
+        additional_params = {"param1": "1", "param2": "2"}
+        credentials = {"con": CONNECTION, **additional_params}
+        SQLQueryDataset(sql=SQL_QUERY, credentials=credentials).engine
+        kedro_datasets.pandas.sql_dataset.create_engine.assert_called_once_with(
+            CONNECTION, **additional_params
+        )


### PR DESCRIPTION


## Description
This PR adds the feature to allow additional parameters for sqlalchemy engine when using a sql dataset.
This is for example necessary when you want to set the pool size of the connection or add additional authentication arguments.

Examples in a credentials.yaml are:
```
# configure pool size 
db_credentials:
          con: postgresql://scott:tiger@localhost/test
          pool_size: 10 # additional parameters

# configure a kerberized hive connection
hive_credentials:
          con: hive://user@server:10000/default
          connect_args:
                auth: 'KERBEROS'
                kerberos_service_name: 'hive'
```

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
