### PR TITLE
feat(telemetry): Unique User IDs in kedro-telemetry - merge only for kedro-telemetry release 0.4.0

### DIFF
--- a/MagicMock/user_config_dir()/140095031570448/telemetry.conf
+++ b/MagicMock/user_config_dir()/140095031570448/telemetry.conf
@@ -1,3 +1,0 @@
-[telemetry]
-uuid = 20bdf01b447d4c95845b5f01496b3ff7
-

--- a/MagicMock/user_config_dir()/140095031570448/telemetry.conf
+++ b/MagicMock/user_config_dir()/140095031570448/telemetry.conf
@@ -1,0 +1,3 @@
+[telemetry]
+uuid = 20bdf01b447d4c95845b5f01496b3ff7
+

--- a/kedro-telemetry/RELEASE.md
+++ b/kedro-telemetry/RELEASE.md
@@ -1,4 +1,5 @@
 # Upcoming release
+* Updated the plugin to generate an unique UUID for each user of `kedro-telemetry`.
 
 # Release 0.3.2
 * Updated plugin to share if a project is being run in a ci environment.

--- a/kedro-telemetry/RELEASE.md
+++ b/kedro-telemetry/RELEASE.md
@@ -1,4 +1,4 @@
-# Upcoming release
+# Upcoming release 0.4.0
 * Updated the plugin to generate an unique UUID for each user of `kedro-telemetry`.
 
 # Release 0.3.2

--- a/kedro-telemetry/RELEASE.md
+++ b/kedro-telemetry/RELEASE.md
@@ -1,5 +1,5 @@
 # Upcoming release
-* Updated the plugin to generate an unique UUID for each user of `kedro-telemetry`.
+* Updated the plugin to generate an unique UUID for each user of `kedro-telemetry`. (On release 0.4)
 
 # Release 0.3.2
 * Updated plugin to share if a project is being run in a ci environment.

--- a/kedro-telemetry/RELEASE.md
+++ b/kedro-telemetry/RELEASE.md
@@ -1,5 +1,5 @@
 # Upcoming release
-* Updated the plugin to generate an unique UUID for each user of `kedro-telemetry`. (On release 0.4)
+* Updated the plugin to generate an unique UUID for each user of `kedro-telemetry`.
 
 # Release 0.3.2
 * Updated plugin to share if a project is being run in a ci environment.

--- a/kedro-telemetry/kedro_telemetry/plugin.py
+++ b/kedro-telemetry/kedro_telemetry/plugin.py
@@ -72,7 +72,18 @@ def _get_or_create_uuid():
 
         # Generate a new UUID and save it to the config file
         if not config.has_section("telemetry"):
-            config.add_section("telemetry")
+            new_uuid = _generate_new_uuid(config, config_path, full_path)
+
+        return new_uuid
+
+    except Exception as e:
+        logging.error(f"Failed to retrieve UUID: {e}")
+        return ""
+
+
+def _generate_new_uuid(config, config_path, full_path):
+    try:
+        config.add_section("telemetry")
         new_uuid = uuid.uuid4().hex
         config.set("telemetry", "uuid", new_uuid)
 
@@ -81,9 +92,8 @@ def _get_or_create_uuid():
             config.write(configfile)
 
         return new_uuid
-
     except Exception as e:
-        logging.error(f"Failed to get or create UUID: {e}")
+        logging.error(f"Failed to create UUID: {e}")
         return ""
 
 

--- a/kedro-telemetry/kedro_telemetry/plugin.py
+++ b/kedro-telemetry/kedro_telemetry/plugin.py
@@ -6,7 +6,6 @@ import logging
 import os
 import sys
 import uuid
-from appdirs import user_config_dir
 from configparser import ConfigParser
 from copy import deepcopy
 from datetime import datetime
@@ -17,6 +16,7 @@ import click
 import requests
 import toml
 import yaml
+from appdirs import user_config_dir
 from kedro import __version__ as KEDRO_VERSION
 from kedro.framework.cli.cli import KedroCLI
 from kedro.framework.cli.hooks import cli_hook_impl

