### PR TITLE
feat(telemetry): Add is_ci_env environment to reported project telemetry

### DIFF
--- a/kedro-telemetry/RELEASE.md
+++ b/kedro-telemetry/RELEASE.md
@@ -1,4 +1,5 @@
-# Upcoming release
+# Upcoming release 0.3.2
+* Updated plugin to share if a project is being run in a ci environment.
 
 # Release 0.3.1
 * Fixed double execution of `after_catalog_created` hook by moving the logic of determining and sending of project statistics from `after_context_created` to the `after_catalog_created` hook.

--- a/kedro-telemetry/kedro_telemetry/plugin.py
+++ b/kedro-telemetry/kedro_telemetry/plugin.py
@@ -149,7 +149,7 @@ class KedroTelemetryProjectHooks:
         )
 
 
-def _check_is_ci_env():
+def _check_is_known_ci_env():
     # Most CI tools will set the CI environment variable to true
     if os.environ.get("CI") is True:
         return True
@@ -171,7 +171,7 @@ def _get_project_properties(hashed_username: str, project_path: str) -> Dict:
         "telemetry_version": TELEMETRY_VERSION,
         "python_version": sys.version,
         "os": sys.platform,
-        "is_ci_env": _check_is_ci_env(),
+        "is_ci_env": _check_is_known_ci_env(),
     }
     pyproject_path = Path(project_path) / "pyproject.toml"
     if pyproject_path.exists():

--- a/kedro-telemetry/kedro_telemetry/plugin.py
+++ b/kedro-telemetry/kedro_telemetry/plugin.py
@@ -35,7 +35,7 @@ KNOWN_CI_ENV_VAR_KEYS = {
     "GITHUB_ACTION",  # https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
     "BITBUCKET_BUILD_NUMBER",  # https://support.atlassian.com/bitbucket-cloud/docs/variables-and-secrets/
     "JENKINS_URL",  # https://www.jenkins.io/doc/book/pipeline/jenkinsfile/#using-environment-variables
-    "CODEBUILD_BUILD_ID"  # https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-env-vars.html
+    "CODEBUILD_BUILD_ID",  # https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-env-vars.html
     "CIRCLECI",  # https://circleci.com/docs/variables/#built-in-environment-variables
     "TRAVIS",  # https://docs.travis-ci.com/user/environment-variables/#default-environment-variables
     "BUILDKITE",  # https://buildkite.com/docs/pipelines/environment-variables

--- a/kedro-telemetry/kedro_telemetry/plugin.py
+++ b/kedro-telemetry/kedro_telemetry/plugin.py
@@ -30,7 +30,7 @@ from kedro_telemetry.masking import _get_cli_structure, _mask_kedro_cli
 HEAP_APPID_PROD = "2388822444"
 HEAP_ENDPOINT = "https://heapanalytics.com/api/track"
 HEAP_HEADERS = {"Content-Type": "application/json"}
-KNOWN_CI_ENV_VAR_KEYS = (
+KNOWN_CI_ENV_VAR_KEYS = {
     "GITLAB_CI",  # https://docs.gitlab.com/ee/ci/variables/predefined_variables.html
     "GITHUB_ACTION",  # https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
     "BITBUCKET_BUILD_NUMBER",  # https://support.atlassian.com/bitbucket-cloud/docs/variables-and-secrets/
@@ -39,7 +39,7 @@ KNOWN_CI_ENV_VAR_KEYS = (
     "CIRCLECI",  # https://circleci.com/docs/variables/#built-in-environment-variables
     "TRAVIS",  # https://docs.travis-ci.com/user/environment-variables/#default-environment-variables
     "BUILDKITE",  # https://buildkite.com/docs/pipelines/environment-variables
-)
+}
 TIMESTAMP_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
 
 logger = logging.getLogger(__name__)
@@ -155,12 +155,12 @@ class KedroTelemetryProjectHooks:
         )
 
 
-def _is_known_ci_env():
+def _is_known_ci_env(known_ci_env_var_keys=KNOWN_CI_ENV_VAR_KEYS):
     # Most CI tools will set the CI environment variable to true
     if os.getenv("CI") == "true":
         return True
     # Not all CI tools follow this convention, we can check through those that don't
-    return any(os.getenv(key) for key in KNOWN_CI_ENV_VAR_KEYS)
+    return any(os.getenv(key) for key in known_ci_env_var_keys)
 
 
 def _get_project_properties(hashed_username: str, project_path: str) -> Dict:

--- a/kedro-telemetry/kedro_telemetry/plugin.py
+++ b/kedro-telemetry/kedro_telemetry/plugin.py
@@ -30,10 +30,16 @@ from kedro_telemetry.masking import _get_cli_structure, _mask_kedro_cli
 HEAP_APPID_PROD = "2388822444"
 HEAP_ENDPOINT = "https://heapanalytics.com/api/track"
 HEAP_HEADERS = {"Content-Type": "application/json"}
-KNOWN_CI_ENV_VAR_KEYS = [
-    "CODEBUILD_BUILD_ID",  # https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-env-vars.html
+KNOWN_CI_ENV_VAR_KEYS = (
+    "GITLAB_CI",  # https://docs.gitlab.com/ee/ci/variables/predefined_variables.html
+    "GITHUB_ACTION",  # https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
+    "BITBUCKET_BUILD_NUMBER",  # https://support.atlassian.com/bitbucket-cloud/docs/variables-and-secrets/
     "JENKINS_URL",  # https://www.jenkins.io/doc/book/pipeline/jenkinsfile/#using-environment-variables
-]
+    "CODEBUILD_BUILD_ID"  # https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-env-vars.html
+    "CIRCLECI",  # https://circleci.com/docs/variables/#built-in-environment-variables
+    "TRAVIS",  # https://docs.travis-ci.com/user/environment-variables/#default-environment-variables
+    "BUILDKITE",  # https://buildkite.com/docs/pipelines/environment-variables
+)
 TIMESTAMP_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
 
 logger = logging.getLogger(__name__)
@@ -149,17 +155,12 @@ class KedroTelemetryProjectHooks:
         )
 
 
