### PR TITLE
fix: Add `--telemetry` flag to to kedro-telemetry CLI masking tests.

### DIFF
--- a/kedro-telemetry/tests/test_masking.py
+++ b/kedro-telemetry/tests/test_masking.py
@@ -110,9 +110,11 @@ class TestCLIMasking:
                 "--example",
                 "--name",
                 "--tools",
+                "--telemetry",
                 "-e",
                 "-n",
                 "-t",
+                "-tc",
             ]
         )
         # now check that once params and args are reached, the values are None


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->

Adds the `--telemetry` flag to the `test_get_cli_structure_depth` on kedro-telemetry, to account for the same changes done on the main Kedro repository.

## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Added a description of this change in the relevant `RELEASE.md` file
- [x] Added tests to cover my changes