--- a/kedro-telemetry/kedro_telemetry/plugin.py
+++ b/kedro-telemetry/kedro_telemetry/plugin.py
@@ -114,7 +114,7 @@ class KedroTelemetryCLIHooks:
                 return
 
             # get KedroCLI and its structure from actual project root
-            cli = KedroCLI(project_path=Path.cwd())
+            cli = KedroCLI(project_path=project_metadata.project_path)
             cli_struct = _get_cli_structure(cli_obj=cli, get_help=False)
             masked_command_args = _mask_kedro_cli(
                 cli_struct=cli_struct, command_args=command_args

--- a/kedro-telemetry/kedro_telemetry/plugin.py
+++ b/kedro-telemetry/kedro_telemetry/plugin.py
@@ -60,7 +60,7 @@ def _get_or_create_uuid():
 
     try:
         if os.path.exists(full_path):
-            with open(full_path, 'r') as f:
+            with open(full_path) as f:
                 config = toml.load(f)
 
                 if "telemetry" in config and "uuid" in config["telemetry"]:

--- a/kedro-telemetry/kedro_telemetry/plugin.py
+++ b/kedro-telemetry/kedro_telemetry/plugin.py
@@ -64,10 +64,7 @@ def _get_or_create_uuid():
                 config = toml.load(f)
 
                 if "telemetry" in config and "uuid" in config["telemetry"]:
-                    try:
-                        return uuid.UUID(config["telemetry"]["uuid"]).hex
-                    except ValueError:
-                        return ""
+                    return uuid.UUID(config["telemetry"]["uuid"]).hex
 
         # Generate a new UUID and save it to the config file
         new_uuid = _generate_new_uuid(full_path)

--- a/kedro-telemetry/kedro_telemetry/plugin.py
+++ b/kedro-telemetry/kedro_telemetry/plugin.py
@@ -56,11 +56,11 @@ def _get_or_create_uuid():
     """
     Reads a UUID from a configuration file or generates and saves a new one if not present.
     """
-    try:
-        config_path = user_config_dir("kedro")
-        full_path = os.path.join(config_path, CONFIG_FILENAME)
-        config = ConfigParser()
+    config_path = user_config_dir("kedro")
+    full_path = os.path.join(config_path, CONFIG_FILENAME)
+    config = ConfigParser()
 
+    try:
         if os.path.exists(full_path):
             config.read(full_path)
 

--- a/kedro-telemetry/kedro_telemetry/plugin.py
+++ b/kedro-telemetry/kedro_telemetry/plugin.py
@@ -68,7 +68,7 @@ def _get_or_create_uuid():
                 try:
                     return uuid.UUID(config["telemetry"]["uuid"]).hex
                 except ValueError:
-                    pass  # Invalid UUID found, will generate a new one
+                    return ""
 
         # Generate a new UUID and save it to the config file
         if not config.has_section("telemetry"):

--- a/kedro-telemetry/pyproject.toml
+++ b/kedro-telemetry/pyproject.toml
@@ -13,6 +13,7 @@ license = {text = "Apache Software License (Apache 2.0)"}
 dependencies = [
     "kedro>=0.18.0",
     "requests~=2.20",
+    "appdirs>=1.4.4",
 ]
 dynamic = ["readme", "version"]
 

--- a/kedro-telemetry/tests/test_plugin.py
+++ b/kedro-telemetry/tests/test_plugin.py
@@ -300,7 +300,7 @@ class TestKedroTelemetryCLIHooks:
         mocked_anon_id = mocker.patch("kedro_telemetry.plugin._hash")
         mocked_anon_id.return_value = "digested"
         mocker.patch("kedro_telemetry.plugin.PACKAGE_NAME", "spaceflights")
-        mocker.patch("kedro_telemetry.plugin.user_config_dir", side_effect=Exception)
+        mocker.patch("builtins.open", side_effect=Exception)
 
         mocked_heap_call = mocker.patch("kedro_telemetry.plugin._send_heap_event")
         telemetry_hook = KedroTelemetryCLIHooks()

--- a/kedro-telemetry/tests/test_plugin.py
+++ b/kedro-telemetry/tests/test_plugin.py
@@ -226,13 +226,17 @@ class TestKedroTelemetryCLIHooks:
         mocked_anon_id = mocker.patch("kedro_telemetry.plugin._hash")
         mocked_anon_id.return_value = "digested"
         mocker.patch("kedro_telemetry.plugin.PACKAGE_NAME", "spaceflights")
+        mocker.patch(
+            "kedro_telemetry.plugin._get_or_create_uuid",
+            return_value="hashed_username",
+        )
 
         mocked_heap_call = mocker.patch("kedro_telemetry.plugin._send_heap_event")
         telemetry_hook = KedroTelemetryCLIHooks()
         command_args = []
         telemetry_hook.before_command_run(fake_metadata, command_args)
         expected_properties = {
-            "username": "digested",
+            "username": "hashed_username",
             "package_name": "digested",
             "project_version": kedro_version,
             "telemetry_version": TELEMETRY_VERSION,
@@ -249,12 +253,12 @@ class TestKedroTelemetryCLIHooks:
         expected_calls = [
             mocker.call(
                 event_name="Command run: kedro",
-                identity="digested",
+                identity="hashed_username",
                 properties=expected_properties,
             ),
             mocker.call(
                 event_name="CLI command",
-                identity="digested",
+                identity="hashed_username",
                 properties=generic_properties,
             ),
         ]
@@ -296,7 +300,7 @@ class TestKedroTelemetryCLIHooks:
         mocked_anon_id = mocker.patch("kedro_telemetry.plugin._hash")
         mocked_anon_id.return_value = "digested"
         mocker.patch("kedro_telemetry.plugin.PACKAGE_NAME", "spaceflights")
-        mocker.patch("getpass.getuser", side_effect=Exception)
+        mocker.patch("kedro_telemetry.plugin.user_config_dir", side_effect=Exception)
 
         mocked_heap_call = mocker.patch("kedro_telemetry.plugin._send_heap_event")
         telemetry_hook = KedroTelemetryCLIHooks()

--- a/kedro-telemetry/tests/test_plugin.py
+++ b/kedro-telemetry/tests/test_plugin.py
@@ -131,7 +131,7 @@ class TestKedroTelemetryCLIHooks:
         mocked_anon_id.return_value = "digested"
         mocker.patch("kedro_telemetry.plugin.PACKAGE_NAME", "spaceflights")
         mocker.patch(
-            "kedro_telemetry.plugin._get_hashed_username",
+            "kedro_telemetry.plugin._get_or_create_uuid",
             return_value="hashed_username",
         )
 
@@ -177,7 +177,7 @@ class TestKedroTelemetryCLIHooks:
         mocked_anon_id.return_value = "digested"
         mocker.patch("kedro_telemetry.plugin.PACKAGE_NAME", "spaceflights")
         mocker.patch(
-            "kedro_telemetry.plugin._get_hashed_username",
+            "kedro_telemetry.plugin._get_or_create_uuid",
             return_value="hashed_username",
         )
 
@@ -474,7 +474,7 @@ class TestKedroTelemetryProjectHooks:
         mocker.patch("kedro_telemetry.plugin._hash", return_value="digested")
         mocker.patch("kedro_telemetry.plugin.PACKAGE_NAME", "spaceflights")
         mocker.patch(
-            "kedro_telemetry.plugin._get_hashed_username",
+            "kedro_telemetry.plugin._get_or_create_uuid",
             return_value="hashed_username",
         )
         mocked_heap_call = mocker.patch("kedro_telemetry.plugin._send_heap_event")
@@ -530,7 +530,7 @@ class TestKedroTelemetryProjectHooks:
         mocker.patch("kedro_telemetry.plugin._hash", return_value="digested")
         mocker.patch("kedro_telemetry.plugin.PACKAGE_NAME", "spaceflights")
         mocker.patch(
-            "kedro_telemetry.plugin._get_hashed_username",
+            "kedro_telemetry.plugin._get_or_create_uuid",
             return_value="hashed_username",
         )
         mocked_heap_call = mocker.patch("kedro_telemetry.plugin._send_heap_event")
@@ -589,7 +589,7 @@ class TestKedroTelemetryProjectHooks:
         mocker.patch("kedro_telemetry.plugin._hash", return_value="digested")
         mocker.patch("kedro_telemetry.plugin.PACKAGE_NAME", "spaceflights")
         mocker.patch(
-            "kedro_telemetry.plugin._get_hashed_username",
+            "kedro_telemetry.plugin._get_or_create_uuid",
             return_value="hashed_username",
         )
         mocked_heap_call = mocker.patch("kedro_telemetry.plugin._send_heap_event")

--- a/kedro-telemetry/tests/test_plugin.py
+++ b/kedro-telemetry/tests/test_plugin.py
@@ -132,7 +132,7 @@ class TestKedroTelemetryCLIHooks:
         mocker.patch("kedro_telemetry.plugin.PACKAGE_NAME", "spaceflights")
         mocker.patch(
             "kedro_telemetry.plugin._get_or_create_uuid",
-            return_value="hashed_username",
+            return_value="user_uuid",
         )
 
         mocked_heap_call = mocker.patch("kedro_telemetry.plugin._send_heap_event")
@@ -140,7 +140,7 @@ class TestKedroTelemetryCLIHooks:
         command_args = ["--version"]
         telemetry_hook.before_command_run(fake_metadata, command_args)
         expected_properties = {
-            "username": "hashed_username",
+            "username": "user_uuid",
             "package_name": "digested",
             "project_version": kedro_version,
             "telemetry_version": TELEMETRY_VERSION,
@@ -157,12 +157,12 @@ class TestKedroTelemetryCLIHooks:
         expected_calls = [
             mocker.call(
                 event_name="Command run: --version",
-                identity="hashed_username",
+                identity="user_uuid",
                 properties=expected_properties,
             ),
             mocker.call(
                 event_name="CLI command",
-                identity="hashed_username",
+                identity="user_uuid",
                 properties=generic_properties,
             ),
         ]
@@ -178,7 +178,7 @@ class TestKedroTelemetryCLIHooks:
         mocker.patch("kedro_telemetry.plugin.PACKAGE_NAME", "spaceflights")
         mocker.patch(
             "kedro_telemetry.plugin._get_or_create_uuid",
-            return_value="hashed_username",
+            return_value="user_uuid",
         )
 
         mocked_heap_call = mocker.patch("kedro_telemetry.plugin._send_heap_event")
@@ -188,7 +188,7 @@ class TestKedroTelemetryCLIHooks:
         command_args = ["--version"]
         telemetry_hook.before_command_run(fake_metadata, command_args)
         expected_properties = {
-            "username": "hashed_username",
+            "username": "user_uuid",
             "package_name": "digested",
             "project_version": kedro_version,
             "telemetry_version": TELEMETRY_VERSION,
@@ -207,12 +207,12 @@ class TestKedroTelemetryCLIHooks:
         expected_calls = [
             mocker.call(
                 event_name="Command run: --version",
-                identity="hashed_username",
+                identity="user_uuid",
                 properties=expected_properties,
             ),
             mocker.call(
                 event_name="CLI command",
-                identity="hashed_username",
+                identity="user_uuid",
                 properties=generic_properties,
             ),
         ]
@@ -228,7 +228,7 @@ class TestKedroTelemetryCLIHooks:
         mocker.patch("kedro_telemetry.plugin.PACKAGE_NAME", "spaceflights")
         mocker.patch(
             "kedro_telemetry.plugin._get_or_create_uuid",
-            return_value="hashed_username",
+            return_value="user_uuid",
         )
 
         mocked_heap_call = mocker.patch("kedro_telemetry.plugin._send_heap_event")
@@ -236,7 +236,7 @@ class TestKedroTelemetryCLIHooks:
         command_args = []
         telemetry_hook.before_command_run(fake_metadata, command_args)
         expected_properties = {
-            "username": "hashed_username",
+            "username": "user_uuid",
             "package_name": "digested",
             "project_version": kedro_version,
             "telemetry_version": TELEMETRY_VERSION,
@@ -253,12 +253,12 @@ class TestKedroTelemetryCLIHooks:
         expected_calls = [
             mocker.call(
                 event_name="Command run: kedro",
-                identity="hashed_username",
+                identity="user_uuid",
                 properties=expected_properties,
             ),
             mocker.call(
                 event_name="CLI command",
-                identity="hashed_username",
+                identity="user_uuid",
                 properties=generic_properties,
             ),
         ]
@@ -479,7 +479,7 @@ class TestKedroTelemetryProjectHooks:
         mocker.patch("kedro_telemetry.plugin.PACKAGE_NAME", "spaceflights")
         mocker.patch(
             "kedro_telemetry.plugin._get_or_create_uuid",
-            return_value="hashed_username",
+            return_value="user_uuid",
         )
         mocked_heap_call = mocker.patch("kedro_telemetry.plugin._send_heap_event")
         mocker.patch("kedro_telemetry.plugin.open")
@@ -491,7 +491,7 @@ class TestKedroTelemetryProjectHooks:
         telemetry_hook.after_catalog_created(fake_catalog)
 
         project_properties = {
-            "username": "hashed_username",
+            "username": "user_uuid",
             "package_name": "digested",
             "project_version": kedro_version,
             "telemetry_version": TELEMETRY_VERSION,
@@ -508,7 +508,7 @@ class TestKedroTelemetryProjectHooks:
 
         expected_call = mocker.call(
             event_name="Kedro Project Statistics",
-            identity="hashed_username",
+            identity="user_uuid",
             properties=expected_properties,
         )
 
@@ -535,7 +535,7 @@ class TestKedroTelemetryProjectHooks:
         mocker.patch("kedro_telemetry.plugin.PACKAGE_NAME", "spaceflights")
         mocker.patch(
             "kedro_telemetry.plugin._get_or_create_uuid",
-            return_value="hashed_username",
+            return_value="user_uuid",
         )
         mocked_heap_call = mocker.patch("kedro_telemetry.plugin._send_heap_event")
         mocker.patch("kedro_telemetry.plugin.toml.load")
@@ -550,7 +550,7 @@ class TestKedroTelemetryProjectHooks:
         telemetry_hook.after_catalog_created(fake_catalog)
 
         project_properties = {
-            "username": "hashed_username",
+            "username": "user_uuid",
             "package_name": "digested",
             "project_version": kedro_version,
             "telemetry_version": TELEMETRY_VERSION,
@@ -567,7 +567,7 @@ class TestKedroTelemetryProjectHooks:
 
         expected_call = mocker.call(
             event_name="Kedro Project Statistics",
-            identity="hashed_username",
+            identity="user_uuid",
             properties=expected_properties,
         )
 
@@ -594,7 +594,7 @@ class TestKedroTelemetryProjectHooks:
         mocker.patch("kedro_telemetry.plugin.PACKAGE_NAME", "spaceflights")
         mocker.patch(
             "kedro_telemetry.plugin._get_or_create_uuid",
-            return_value="hashed_username",
+            return_value="user_uuid",
         )
         mocked_heap_call = mocker.patch("kedro_telemetry.plugin._send_heap_event")
         mocker.patch("builtins.open", mocker.mock_open(read_data=MOCK_PYPROJECT_TOOLS))
@@ -611,7 +611,7 @@ class TestKedroTelemetryProjectHooks:
         telemetry_hook.after_catalog_created(fake_catalog)
 
         project_properties = {
-            "username": "hashed_username",
+            "username": "user_uuid",
             "package_name": "digested",
             "project_version": kedro_version,
             "telemetry_version": TELEMETRY_VERSION,
@@ -630,7 +630,7 @@ class TestKedroTelemetryProjectHooks:
 
         expected_call = mocker.call(
             event_name="Kedro Project Statistics",
-            identity="hashed_username",
+            identity="user_uuid",
             properties=expected_properties,
         )
 


### PR DESCRIPTION
## Description
This PR introduces a unique identifier (UUID) for each user of the kedro-telemetry.

- Instead of relying on hashed usernames, we now generate a unique UUID for each user. This UUID is generated using uuid.uuid4() function.
- Generated UUID is stored in a user-specific configuration file, leveraging the appdirs library to determine the appropriate OS-specific path for this file (~/Library/Application Support/kedro/telemetry.conf on MAC)
- If a UUID does not already exist, the function generates a new one, stores it, and then uses this UUID in subsequent telemetry events.


## Checklist

- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [x] Added a description of this change in the relevant `RELEASE.md` file
- [x] Added tests to cover my changes