-def _check_is_known_ci_env():
+def _is_known_ci_env():
     # Most CI tools will set the CI environment variable to true
     if os.getenv("CI") == "true":
         return True
-
     # Not all CI tools follow this convention, we can check through those that don't
-    for env_var_key in KNOWN_CI_ENV_VAR_KEYS:
-        if env_var_key in os.environ:
-            return True
-
-    return False
+    return any(os.getenv(key) for key in KNOWN_CI_ENV_VAR_KEYS)
 
 
 def _get_project_properties(hashed_username: str, project_path: str) -> Dict:
@@ -171,7 +172,7 @@ def _get_project_properties(hashed_username: str, project_path: str) -> Dict:
         "telemetry_version": TELEMETRY_VERSION,
         "python_version": sys.version,
         "os": sys.platform,
-        "is_ci_env": _check_is_known_ci_env(),
+        "is_ci_env": _is_known_ci_env(),
     }
     pyproject_path = Path(project_path) / "pyproject.toml"
     if pyproject_path.exists():

--- a/kedro-telemetry/kedro_telemetry/plugin.py
+++ b/kedro-telemetry/kedro_telemetry/plugin.py
@@ -31,7 +31,7 @@ HEAP_APPID_PROD = "2388822444"
 HEAP_ENDPOINT = "https://heapanalytics.com/api/track"
 HEAP_HEADERS = {"Content-Type": "application/json"}
 KNOWN_CI_ENV_VAR_KEYS = [
-    "CODEBUILD_BUILD_ID"  # https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-env-vars.html
+    "CODEBUILD_BUILD_ID",  # https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-env-vars.html
     "JENKINS_URL",  # https://www.jenkins.io/doc/book/pipeline/jenkinsfile/#using-environment-variables
 ]
 TIMESTAMP_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
@@ -151,7 +151,7 @@ class KedroTelemetryProjectHooks:
 
 def _check_is_known_ci_env():
     # Most CI tools will set the CI environment variable to true
-    if os.environ.get("CI") is True:
+    if os.getenv("CI") == "true":
         return True
 
     # Not all CI tools follow this convention, we can check through those that don't

