### PR TITLE
feat(datasets) Experimental - sqlframe datasets

### DIFF
--- a/kedro-datasets/kedro_datasets_experimental/sqlframe/__init__.py
+++ b/kedro-datasets/kedro_datasets_experimental/sqlframe/__init__.py
@@ -1,0 +1,13 @@
+"""Provide data loading and saving functionality for SqlFrame's backends."""
+
+from typing import Any
+
+import lazy_loader as lazy
+
+# https://github.com/pylint-dev/pylint/issues/4300#issuecomment-1043601901
+TableDataset: Any
+FileDataset: Any
+
+__getattr__, __dir__, __all__ = lazy.attach(
+    __name__, submod_attrs={"sqlframe": ["TableDataset", "FileDataset"]}
+)

--- a/kedro-datasets/kedro_datasets_experimental/sqlframe/resolvers.py
+++ b/kedro-datasets/kedro_datasets_experimental/sqlframe/resolvers.py
@@ -1,0 +1,34 @@
+from typing import Generator, Optional
+from omegaconf import OmegaConf
+import duckdb
+
+
+def _make_lazy(func) -> Generator:
+    """Make function lazy so it can be deepcopied"""
+
+    def wrapper(*args, **kwargs):
+        def generator():
+            yield func(*args, **kwargs)
+
+        return generator
+
+    return wrapper
+
+
+@_make_lazy
+def create_duckdb_conn(
+    database_name: str, password: Optional[str]
+) -> Generator[duckdb.DuckDBPyConnection, None, None]:
+    """Create a lazy duckdb connection"""
+    config = {"password": password} if password else {}
+    conn = duckdb.connect(f"{database_name}.duckdb", config=config)
+    return conn
+
+
+def get_credentials(path) -> str:
+    """Retrieve credentials earlier in the lifecycle"""
+    data = OmegaConf.load("conf/local/credentials.yml")
+    return OmegaConf.select(data, path)
+
+
+from kedro.io.data_catalog import DataCatalog

--- a/kedro-datasets/kedro_datasets_experimental/sqlframe/sqlframe.py
+++ b/kedro-datasets/kedro_datasets_experimental/sqlframe/sqlframe.py
@@ -183,6 +183,22 @@ class FileDataset(AbstractDataset[_BaseDataFrame, _BaseDataFrame]):
         load_args: Optional[dict[str, any]] = None,
         save_args: Optional[dict[str, any]] = None,
     ) -> None:
+        """``FileDataset`` creates a spark-like session for the associated
+        database backend e.g. DuckDB or BigQuery. The connection Generator is used
+        to provide a live connection object. It needs to be a generator if provided
+        since this allows us to initialise lazily with OmegaConf and pass through the
+        DataCatalog initialization process which includes a non-picklable deepcopy.
+
+        Args:
+            backend: The SQL backend to use
+            filepath: The filepath in question
+            file_format: csv, json, parquet or others provided as attributes 
+                of the writer object
+            connection: The lazily defined connection object
+                e.g. duckdb.DuckDBPyConnection or similar
+            load_args: Arbitrary load args provided to ``session.read.{file_format}``
+            save_args: Arbitrary save args provided  ``DataFrame.write.{file_format}``
+        """
         self.backend = backend
         module = importlib.import_module(f"sqlframe.{backend}")
         session_class = _getattr_case_insensitive(module, f"{backend}session")

