### PR TITLE
feat(airflow): add --tags option for node filtering in airflow create

### DIFF
--- a/kedro-airflow/kedro_airflow/plugin.py
+++ b/kedro-airflow/kedro_airflow/plugin.py
@@ -10,7 +10,12 @@ import jinja2
 from click import secho
 from kedro.config import MissingConfigException
 from kedro.framework.cli.project import PARAMS_ARG_HELP
-from kedro.framework.cli.utils import ENV_HELP, KedroCliError, _split_params
+from kedro.framework.cli.utils import (
+    ENV_HELP,
+    KedroCliError,
+    _split_params,
+    split_string,
+)
 from kedro.framework.context import KedroContext
 from kedro.framework.project import pipelines
 from kedro.framework.session import KedroSession
@@ -120,6 +125,7 @@ def _get_pipeline_config(config_airflow: dict, params: dict, pipeline_name: str)
     type=str,
     default="",
     help=TAGS_ARG_HELP,
+    callback=split_string,
 )
 @click.option(
     "--params",
@@ -191,8 +197,7 @@ def create(  # noqa: PLR0913, PLR0912
         dag_filename = dags_folder / dag_name
 
         if tags:
-            tags_list = tags.split(",")
-            pipeline = pipeline.only_nodes_with_tags(*tags_list)  # noqa: PLW2901
+            pipeline = pipeline.only_nodes_with_tags(*tags)  # noqa: PLW2901
 
         # group memory nodes
         if group_in_memory:

--- a/kedro-airflow/kedro_airflow/plugin.py
+++ b/kedro-airflow/kedro_airflow/plugin.py
@@ -24,6 +24,9 @@ If not set, the '__default__' pipeline is used. This argument supports
 passing multiple values using `--pipeline [p1] --pipeline [p2]`.
 Use the `--all` flag to convert all registered pipelines at once."""
 ALL_ARG_HELP = """Convert all registered pipelines at once."""
+TAGS_ARG_HELP = """Tags to be used for filtering pipeline nodes.
+Multiple tags are supported. Use the following format:
+`--tags tag1,tag2`."""
 DEFAULT_RUN_ENV = "local"
 DEFAULT_PIPELINE = "__default__"
 
@@ -113,6 +116,12 @@ def _get_pipeline_config(config_airflow: dict, params: dict, pipeline_name: str)
     "as they do not persist between Airflow operators.",
 )
 @click.option(
+    "--tags",
+    type=str,
+    default="",
+    help=TAGS_ARG_HELP,
+)
+@click.option(
     "--params",
     type=click.UNPROCESSED,
     default="",
@@ -127,6 +136,7 @@ def create(  # noqa: PLR0913
     target_path,
     jinja_file,
     group_in_memory,
+    tags,
     params,
     convert_all: bool,
 ):
@@ -179,6 +189,10 @@ def create(  # noqa: PLR0913
             dag_name += f"_{name}"
         dag_name += "_dag.py"
         dag_filename = dags_folder / dag_name
+
+        if tags:
+            tags_list = tags.split(",")
+            pipeline = pipeline.only_nodes_with_tags(*tags_list)
 
         # group memory nodes
         if group_in_memory:

--- a/kedro-airflow/kedro_airflow/plugin.py
+++ b/kedro-airflow/kedro_airflow/plugin.py
@@ -129,7 +129,7 @@ def _get_pipeline_config(config_airflow: dict, params: dict, pipeline_name: str)
     callback=_split_params,
 )
 @click.pass_obj
-def create(  # noqa: PLR0913
+def create(  # noqa: PLR0913, PLR0912
     metadata: ProjectMetadata,
     pipeline_names,
     env,
@@ -192,7 +192,7 @@ def create(  # noqa: PLR0913
 
         if tags:
             tags_list = tags.split(",")
-            pipeline = pipeline.only_nodes_with_tags(*tags_list)
+            pipeline = pipeline.only_nodes_with_tags(*tags_list)  # noqa: PLW2901
 
         # group memory nodes
         if group_in_memory:

--- a/kedro-airflow/tests/conftest.py
+++ b/kedro-airflow/tests/conftest.py
@@ -67,8 +67,9 @@ def identity(arg):
 def register_pipelines():
     pipeline = Pipeline(
         [
-            node(identity, ["input"], ["intermediate"], name="node0"),
+            node(identity, ["input"], ["intermediate"], name="node0", tags=["tag0"]),
             node(identity, ["intermediate"], ["output"], name="node1"),
+            node(identity, ["intermediate"], ["output2"], name="node2", tags=["tag0"]),
         ],
         tags="pipeline0",
     )

--- a/kedro-airflow/tests/conftest.py
+++ b/kedro-airflow/tests/conftest.py
@@ -67,9 +67,11 @@ def identity(arg):
 def register_pipelines():
     pipeline = Pipeline(
         [
-            node(identity, ["input"], ["intermediate"], name="node0", tags=["tag0"]),
+            node(identity, ["input"], ["intermediate"], name="node0", tags=["tag0", "tag1"]),
             node(identity, ["intermediate"], ["output"], name="node1"),
             node(identity, ["intermediate"], ["output2"], name="node2", tags=["tag0"]),
+            node(identity, ["intermediate"], ["output3"], name="node3", tags=["tag1", "tag2"]),
+            node(identity, ["intermediate"], ["output4"], name="node4", tags=["tag2"]),
         ],
         tags="pipeline0",
     )

--- a/kedro-airflow/tests/test_plugin.py
+++ b/kedro-airflow/tests/test_plugin.py
@@ -282,7 +282,7 @@ def test_create_airflow_dag_env_parameter_exists(cli_runner, metadata):
         ),
         # Test few tags with whitespaces
         (
-            ["--tags", "tag0,tag1"],
+            ["--tags", "tag0 , tag1"],
             ['tasks["node0"] >> tasks["node2"]', 'tasks["node0"] >> tasks["node3"]'],
             ['tasks["node0"] >> tasks["node1"]', 'tasks["node0"] >> tasks["node4"]'],
         ),

--- a/kedro-airflow/tests/test_plugin.py
+++ b/kedro-airflow/tests/test_plugin.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
+import shutil
 from pathlib import Path
 from typing import Any
 
 import pytest
-import shutil
 import yaml
 
 from kedro_airflow.plugin import commands

--- a/kedro-airflow/tests/test_plugin.py
+++ b/kedro-airflow/tests/test_plugin.py
@@ -242,12 +242,12 @@ def test_custom_template_nonexistent(cli_runner, metadata):
     )
 
 
-def _kedro_create_env(project_root: Path):
-    (project_root / "conf" / "remote").mkdir(parents=True)
+def _kedro_create_env(project_root: Path, env: str):
+    (project_root / "conf" / env).mkdir(parents=True)
 
 
-def _kedro_remove_env(project_root: Path):
-    shutil.rmtree(project_root / "conf" / "remote")
+def _kedro_remove_env(project_root: Path, env: str):
+    shutil.rmtree(project_root / "conf" / env)
 
 
 def test_create_airflow_dag_env_parameter_exists(cli_runner, metadata):
@@ -255,7 +255,7 @@ def test_create_airflow_dag_env_parameter_exists(cli_runner, metadata):
     dag_name = "hello_world"
     command = ["airflow", "create", "--env", "remote"]
 
-    _kedro_create_env(Path.cwd())
+    _kedro_create_env(Path.cwd(), "remote")
 
     dag_file = Path.cwd() / "airflow_dags" / f"{dag_name}_remote_dag.py"
     result = cli_runner.invoke(commands, command, obj=metadata)
@@ -268,7 +268,7 @@ def test_create_airflow_dag_env_parameter_exists(cli_runner, metadata):
         dag_code = [line.strip() for line in f.read().splitlines()]
     assert expected_airflow_dag in dag_code
 
-    _kedro_remove_env(Path.cwd())
+    _kedro_remove_env(Path.cwd(), "remote")
 
 
 @pytest.mark.parametrize(
@@ -295,7 +295,7 @@ def test_create_airflow_dag_tags_parameter_exists(
     dag_name = "hello_world"
     command = ["airflow", "create", "--env", "remote"] + tags
 
-    _kedro_create_env(Path.cwd())
+    _kedro_create_env(Path.cwd(), "remote")
 
     dag_file = Path.cwd() / "airflow_dags" / f"{dag_name}_remote_dag.py"
     result = cli_runner.invoke(commands, command, obj=metadata)
@@ -310,7 +310,7 @@ def test_create_airflow_dag_tags_parameter_exists(
     for unexpected_dag in unexpected_airflow_dags:
         assert unexpected_dag not in dag_code
 
-    _kedro_remove_env(Path.cwd())
+    _kedro_remove_env(Path.cwd(), "remote")
 
 
 def test_create_airflow_dag_nonexistent_pipeline(cli_runner, metadata):

--- a/kedro-airflow/tests/test_plugin.py
+++ b/kedro-airflow/tests/test_plugin.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+import shutil
 import yaml
 
 from kedro_airflow.plugin import commands
@@ -245,6 +246,10 @@ def _kedro_create_env(project_root: Path):
     (project_root / "conf" / "remote").mkdir(parents=True)
 
 
+def _kedro_remove_env(project_root: Path):
+    shutil.rmtree(project_root / "conf" / "remote")
+
+
 def test_create_airflow_dag_env_parameter_exists(cli_runner, metadata):
     """Test the `env` parameter"""
     dag_name = "hello_world"
@@ -262,6 +267,8 @@ def test_create_airflow_dag_env_parameter_exists(cli_runner, metadata):
     with dag_file.open(encoding="utf-8") as f:
         dag_code = [line.strip() for line in f.read().splitlines()]
     assert expected_airflow_dag in dag_code
+
+    _kedro_remove_env(Path.cwd())
 
 
 def test_create_airflow_dag_tags_parameter_exists(cli_runner, metadata):
@@ -283,6 +290,8 @@ def test_create_airflow_dag_tags_parameter_exists(cli_runner, metadata):
         dag_code = [line.strip() for line in f.read().splitlines()]
     assert expected_airflow_dag in dag_code
     assert unexpected_airflow_dag not in dag_code
+
+    _kedro_remove_env(Path.cwd())
 
 
 def test_create_airflow_dag_nonexistent_pipeline(cli_runner, metadata):

--- a/kedro-airflow/tests/test_plugin.py
+++ b/kedro-airflow/tests/test_plugin.py
@@ -264,6 +264,27 @@ def test_create_airflow_dag_env_parameter_exists(cli_runner, metadata):
     assert expected_airflow_dag in dag_code
 
 
+def test_create_airflow_dag_tags_parameter_exists(cli_runner, metadata):
+    """Test the `tags` parameter"""
+    dag_name = "hello_world"
+    command = ["airflow", "create", "--tags", "tag0", "--env", "remote"]
+
+    _kedro_create_env(Path.cwd())
+
+    dag_file = Path.cwd() / "airflow_dags" / f"{dag_name}_remote_dag.py"
+    result = cli_runner.invoke(commands, command, obj=metadata)
+
+    assert result.exit_code == 0, (result.exit_code, result.stdout)
+    assert dag_file.exists()
+
+    expected_airflow_dag = 'tasks["node0"] >> tasks["node2"]'
+    unexpected_airflow_dag = 'tasks["node0"] >> tasks["node1"]'
+    with dag_file.open(encoding="utf-8") as f:
+        dag_code = [line.strip() for line in f.read().splitlines()]
+    assert expected_airflow_dag in dag_code
+    assert unexpected_airflow_dag not in dag_code
+
+
 def test_create_airflow_dag_nonexistent_pipeline(cli_runner, metadata):
     """Test executing with a non-existing pipeline"""
     command = ["airflow", "create", "--pipeline", "de"]


### PR DESCRIPTION
## Description
This PR introduces an option to use the `--tags="ABC"` argument together with the `airflow create` command, enabling the filtering of nodes based on specific tags.

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
