### PR TITLE
fix(airflow): fix the link to correct deployment manual

### DIFF
--- a/kedro-airflow/README.md
+++ b/kedro-airflow/README.md
@@ -42,7 +42,7 @@ The Airflow DAG configuration can be customized by editing this file.
 ### Step 3: Package and install the Kedro pipeline in the Airflow executor's environment
 
 After generating and deploying the DAG file, you will then need to package and install the Kedro pipeline into the Airflow executor's environment.
-Please visit the guide to [deploy Kedro as a Python package](https://docs.kedro.org/en/stable/deployment/single_machine.html#package-based) for more details.
+Please visit the guide to [Apache Airflow deployment](https://docs.kedro.org/en/stable/deployment/airflow.html) for more details.
 
 ### FAQ
 


### PR DESCRIPTION
## Description
The Kedro Airflow Deployment manual was recently updated via two pull requests: [#3792](https://github.com/kedro-org/kedro/pull/3792) and [#3860](https://github.com/kedro-org/kedro/pull/3860). That PR will fix the link in the `README.md` of `kedro-airflow` to point to the correct deployment manual.

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
