### PR TITLE
ci(docker): Only run one pipeline with the `ParallelRunner` in the e2e test

### DIFF
--- a/kedro-docker/features/docker.feature
+++ b/kedro-docker/features/docker.feature
@@ -40,7 +40,7 @@ Feature: Docker commands in new projects
 
   Scenario: Execute docker run in parallel mode
     Given I have executed the kedro command "docker build"
-    When I execute the kedro command "docker run --runner=ParallelRunner"
+    When I execute the kedro command "docker run --runner=ParallelRunner --pipeline=data_processing"
     Then I should get a successful exit code
     And I should get a message including "Pipeline execution completed"
 


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
Fix #558 

The failures are not related to `kedro-docker` itself but an incompatibility between the latest release of `scikit-learn` and `ParallelRunner`. Ticket to fix the underlying issue - https://github.com/kedro-org/kedro/issues/3674

In the meanwhile, we can just skip running the `data_science` pipeline with the `ParallelRunner` in the e2e test for `kedro-docker` to unblock the CI and then revert this after https://github.com/kedro-org/kedro/issues/3674 is fixed. 

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
