### PR TITLE
fix(airflow): Fix incorrect node names + switch e2e tests to spaceflights-pandas

### DIFF
--- a/kedro-airflow/features/airflow.feature
+++ b/kedro-airflow/features/airflow.feature
@@ -10,9 +10,9 @@ Feature: Airflow
     And I have executed the kedro command "airflow create -t ../airflow/dags/"
     When I execute the airflow command "tasks list project-dummy"
     Then I should get a successful exit code
-    And I should get a message including "split"
-    And I should get a message including "train"
-    And I should get a message including "predict"
+    And I should get a message including "create-model-input-table-node"
+    And I should get a message including "preprocess-companies-node"
+    And I should get a message including "preprocess-shuttles-node"
 
   Scenario: Run Airflow task locally with latest Kedro
     Given I have installed kedro version "latest"
@@ -20,6 +20,6 @@ Feature: Airflow
     And I have run a non-interactive kedro new
     And I have executed the kedro command "airflow create -t ../airflow/dags/"
     And I have installed the kedro project package
-    When I execute the airflow command "tasks test project-dummy split"
+    When I execute the airflow command "tasks test project-dummy preprocess-companies-node"
     Then I should get a successful exit code
     And I should get a message including "Loading data"

--- a/kedro-airflow/features/steps/cli_steps.py
+++ b/kedro-airflow/features/steps/cli_steps.py
@@ -93,7 +93,7 @@ def create_project_from_config_file(context):
             "-c",
             str(context.config_file),
             "--starter",
-            "astro-airflow-iris",
+            "spaceflights-pandas",
         ],
         env=context.env,
         cwd=str(context.temp_dir),

--- a/kedro-airflow/kedro_airflow/airflow_dag_template.j2
+++ b/kedro-airflow/kedro_airflow/airflow_dag_template.j2
@@ -65,7 +65,7 @@ with DAG(
             task_id="{{ node_name | safe | slugify  }}",
             package_name=package_name,
             pipeline_name=pipeline_name,
-            node_name={% if node_list | length > 1 %}[{% endif %}{% for node in node_list %}"{{ node.name | safe | slugify }}"{% if not loop.last %}, {% endif %}{% endfor %}{% if node_list | length > 1 %}]{% endif %},
+            node_name={% if node_list | length > 1 %}[{% endif %}{% for node in node_list %}"{{ node.name | safe }}"{% if not loop.last %}, {% endif %}{% endfor %}{% if node_list | length > 1 %}]{% endif %},
             project_path=project_path,
             env=env,
         ),


### PR DESCRIPTION
## Description
Fix #544 


## Development notes
<!-- What have you changed, and how has this been tested? -->
It was a quick change - reverting the `slugify` added in #241 

I've also switched the e2e tests to use `spaceflights-pandas` again because `astro-airflow-iris` had one word node names so this bug wasn't immediately obvious. We switched to `astro-airflow-iris` because it didn't have `kedro-viz` in its requirements which was not supporting `pydantic` v2 but they've just added the v2 support so it should work now.


## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
