### PR TITLE
build(telemetry): Add python 3.12 support

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -12,6 +12,8 @@ on:
 
 jobs:
   e2e-tests:
+    env:
+      UV_HTTP_TIMEOUT: 600
     defaults:
       run:
         shell: bash

--- a/.github/workflows/kedro-datasets.yml
+++ b/.github/workflows/kedro-datasets.yml
@@ -38,6 +38,8 @@ jobs:
 
   check-docs:
     runs-on: ubuntu-latest
+    env:
+      UV_HTTP_TIMEOUT: 600
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/kedro-telemetry.yml
+++ b/.github/workflows/kedro-telemetry.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        python-version: [ "3.8", "3.9", "3.10", "3.11" ]
+        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
     uses: ./.github/workflows/unit-tests.yml
     with:
       plugin: kedro-telemetry
@@ -40,7 +40,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        python-version: [ "3.8", "3.9", "3.10", "3.11" ]
+        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
     uses: ./.github/workflows/e2e-tests.yml
     with:
       plugin: kedro-telemetry

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,6 +12,8 @@ on:
 
 jobs:
   lint:
+    env:
+      UV_HTTP_TIMEOUT: 600
     defaults:
       run:
         shell: bash

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -14,6 +14,8 @@ jobs:
 
   unit-tests:
     runs-on: ${{ inputs.os }}
+    env:
+      UV_HTTP_TIMEOUT: 600
     defaults:
       run:
         shell: bash

--- a/kedro-datasets/.readthedocs.yaml
+++ b/kedro-datasets/.readthedocs.yaml
@@ -12,6 +12,7 @@ build:
   jobs:
     pre_install:
       - python -m pip install "uv==0.1.13"
+      - export UV_HTTP_TIMEOUT=600
       - uv pip install --system --upgrade sphinx readthedocs-sphinx-ext "kedro-datasets[docs,test] @ ./kedro-datasets"
       - uv pip freeze
     pre_build:

--- a/kedro-telemetry/RELEASE.md
+++ b/kedro-telemetry/RELEASE.md
@@ -1,5 +1,6 @@
 # Upcoming release 0.4.0
 * Updated the plugin to generate an unique UUID for each user of `kedro-telemetry`.
+* Added support for Python 3.12.
 
 # Release 0.3.2
 * Updated plugin to share if a project is being run in a ci environment.


### PR DESCRIPTION
## Description
Related #613, Also solve https://github.com/kedro-org/kedro-plugins/issues/618

## Development notes
<!-- What have you changed, and how has this been tested? -->
No changes required to upgrade to Python 3.12 as such for `kedro-telemetry`

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
