### PR TITLE
chore(telemetry): Remove dummy e2e test

### DIFF
--- a/.github/workflows/kedro-telemetry.yml
+++ b/.github/workflows/kedro-telemetry.yml
@@ -35,14 +35,3 @@ jobs:
       plugin: kedro-telemetry
       os: ubuntu-latest
       python-version: "3.11"
-
-  e2e-tests:
-    strategy:
-      matrix:
-        os: [ ubuntu-latest ]
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
-    uses: ./.github/workflows/e2e-tests.yml
-    with:
-      plugin: kedro-telemetry
-      os: ${{ matrix.os }}
-      python-version: ${{ matrix.python-version }}

--- a/kedro-telemetry/features/steps/dummy.feature
+++ b/kedro-telemetry/features/steps/dummy.feature
@@ -1,1 +1,0 @@
-# A dummy file to keep CI behaving correctly

--- a/kedro-telemetry/pyproject.toml
+++ b/kedro-telemetry/pyproject.toml
@@ -25,7 +25,6 @@ Tracker = "https://github.com/kedro-org/kedro-plugins/issues"
 [project.optional-dependencies]
 test = [
     "bandit>=1.6.2, <2.0",
-    "behave",
     "black~=22.0",
     "pre-commit>=2.9.2",
     "pytest",


### PR DESCRIPTION
## Description
I realised we have dummy e2e tests in `kedro-telemetry` from 2 years ago https://github.com/kedro-org/kedro-plugins/pull/71
Don't think we need it anymore with the GitHub Actions setup.

## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