--- a/kedro-telemetry/tests/test_plugin.py
+++ b/kedro-telemetry/tests/test_plugin.py
@@ -439,7 +439,6 @@ class TestKedroTelemetryCLIHooks:
             ({"CI": "false", "TRAVIS": "Testing known CI env var"}, True),
             ({"GITLAB_CI": "Testing known CI env var"}, True),
             ({"CI": "false", "CIRCLECI": "Testing known CI env var"}, True),
-            ({"CI": "false", "GITHUB_ACTION": "Testing known CI env var"}, True),
             (
                 {"CI": "false", "BITBUCKET_BUILD_NUMBER": "Testing known CI env var"},
                 True,

--- a/kedro-telemetry/tests/test_plugin.py
+++ b/kedro-telemetry/tests/test_plugin.py
@@ -16,7 +16,6 @@ from kedro_telemetry.plugin import (
     KedroTelemetryCLIHooks,
     KedroTelemetryProjectHooks,
     _check_for_telemetry_consent,
-    _check_is_known_ci_env,
     _confirm_consent,
 )
 
@@ -119,9 +118,7 @@ class TestKedroTelemetryCLIHooks:
         mocker.patch(
             "kedro_telemetry.plugin._check_for_telemetry_consent", return_value=True
         )
-        mocker.patch(
-            "kedro_telemetry.plugin._check_is_known_ci_env", return_value=True
-        )
+        mocker.patch("kedro_telemetry.plugin._check_is_known_ci_env", return_value=True)
         mocked_anon_id = mocker.patch("kedro_telemetry.plugin._hash")
         mocked_anon_id.return_value = "digested"
         mocker.patch("kedro_telemetry.plugin.PACKAGE_NAME", "spaceflights")
@@ -167,9 +164,7 @@ class TestKedroTelemetryCLIHooks:
         mocker.patch(
             "kedro_telemetry.plugin._check_for_telemetry_consent", return_value=True
         )
-        mocker.patch(
-            "kedro_telemetry.plugin._check_is_known_ci_env", return_value=True
-        )
+        mocker.patch("kedro_telemetry.plugin._check_is_known_ci_env", return_value=True)
         mocked_anon_id = mocker.patch("kedro_telemetry.plugin._hash")
         mocked_anon_id.return_value = "digested"
         mocker.patch("kedro_telemetry.plugin.PACKAGE_NAME", "spaceflights")
@@ -218,9 +213,7 @@ class TestKedroTelemetryCLIHooks:
         mocker.patch(
             "kedro_telemetry.plugin._check_for_telemetry_consent", return_value=True
         )
-        mocker.patch(
-            "kedro_telemetry.plugin._check_is_known_ci_env", return_value=True
-        )
+        mocker.patch("kedro_telemetry.plugin._check_is_known_ci_env", return_value=True)
         mocked_anon_id = mocker.patch("kedro_telemetry.plugin._hash")
         mocked_anon_id.return_value = "digested"
         mocker.patch("kedro_telemetry.plugin.PACKAGE_NAME", "spaceflights")
@@ -290,9 +283,7 @@ class TestKedroTelemetryCLIHooks:
         mocker.patch(
             "kedro_telemetry.plugin._check_for_telemetry_consent", return_value=True
         )
-        mocker.patch(
-            "kedro_telemetry.plugin._check_is_known_ci_env", return_value=True
-        )
+        mocker.patch("kedro_telemetry.plugin._check_is_known_ci_env", return_value=True)
         mocked_anon_id = mocker.patch("kedro_telemetry.plugin._hash")
         mocked_anon_id.return_value = "digested"
         mocker.patch("kedro_telemetry.plugin.PACKAGE_NAME", "spaceflights")
@@ -446,9 +437,7 @@ class TestKedroTelemetryProjectHooks:
         mocker.patch(
             "kedro_telemetry.plugin._check_for_telemetry_consent", return_value=True
         )
-        mocker.patch(
-            "kedro_telemetry.plugin._check_is_known_ci_env", return_value=True
-        )
+        mocker.patch("kedro_telemetry.plugin._check_is_known_ci_env", return_value=True)
         mocker.patch("kedro_telemetry.plugin._hash", return_value="digested")
         mocker.patch("kedro_telemetry.plugin.PACKAGE_NAME", "spaceflights")
         mocker.patch(
@@ -504,9 +493,7 @@ class TestKedroTelemetryProjectHooks:
         mocker.patch(
             "kedro_telemetry.plugin._check_for_telemetry_consent", return_value=True
         )
-        mocker.patch(
-            "kedro_telemetry.plugin._check_is_known_ci_env", return_value=True
-        )
+        mocker.patch("kedro_telemetry.plugin._check_is_known_ci_env", return_value=True)
         mocker.patch("kedro_telemetry.plugin._hash", return_value="digested")
         mocker.patch("kedro_telemetry.plugin.PACKAGE_NAME", "spaceflights")
         mocker.patch(
@@ -565,9 +552,7 @@ class TestKedroTelemetryProjectHooks:
         mocker.patch(
             "kedro_telemetry.plugin._check_for_telemetry_consent", return_value=True
         )
-        mocker.patch(
-            "kedro_telemetry.plugin._check_is_known_ci_env", return_value=True
-        )
+        mocker.patch("kedro_telemetry.plugin._check_is_known_ci_env", return_value=True)
         mocker.patch("kedro_telemetry.plugin._hash", return_value="digested")
         mocker.patch("kedro_telemetry.plugin.PACKAGE_NAME", "spaceflights")
         mocker.patch(

--- a/kedro-telemetry/tests/test_plugin.py
+++ b/kedro-telemetry/tests/test_plugin.py
@@ -16,8 +16,8 @@ from kedro_telemetry.plugin import (
     KedroTelemetryCLIHooks,
     KedroTelemetryProjectHooks,
     _check_for_telemetry_consent,
-    _check_is_known_ci_env,
     _confirm_consent,
+    _is_known_ci_env,
 )
 
 REPO_NAME = "dummy_project"
@@ -125,7 +125,7 @@ class TestKedroTelemetryCLIHooks:
         mocker.patch(
             "kedro_telemetry.plugin._check_for_telemetry_consent", return_value=True
         )
-        mocker.patch("kedro_telemetry.plugin._check_is_known_ci_env", return_value=True)
+        mocker.patch("kedro_telemetry.plugin._is_known_ci_env", return_value=True)
         mocked_anon_id = mocker.patch("kedro_telemetry.plugin._hash")
         mocked_anon_id.return_value = "digested"
         mocker.patch("kedro_telemetry.plugin.PACKAGE_NAME", "spaceflights")
@@ -171,7 +171,7 @@ class TestKedroTelemetryCLIHooks:
         mocker.patch(
             "kedro_telemetry.plugin._check_for_telemetry_consent", return_value=True
         )
-        mocker.patch("kedro_telemetry.plugin._check_is_known_ci_env", return_value=True)
+        mocker.patch("kedro_telemetry.plugin._is_known_ci_env", return_value=True)
         mocked_anon_id = mocker.patch("kedro_telemetry.plugin._hash")
         mocked_anon_id.return_value = "digested"
         mocker.patch("kedro_telemetry.plugin.PACKAGE_NAME", "spaceflights")
@@ -221,7 +221,7 @@ class TestKedroTelemetryCLIHooks:
         mocker.patch(
             "kedro_telemetry.plugin._check_for_telemetry_consent", return_value=True
         )
-        mocker.patch("kedro_telemetry.plugin._check_is_known_ci_env", return_value=True)
+        mocker.patch("kedro_telemetry.plugin._is_known_ci_env", return_value=True)
         mocked_anon_id = mocker.patch("kedro_telemetry.plugin._hash")
         mocked_anon_id.return_value = "digested"
         mocker.patch("kedro_telemetry.plugin.PACKAGE_NAME", "spaceflights")
@@ -291,7 +291,7 @@ class TestKedroTelemetryCLIHooks:
         mocker.patch(
             "kedro_telemetry.plugin._check_for_telemetry_consent", return_value=True
         )
-        mocker.patch("kedro_telemetry.plugin._check_is_known_ci_env", return_value=True)
+        mocker.patch("kedro_telemetry.plugin._is_known_ci_env", return_value=True)
         mocked_anon_id = mocker.patch("kedro_telemetry.plugin._hash")
         mocked_anon_id.return_value = "digested"
         mocker.patch("kedro_telemetry.plugin.PACKAGE_NAME", "spaceflights")
@@ -435,13 +435,20 @@ class TestKedroTelemetryCLIHooks:
             ({"CI": "false"}, False),
             ({"CI": "false", "CODEBUILD_BUILD_ID": "Testing known CI env var"}, True),
             ({"CI": "false", "JENKINS_URL": "Testing known CI env var"}, True),
+            ({"CI": "false", "TRAVIS": "Testing known CI env var"}, True),
+            ({"CI": "false", "GITLAB_CI": "Testing known CI env var"}, True),
+            ({"CI": "false", "CIRCLECI": "Testing known CI env var"}, True),
+            ({"CI": "false", "GITHUB_ACTIONS": "Testing known CI env var"}, True),
+            (
+                {"CI": "false", "BITBUCKET_BUILD_NUMBER": "Testing known CI env var"},
+                True,
+            ),
         ],
     )
     def test_check_is_known_ci_env(self, monkeypatch, env_vars, result):
         for env_var, env_var_value in env_vars.items():
             monkeypatch.setenv(env_var, env_var_value)
-
-        assert _check_is_known_ci_env() == result
+        assert _is_known_ci_env() == result
 
 
 class TestKedroTelemetryProjectHooks:
@@ -453,14 +460,13 @@ class TestKedroTelemetryProjectHooks:
         fake_sub_pipeline,
         fake_context,
     ):
-
         mocker.patch.dict(
             pipelines, {"__default__": fake_default_pipeline, "sub": fake_sub_pipeline}
         )
         mocker.patch(
             "kedro_telemetry.plugin._check_for_telemetry_consent", return_value=True
         )
-        mocker.patch("kedro_telemetry.plugin._check_is_known_ci_env", return_value=True)
+        mocker.patch("kedro_telemetry.plugin._is_known_ci_env", return_value=True)
         mocker.patch("kedro_telemetry.plugin._hash", return_value="digested")
         mocker.patch("kedro_telemetry.plugin.PACKAGE_NAME", "spaceflights")
         mocker.patch(
@@ -516,7 +522,7 @@ class TestKedroTelemetryProjectHooks:
         mocker.patch(
             "kedro_telemetry.plugin._check_for_telemetry_consent", return_value=True
         )
-        mocker.patch("kedro_telemetry.plugin._check_is_known_ci_env", return_value=True)
+        mocker.patch("kedro_telemetry.plugin._is_known_ci_env", return_value=True)
         mocker.patch("kedro_telemetry.plugin._hash", return_value="digested")
         mocker.patch("kedro_telemetry.plugin.PACKAGE_NAME", "spaceflights")
         mocker.patch(
@@ -575,7 +581,7 @@ class TestKedroTelemetryProjectHooks:
         mocker.patch(
             "kedro_telemetry.plugin._check_for_telemetry_consent", return_value=True
         )
-        mocker.patch("kedro_telemetry.plugin._check_is_known_ci_env", return_value=True)
+        mocker.patch("kedro_telemetry.plugin._is_known_ci_env", return_value=True)
         mocker.patch("kedro_telemetry.plugin._hash", return_value="digested")
         mocker.patch("kedro_telemetry.plugin.PACKAGE_NAME", "spaceflights")
         mocker.patch(
@@ -603,9 +609,9 @@ class TestKedroTelemetryProjectHooks:
             "telemetry_version": TELEMETRY_VERSION,
             "python_version": sys.version,
             "os": sys.platform,
+            "is_ci_env": True,
             "tools": "Linting, Testing, Custom Logging, Documentation, Data Structure, PySpark",
             "example_pipeline": "True",
-
         }
         project_statistics = {
             "number_of_datasets": 3,

--- a/kedro-telemetry/tests/test_plugin.py
+++ b/kedro-telemetry/tests/test_plugin.py
@@ -1,3 +1,5 @@
+import logging
+import os
 import sys
 from pathlib import Path
 
@@ -447,6 +449,9 @@ class TestKedroTelemetryCLIHooks:
     def test_check_is_known_ci_env(self, monkeypatch, env_vars, result):
         for env_var, env_var_value in env_vars.items():
             monkeypatch.setenv(env_var, env_var_value)
+
+        logging.warning(os.environ)
+        raise
         assert _is_known_ci_env() == result
 
 

--- a/kedro-telemetry/tests/test_plugin.py
+++ b/kedro-telemetry/tests/test_plugin.py
@@ -1,5 +1,3 @@
-import logging
-import os
 import sys
 from pathlib import Path
 

--- a/kedro-telemetry/tests/test_plugin.py
+++ b/kedro-telemetry/tests/test_plugin.py
@@ -432,11 +432,10 @@ class TestKedroTelemetryCLIHooks:
         "env_vars,result",
         [
             ({"CI": "true"}, True),
-            ({"CI": "false"}, False),
             ({"CI": "false", "CODEBUILD_BUILD_ID": "Testing known CI env var"}, True),
-            ({"CI": "false", "JENKINS_URL": "Testing known CI env var"}, True),
+            ({"JENKINS_URL": "Testing known CI env var"}, True),
             ({"CI": "false", "TRAVIS": "Testing known CI env var"}, True),
-            ({"CI": "false", "GITLAB_CI": "Testing known CI env var"}, True),
+            ({"GITLAB_CI": "Testing known CI env var"}, True),
             ({"CI": "false", "CIRCLECI": "Testing known CI env var"}, True),
             ({"CI": "false", "GITHUB_ACTIONS": "Testing known CI env var"}, True),
             (

--- a/kedro-telemetry/tests/test_plugin.py
+++ b/kedro-telemetry/tests/test_plugin.py
@@ -16,6 +16,7 @@ from kedro_telemetry.plugin import (
     KedroTelemetryCLIHooks,
     KedroTelemetryProjectHooks,
     _check_for_telemetry_consent,
+    _check_is_known_ci_env,
     _confirm_consent,
 )
 
@@ -118,6 +119,9 @@ class TestKedroTelemetryCLIHooks:
         mocker.patch(
             "kedro_telemetry.plugin._check_for_telemetry_consent", return_value=True
         )
+        mocker.patch(
+            "kedro_telemetry.plugin._check_is_known_ci_env", return_value=True
+        )
         mocked_anon_id = mocker.patch("kedro_telemetry.plugin._hash")
         mocked_anon_id.return_value = "digested"
         mocker.patch("kedro_telemetry.plugin.PACKAGE_NAME", "spaceflights")
@@ -138,6 +142,7 @@ class TestKedroTelemetryCLIHooks:
             "python_version": sys.version,
             "os": sys.platform,
             "command": "kedro --version",
+            "is_ci_env": True,
         }
         generic_properties = {
             **expected_properties,
@@ -162,6 +167,9 @@ class TestKedroTelemetryCLIHooks:
         mocker.patch(
             "kedro_telemetry.plugin._check_for_telemetry_consent", return_value=True
         )
+        mocker.patch(
+            "kedro_telemetry.plugin._check_is_known_ci_env", return_value=True
+        )
         mocked_anon_id = mocker.patch("kedro_telemetry.plugin._hash")
         mocked_anon_id.return_value = "digested"
         mocker.patch("kedro_telemetry.plugin.PACKAGE_NAME", "spaceflights")
@@ -183,6 +191,7 @@ class TestKedroTelemetryCLIHooks:
             "telemetry_version": TELEMETRY_VERSION,
             "python_version": sys.version,
             "os": sys.platform,
+            "is_ci_env": True,
             "command": "kedro --version",
             "tools": "['Linting', 'Testing', 'Custom Logging', 'Documentation', 'Data Structure', 'PySpark']",
         }
@@ -209,6 +218,9 @@ class TestKedroTelemetryCLIHooks:
         mocker.patch(
             "kedro_telemetry.plugin._check_for_telemetry_consent", return_value=True
         )
+        mocker.patch(
+            "kedro_telemetry.plugin._check_is_known_ci_env", return_value=True
+        )
         mocked_anon_id = mocker.patch("kedro_telemetry.plugin._hash")
         mocked_anon_id.return_value = "digested"
         mocker.patch("kedro_telemetry.plugin.PACKAGE_NAME", "spaceflights")
@@ -224,6 +236,7 @@ class TestKedroTelemetryCLIHooks:
             "telemetry_version": TELEMETRY_VERSION,
             "python_version": sys.version,
             "os": sys.platform,
+            "is_ci_env": True,
             "command": "kedro",
         }
         generic_properties = {
@@ -277,6 +290,9 @@ class TestKedroTelemetryCLIHooks:
         mocker.patch(
             "kedro_telemetry.plugin._check_for_telemetry_consent", return_value=True
         )
+        mocker.patch(
+            "kedro_telemetry.plugin._check_is_known_ci_env", return_value=True
+        )
         mocked_anon_id = mocker.patch("kedro_telemetry.plugin._hash")
         mocked_anon_id.return_value = "digested"
         mocker.patch("kedro_telemetry.plugin.PACKAGE_NAME", "spaceflights")
@@ -294,6 +310,7 @@ class TestKedroTelemetryCLIHooks:
             "telemetry_version": TELEMETRY_VERSION,
             "python_version": sys.version,
             "os": sys.platform,
+            "is_ci_env": True,
         }
         generic_properties = {
             "main_command": "--version",
@@ -429,6 +446,9 @@ class TestKedroTelemetryProjectHooks:
         mocker.patch(
             "kedro_telemetry.plugin._check_for_telemetry_consent", return_value=True
         )
+        mocker.patch(
+            "kedro_telemetry.plugin._check_is_known_ci_env", return_value=True
+        )
         mocker.patch("kedro_telemetry.plugin._hash", return_value="digested")
         mocker.patch("kedro_telemetry.plugin.PACKAGE_NAME", "spaceflights")
         mocker.patch(
@@ -451,6 +471,7 @@ class TestKedroTelemetryProjectHooks:
             "telemetry_version": TELEMETRY_VERSION,
             "python_version": sys.version,
             "os": sys.platform,
+            "is_ci_env": True,
         }
         project_statistics = {
             "number_of_datasets": 3,
@@ -483,6 +504,9 @@ class TestKedroTelemetryProjectHooks:
         mocker.patch(
             "kedro_telemetry.plugin._check_for_telemetry_consent", return_value=True
         )
+        mocker.patch(
+            "kedro_telemetry.plugin._check_is_known_ci_env", return_value=True
+        )
         mocker.patch("kedro_telemetry.plugin._hash", return_value="digested")
         mocker.patch("kedro_telemetry.plugin.PACKAGE_NAME", "spaceflights")
         mocker.patch(
@@ -508,6 +532,7 @@ class TestKedroTelemetryProjectHooks:
             "telemetry_version": TELEMETRY_VERSION,
             "python_version": sys.version,
             "os": sys.platform,
+            "is_ci_env": True,
         }
         project_statistics = {
             "number_of_datasets": 3,
@@ -540,6 +565,9 @@ class TestKedroTelemetryProjectHooks:
         mocker.patch(
             "kedro_telemetry.plugin._check_for_telemetry_consent", return_value=True
         )
+        mocker.patch(
+            "kedro_telemetry.plugin._check_is_known_ci_env", return_value=True
+        )
         mocker.patch("kedro_telemetry.plugin._hash", return_value="digested")
         mocker.patch("kedro_telemetry.plugin.PACKAGE_NAME", "spaceflights")
         mocker.patch(
@@ -567,6 +595,7 @@ class TestKedroTelemetryProjectHooks:
             "telemetry_version": TELEMETRY_VERSION,
             "python_version": sys.version,
             "os": sys.platform,
+            "is_ci_env": True,
             "tools": "['Linting', 'Testing', 'Custom Logging', 'Documentation', 'Data Structure', 'PySpark']",
         }
         project_statistics = {


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
Closes #483 

## Development notes
<!-- What have you changed, and how has this been tested? -->
This implementation diverges from the Dagster in several ways:
* `KNOWN_CI_ENV_VAR_KEYS` is implemented as a list, not a set, as lists have better iteration time on average
* We use `os.getenv()` instead of `os.environ.get()` for consistency within our codebase
* `KNOWN_CI_ENV_VAR_KEYS` does not contain keys for tools that set the CI env in our implementation, all keys exempted belong to tools that would otherwise set the CI env var to true

## Checklist

- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [x] Added a description of this change in the relevant `RELEASE.md` file
- [x] Added tests to cover my changes