--- a/kedro-datasets/kedro_datasets_experimental/sqlframe/sqlframe.py
+++ b/kedro-datasets/kedro_datasets_experimental/sqlframe/sqlframe.py
@@ -1,0 +1,143 @@
+import importlib
+import logging
+from typing import Any, Generator, Optional
+from kedro.io import AbstractDataset
+from sqlframe.base.dataframe import _BaseDataFrame
+from sqlframe.standalone.session import _BaseSession
+
+logger = logging.getLogger(__name__)
+
+
+def _getattr_case_insensitive(obj: object, attr_name: str) -> callable:
+    """
+    Used to retrieve session object when capitalization is not know
+    ahead of time. Take the backend name `duckdb` as an example
+    importing the class `from sqlframe.duckdb import DuckDBSession`
+    is near impossible to predict ahead of time.
+    """
+    attr_name_lower = attr_name.lower()
+    for attr in dir(obj):
+        if attr.lower() == attr_name_lower:
+            attribute = getattr(obj, attr)
+            logger.debug(f"Retrieved {obj.__name__}.{attr}")
+            return attribute
+    raise AttributeError(
+        f"'{type(obj).__name__}' object has no attribute '{attr_name}'"
+    )
+
+
+class TableDataset(AbstractDataset[_BaseDataFrame, _BaseDataFrame]):
+    """``TableDataSet`` loads/saves data from/to sqlframe table expressions
+
+    Example usage for the
+    `YAML API <https://kedro.readthedocs.io/en/stable/data/\
+    data_catalog_yaml_examples.html>`_:
+
+    (In the following example one must use a OmegaConf resolver to create a
+    live connection object, these are registered in ``settings.py`` and imported
+    from ``kedro_datasets_experimental.sqlframe.resolvers``)
+
+    .. code-block:: yaml
+
+        my_table:
+            type: kedro_datasets_experimental.sqlframe.TableDataset
+            backend: duckdb
+            table_name: "my_table"
+            connection: ${duckdb_conn:data/01_raw/my_database}
+
+    Example usage for the
+    `Python API <https://kedro.readthedocs.io/en/stable/data/\
+    advanced_data_catalog_usage.html>`_:
+
+    .. code-block:: pycon
+
+        >>> import duckdb
+        >>> from sqlframe.duckdb import DuckDBSession
+        >>>
+        >>> conn = duckdb.connect("test.duckdb") # or `:memory:`
+        >>> session = DuckDBSession(conn)
+        >>> df = session.createDataFrame([{"id": 1, "fname": "Jack"}])
+        >>> dataset = TableDataset(
+        >>>     backend="duckdb",
+        >>>     table_name="test"
+        >>> )
+        >>> dataset.save(df)
+        >>> dataset.load().show()
+
+    .. code-block:: pycon
+
+        >>> from psycopg2 import connect
+        >>> from sqlframe.postgres import PostgresSession
+        >>>
+        >>> conn = connect(
+        >>>    dbname="postgres",
+        >>>    user="postgres",
+        >>>    password="password",
+        >>>    host="localhost",
+        >>>    port="5432",
+        >>> )
+        >>> session = PostgresSession(conn=conn)
+        >>> df = session.createDataFrame([{"id": 1, "fname": "Jack"}])
+        >>> dataset = TableDataset(
+        >>>     backend="postgres",
+        >>>     table_name="test"
+        >>> )
+        >>> dataset.save(df)
+        >>> dataset.load().show()
+
+    """
+
+    def __init__(
+        self,
+        *,
+        backend: str,
+        table_name: str,
+        connection: Optional[Generator] = None,
+        load_args: Optional[dict[str, any]] = None,
+        save_args: Optional[dict[str, any]] = None,
+    ):
+        """``TableDataset`` creates a spark-like session for the associated
+        database backend e.g. DuckDB or BigQuery. The connection Generator is used
+        to provide a live connection object. It needs to be a generator if provided
+        since this allows us to initialise lazily with OmegaConf and pass through the
+        DataCatalog initialization process which includes a non-picklable deepcopy.
+
+        Args:
+            backend: The SQL backend to use
+            table_name: The table to read
+            connection: The lazily defined connection object
+                e.g. duckdb.DuckDBPyConnection or similar
+            load_args: Arbitrary load args provided to ``session.read.table``
+            save_args: Arbitrary save args provided  ``DataFrame.write.saveAsTable``
+        """
+        module = importlib.import_module(f"sqlframe.{backend}")
+        session_class = _getattr_case_insensitive(module, f"{backend}session")
+        self._connection = connection
+        self._table_name = table_name
+        self._load_args = load_args if load_args else {}
+        self._save_args = save_args if save_args else {}
+
+        if connection:
+            self.session: _BaseSession = session_class(next(self._connection()))
+        else:
+            self.session: _BaseSession = session_class()
+
+    def _load(self) -> _BaseDataFrame:
+        """Read table from backend"""
+        return self.session.read.table(self._table_name, **self._load_args)
+
+    def _save(self, data: _BaseDataFrame) -> None:
+        """Write table from backend"""
+        return data.write.saveAsTable(name=self._table_name, **self._save_args)
+
+    def _describe(self) -> dict[str, str]:
+        return {
+            "session": str(self.session.__class__.__name__),
+            "load_args": self._load_args,
+            "save_args": self._save_args,
+        }
+
+
+class FileDataset(AbstractDataset[_BaseDataFrame, _BaseDataFrame]):
+    def __init__(self) -> None:
+        raise NotImplementedError()

--- a/kedro-datasets/pyproject.toml
+++ b/kedro-datasets/pyproject.toml
@@ -71,6 +71,13 @@ ibis-sqlite = ["ibis-framework[sqlite]"]
 ibis-trino = ["ibis-framework[trino]"]
 ibis = ["ibis-framework"]
 
+sqlframe = ["sqlframe"]
+sqlframe-duckdb = ["sqlframe[duckdb]"]
+sqlframe-postgres = ["sqlframe[postgres]"]
+sqlframe-redshift = ["sqlframe[redshift]"]
+sqlframe-snowflake = ["sqlframe[snowflake]"]
+sqlframe-spark = ["sqlframe[spark]"]
+
 json-jsondataset = []
 json = ["kedro-datasets[json-jsondataset]"]
 


### PR DESCRIPTION
## Description
Leveraging [sqlframe](https://sqlframe.readthedocs.io/en/latest/) a new dataframe library which targets SQL backends (e.g. duckdb/bigquery/postgres) but exposes the PySpark API data frame syntax.... without the JVM or actually running Spark itself. 

This has two major benefits for users:
- Like Ibis it allows users to leverage SQL platforms as an execution engine in addition to a storage engine. Approaches like our `pandas.SQLTableDataset` are naive in the sense they don't use the SQL engine for processing, only storage.
- For users already accustomed to Spark syntax or brownfield projects already written in spark this provides a low-friction adoption route.

## Development notes
- This has been tested locally in the terminal, I've not yet written formal tests. Experimental mode baby 😎 .
- I've also done some funky `OmegaConf` resolver stuff so that the SQL connection can be lazily defined in YAML without creating a super complicated dataset class whilst still supporting dynamic switching of back-ends.

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
