### PR TITLE
fix(telemetry): Single project identifier

### DIFF
--- a/kedro-telemetry/RELEASE.md
+++ b/kedro-telemetry/RELEASE.md
@@ -1,7 +1,8 @@
 # Upcoming release
+* Updated the plugin to generate a unique project UUID for kedro project and store it in `pyproject.toml`.
 
 # Release 0.4.0
-* Updated the plugin to generate an unique UUID for each user of `kedro-telemetry`.
+* Updated the plugin to generate a unique UUID for each user of `kedro-telemetry`.
 * Added support for Python 3.12.
 
 # Release 0.3.2

--- a/kedro-telemetry/kedro_telemetry/plugin.py
+++ b/kedro-telemetry/kedro_telemetry/plugin.py
@@ -11,7 +11,7 @@ import uuid
 from copy import deepcopy
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, Optional
 
 import click
 import requests
@@ -46,7 +46,6 @@ KNOWN_CI_ENV_VAR_KEYS = {
 TIMESTAMP_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
 CONFIG_FILENAME = "telemetry.toml"
 PYPROJECT_CONFIG_NAME = "pyproject.toml"
-UNDEFINED_PROJECT_UUID = "undefined_project_uuid"
 UNDEFINED_PACKAGE_NAME = "undefined_package_name"
 
 logger = logging.getLogger(__name__)
@@ -81,7 +80,7 @@ def _get_or_create_uuid() -> str:
         return ""
 
 
-def _get_or_create_project_uuid(pyproject_path: Path) -> str:
+def _get_or_create_project_uuid(pyproject_path: Path) -> Optional[str]:
     """
     Reads a project UUID from a configuration file or generates and saves a new one if not present.
     """
@@ -103,7 +102,7 @@ def _get_or_create_project_uuid(pyproject_path: Path) -> str:
         f"Failed to retrieve UUID or save project UUID: {str(pyproject_path)} does not exist"
     )
 
-    return UNDEFINED_PROJECT_UUID
+    return None
 
 
 def _add_tool_properties(
@@ -251,7 +250,9 @@ def _is_known_ci_env(known_ci_env_var_keys: set[str]):
 def _get_project_properties(user_uuid: str, pyproject_path: Path) -> dict:
     project_uuid = _get_or_create_project_uuid(pyproject_path)
     package_name = PACKAGE_NAME or UNDEFINED_PACKAGE_NAME
-    hashed_project_uuid = _hash(f"{project_uuid}{package_name}")
+    hashed_project_uuid = (
+        _hash(f"{project_uuid}{package_name}") if project_uuid is not None else None
+    )
 
     properties = {
         "username": user_uuid,

--- a/kedro-telemetry/kedro_telemetry/plugin.py
+++ b/kedro-telemetry/kedro_telemetry/plugin.py
@@ -11,7 +11,7 @@ import uuid
 from copy import deepcopy
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 
 import click
 import requests
@@ -80,7 +80,7 @@ def _get_or_create_uuid() -> str:
         return ""
 
 
-def _get_or_create_project_uuid(pyproject_path: Path) -> Optional[str]:
+def _get_or_create_project_uuid(pyproject_path: Path) -> str | None:
     """
     Reads a project UUID from a configuration file or generates and saves a new one if not present.
     """

--- a/kedro-telemetry/kedro_telemetry/plugin.py
+++ b/kedro-telemetry/kedro_telemetry/plugin.py
@@ -86,14 +86,16 @@ def _get_or_create_project_uuid(pyproject_path: Path) -> str:
     Reads a project UUID from a configuration file or generates and saves a new one if not present.
     """
     if pyproject_path.exists():
-        pyproject_data = toml.load(pyproject_path)
+        with open(pyproject_path, "r+") as file:
+            pyproject_data = toml.load(file)
 
-        if "project" not in pyproject_data:
-            pyproject_data["project"] = {}
-        if "project_uuid" not in pyproject_data["project"]:
-            pyproject_data["project"]["project_uuid"] = uuid.uuid4().hex
-            with open(pyproject_path, "w") as file:
+            if "project" not in pyproject_data:
+                pyproject_data["project"] = {}
+            if "project_uuid" not in pyproject_data["project"]:
+                pyproject_data["project"]["project_uuid"] = uuid.uuid4().hex
+                file.seek(0)
                 toml.dump(pyproject_data, file)
+                file.truncate()
 
         return pyproject_data["project"]["project_uuid"]
 

--- a/kedro-telemetry/kedro_telemetry/plugin.py
+++ b/kedro-telemetry/kedro_telemetry/plugin.py
@@ -80,7 +80,7 @@ def _get_or_create_uuid() -> str:
         return ""
 
 
-def _get_or_create_project_uuid(pyproject_path: Path) -> str | None:
+def _get_or_create_project_id(pyproject_path: Path) -> str | None:
     """
     Reads a project UUID from a configuration file or generates and saves a new one if not present.
     """
@@ -89,15 +89,13 @@ def _get_or_create_project_uuid(pyproject_path: Path) -> str | None:
             pyproject_data = toml.load(file)
 
             try:
-                project_uuid = pyproject_data["tool"]["kedro_telemetry"]["project_uuid"]
+                project_id = pyproject_data["tool"]["kedro_telemetry"]["project_id"]
             except KeyError:
-                project_uuid = uuid.uuid4().hex
-                toml_string = (
-                    f'\n[tool.kedro_telemetry]\nproject_uuid = "{project_uuid}"\n'
-                )
+                project_id = uuid.uuid4().hex
+                toml_string = f'\n[tool.kedro_telemetry]\nproject_id = "{project_id}"\n'
                 file.write(toml_string)
 
-            return project_uuid
+            return project_id
 
     logging.debug(
         f"Failed to retrieve UUID or save project UUID: {str(pyproject_path)} does not exist"
@@ -249,15 +247,15 @@ def _is_known_ci_env(known_ci_env_var_keys: set[str]):
 
 
 def _get_project_properties(user_uuid: str, pyproject_path: Path) -> dict:
-    project_uuid = _get_or_create_project_uuid(pyproject_path)
+    project_id = _get_or_create_project_id(pyproject_path)
     package_name = PACKAGE_NAME or UNDEFINED_PACKAGE_NAME
-    hashed_project_uuid = (
-        _hash(f"{project_uuid}{package_name}") if project_uuid is not None else None
+    hashed_project_id = (
+        _hash(f"{project_id}{package_name}") if project_id is not None else None
     )
 
     properties = {
         "username": user_uuid,
-        "project_uuid": hashed_project_uuid,
+        "project_id": hashed_project_id,
         "project_version": KEDRO_VERSION,
         "telemetry_version": TELEMETRY_VERSION,
         "python_version": sys.version,

--- a/kedro-telemetry/kedro_telemetry/plugin.py
+++ b/kedro-telemetry/kedro_telemetry/plugin.py
@@ -103,7 +103,8 @@ def _get_or_create_project_id(pyproject_path: Path) -> str | None:
                 return project_id
             except KeyError:
                 logging.debug(
-                    f"Failed to retrieve project id or save project id: {str(pyproject_path)} does not relate to Kedro"
+                    f"Failed to retrieve project id or save project id: "
+                    f"{str(pyproject_path)} does not contain a [tool.kedro] section"
                 )
                 return None
 

--- a/kedro-telemetry/kedro_telemetry/plugin.py
+++ b/kedro-telemetry/kedro_telemetry/plugin.py
@@ -236,12 +236,12 @@ class KedroTelemetryProjectHooks:
         )
 
 
-def _is_known_ci_env():
+def _is_known_ci_env(known_ci_env_var_keys: set[str]):
     # Most CI tools will set the CI environment variable to true
     if os.getenv("CI") == "true":
         return True
     # Not all CI tools follow this convention, we can check through those that don't
-    return any(os.getenv(key) for key in KNOWN_CI_ENV_VAR_KEYS)
+    return any(os.getenv(key) for key in known_ci_env_var_keys)
 
 
 def _get_project_properties(user_uuid: str, pyproject_path: Path) -> dict:
@@ -256,7 +256,7 @@ def _get_project_properties(user_uuid: str, pyproject_path: Path) -> dict:
         "telemetry_version": TELEMETRY_VERSION,
         "python_version": sys.version,
         "os": sys.platform,
-        "is_ci_env": _is_known_ci_env(),
+        "is_ci_env": _is_known_ci_env(KNOWN_CI_ENV_VAR_KEYS),
     }
 
     properties = _add_tool_properties(properties, pyproject_path)

--- a/kedro-telemetry/kedro_telemetry/plugin.py
+++ b/kedro-telemetry/kedro_telemetry/plugin.py
@@ -88,15 +88,16 @@ def _get_or_create_project_uuid(pyproject_path: Path) -> str | None:
         with open(pyproject_path, "r+") as file:
             pyproject_data = toml.load(file)
 
-            if "project" not in pyproject_data:
-                pyproject_data["project"] = {}
-            if "project_uuid" not in pyproject_data["project"]:
-                pyproject_data["project"]["project_uuid"] = uuid.uuid4().hex
-                file.seek(0)
-                toml.dump(pyproject_data, file)
-                file.truncate()
+            try:
+                project_uuid = pyproject_data["tool"]["kedro_telemetry"]["project_uuid"]
+            except KeyError:
+                project_uuid = uuid.uuid4().hex
+                toml_string = (
+                    f'\n[tool.kedro_telemetry]\nproject_uuid = "{project_uuid}"\n'
+                )
+                file.write(toml_string)
 
-        return pyproject_data["project"]["project_uuid"]
+            return project_uuid
 
     logging.debug(
         f"Failed to retrieve UUID or save project UUID: {str(pyproject_path)} does not exist"

--- a/kedro-telemetry/kedro_telemetry/plugin.py
+++ b/kedro-telemetry/kedro_telemetry/plugin.py
@@ -85,7 +85,7 @@ def _get_or_create_project_id(pyproject_path: Path) -> str | None:
     Reads a project id from a configuration file or generates and saves a new one if not present.
     Returns None if configuration file does not exist or does not relate to Kedro.
     """
-    if pyproject_path.exists():
+    try:
         with open(pyproject_path, "r+") as file:
             pyproject_data = toml.load(file)
 
@@ -102,15 +102,13 @@ def _get_or_create_project_id(pyproject_path: Path) -> str | None:
                     file.write(toml_string)
                 return project_id
             except KeyError:
-                logging.debug(
+                logging.error(
                     f"Failed to retrieve project id or save project id: "
                     f"{str(pyproject_path)} does not contain a [tool.kedro] section"
                 )
                 return None
-
-    logging.debug(
-        f"Failed to retrieve project id or save project id: {str(pyproject_path)} does not exist"
-    )
+    except OSError as exc:
+        logging.error(f"Failed to read the file: {str(pyproject_path)}.\n{str(exc)}")
     return None
 
 

--- a/kedro-telemetry/kedro_telemetry/plugin.py
+++ b/kedro-telemetry/kedro_telemetry/plugin.py
@@ -86,16 +86,16 @@ def _get_or_create_project_uuid(pyproject_path: Path) -> str:
     Reads a project UUID from a configuration file or generates and saves a new one if not present.
     """
     if pyproject_path.exists():
-        with open(pyproject_path) as file:
-            pyproject_data = toml.load(file)
+        pyproject_data = toml.load(pyproject_path)
 
-            if "project" not in pyproject_data:
-                pyproject_data["project"] = {}
-            if "project_uuid" not in pyproject_data["project"]:
-                pyproject_data["project"]["project_uuid"] = uuid.uuid4().hex
+        if "project" not in pyproject_data:
+            pyproject_data["project"] = {}
+        if "project_uuid" not in pyproject_data["project"]:
+            pyproject_data["project"]["project_uuid"] = uuid.uuid4().hex
+            with open(pyproject_path, "w") as file:
                 toml.dump(pyproject_data, file)
 
-            return pyproject_data["project"]["project_uuid"]
+        return pyproject_data["project"]["project_uuid"]
 
     return UNDEFINED_PROJECT_UUID
 

--- a/kedro-telemetry/kedro_telemetry/plugin.py
+++ b/kedro-telemetry/kedro_telemetry/plugin.py
@@ -99,6 +99,10 @@ def _get_or_create_project_uuid(pyproject_path: Path) -> str:
 
         return pyproject_data["project"]["project_uuid"]
 
+    logging.debug(
+        f"Failed to retrieve UUID or save project UUID: {str(pyproject_path)} does not exist"
+    )
+
     return UNDEFINED_PROJECT_UUID
 
 

--- a/kedro-telemetry/kedro_telemetry/plugin.py
+++ b/kedro-telemetry/kedro_telemetry/plugin.py
@@ -112,16 +112,14 @@ def _add_tool_properties(
         with open(pyproject_path) as file:
             pyproject_data = toml.load(file)
 
-        if "tool" in pyproject_data and "kedro" in pyproject_data["tool"]:
-            if "tools" in pyproject_data["tool"]["kedro"]:
-                # convert list of tools to comma-separated string
-                properties["tools"] = ", ".join(
-                    pyproject_data["tool"]["kedro"]["tools"]
-                )
-            if "example_pipeline" in pyproject_data["tool"]["kedro"]:
-                properties["example_pipeline"] = pyproject_data["tool"]["kedro"][
-                    "example_pipeline"
-                ]
+        try:
+            tool_kedro = pyproject_data["tool"]["kedro"]
+            if "tools" in tool_kedro:
+                properties["tools"] = ", ".join(tool_kedro["tools"])
+            if "example_pipeline" in tool_kedro:
+                properties["example_pipeline"] = tool_kedro["example_pipeline"]
+        except KeyError:
+            pass
 
     return properties
 

--- a/kedro-telemetry/tests/test_plugin.py
+++ b/kedro-telemetry/tests/test_plugin.py
@@ -659,9 +659,6 @@ class TestKedroTelemetryProjectHooks:
             identity="user_uuid",
             properties=expected_properties,
         )
-        print(mocked_heap_call.call_args_list[2])
-        print("-" * 50)
-        print(expected_call)
         # CLI hook makes the first 2 calls, the 3rd one is the Project hook
         assert mocked_heap_call.call_args_list[2] == expected_call
 

--- a/kedro-telemetry/tests/test_plugin.py
+++ b/kedro-telemetry/tests/test_plugin.py
@@ -312,7 +312,7 @@ class TestKedroTelemetryCLIHooks:
         mocked_anon_id = mocker.patch("kedro_telemetry.plugin._hash")
         mocked_anon_id.return_value = "digested"
         mocker.patch("kedro_telemetry.plugin.PACKAGE_NAME", "spaceflights")
-        mocker.patch("builtins.open", side_effect=Exception)
+        mocker.patch("builtins.open", side_effect=OSError)
 
         mocked_heap_call = mocker.patch("kedro_telemetry.plugin._send_heap_event")
         telemetry_hook = KedroTelemetryCLIHooks()

--- a/kedro-telemetry/tests/test_plugin.py
+++ b/kedro-telemetry/tests/test_plugin.py
@@ -481,9 +481,11 @@ class TestKedroTelemetryProjectHooks:
             "kedro_telemetry.plugin._get_or_create_uuid",
             return_value="user_uuid",
         )
+
         mocked_heap_call = mocker.patch("kedro_telemetry.plugin._send_heap_event")
         mocker.patch("kedro_telemetry.plugin.open")
         mocker.patch("kedro_telemetry.plugin.toml.load")
+        mocker.patch("kedro_telemetry.plugin.toml.dump")
 
         # Without CLI invoked - i.e. `session.run` in Jupyter/IPython
         telemetry_hook = KedroTelemetryProjectHooks()
@@ -505,7 +507,6 @@ class TestKedroTelemetryProjectHooks:
             "number_of_pipelines": 2,
         }
         expected_properties = {**project_properties, **project_statistics}
-
         expected_call = mocker.call(
             event_name="Kedro Project Statistics",
             identity="user_uuid",
@@ -539,6 +540,7 @@ class TestKedroTelemetryProjectHooks:
         )
         mocked_heap_call = mocker.patch("kedro_telemetry.plugin._send_heap_event")
         mocker.patch("kedro_telemetry.plugin.toml.load")
+        mocker.patch("kedro_telemetry.plugin.toml.dump")
         # CLI run first
         telemetry_cli_hook = KedroTelemetryCLIHooks()
         command_args = ["--version"]

--- a/kedro-telemetry/tests/test_plugin.py
+++ b/kedro-telemetry/tests/test_plugin.py
@@ -141,7 +141,7 @@ class TestKedroTelemetryCLIHooks:
         telemetry_hook.before_command_run(fake_metadata, command_args)
         expected_properties = {
             "username": "user_uuid",
-            "package_name": "digested",
+            "project_uuid": "digested",
             "project_version": kedro_version,
             "telemetry_version": TELEMETRY_VERSION,
             "python_version": sys.version,

--- a/kedro-telemetry/tests/test_plugin.py
+++ b/kedro-telemetry/tests/test_plugin.py
@@ -135,8 +135,8 @@ class TestKedroTelemetryCLIHooks:
             return_value="user_uuid",
         )
         mocker.patch(
-            "kedro_telemetry.plugin._get_or_create_project_uuid",
-            return_value="project_uuid",
+            "kedro_telemetry.plugin._get_or_create_project_id",
+            return_value="project_id",
         )
 
         mocked_heap_call = mocker.patch("kedro_telemetry.plugin._send_heap_event")
@@ -145,7 +145,7 @@ class TestKedroTelemetryCLIHooks:
         telemetry_hook.before_command_run(fake_metadata, command_args)
         expected_properties = {
             "username": "user_uuid",
-            "project_uuid": "digested",
+            "project_id": "digested",
             "project_version": kedro_version,
             "telemetry_version": TELEMETRY_VERSION,
             "python_version": sys.version,
@@ -185,8 +185,8 @@ class TestKedroTelemetryCLIHooks:
             return_value="user_uuid",
         )
         mocker.patch(
-            "kedro_telemetry.plugin._get_or_create_project_uuid",
-            return_value="project_uuid",
+            "kedro_telemetry.plugin._get_or_create_project_id",
+            return_value="project_id",
         )
 
         mocked_heap_call = mocker.patch("kedro_telemetry.plugin._send_heap_event")
@@ -197,7 +197,7 @@ class TestKedroTelemetryCLIHooks:
         telemetry_hook.before_command_run(fake_metadata, command_args)
         expected_properties = {
             "username": "user_uuid",
-            "project_uuid": "digested",
+            "project_id": "digested",
             "project_version": kedro_version,
             "telemetry_version": TELEMETRY_VERSION,
             "python_version": sys.version,
@@ -239,8 +239,8 @@ class TestKedroTelemetryCLIHooks:
             return_value="user_uuid",
         )
         mocker.patch(
-            "kedro_telemetry.plugin._get_or_create_project_uuid",
-            return_value="project_uuid",
+            "kedro_telemetry.plugin._get_or_create_project_id",
+            return_value="project_id",
         )
 
         mocked_heap_call = mocker.patch("kedro_telemetry.plugin._send_heap_event")
@@ -249,7 +249,7 @@ class TestKedroTelemetryCLIHooks:
         telemetry_hook.before_command_run(fake_metadata, command_args)
         expected_properties = {
             "username": "user_uuid",
-            "project_uuid": "digested",
+            "project_id": "digested",
             "project_version": kedro_version,
             "telemetry_version": TELEMETRY_VERSION,
             "python_version": sys.version,
@@ -321,7 +321,7 @@ class TestKedroTelemetryCLIHooks:
         expected_properties = {
             "username": "",
             "command": "kedro --version",
-            "project_uuid": None,
+            "project_id": None,
             "project_version": kedro_version,
             "telemetry_version": TELEMETRY_VERSION,
             "python_version": sys.version,
@@ -494,8 +494,8 @@ class TestKedroTelemetryProjectHooks:
             return_value="user_uuid",
         )
         mocker.patch(
-            "kedro_telemetry.plugin._get_or_create_project_uuid",
-            return_value="project_uuid",
+            "kedro_telemetry.plugin._get_or_create_project_id",
+            return_value="project_id",
         )
 
         mocked_heap_call = mocker.patch("kedro_telemetry.plugin._send_heap_event")
@@ -510,7 +510,7 @@ class TestKedroTelemetryProjectHooks:
 
         project_properties = {
             "username": "user_uuid",
-            "project_uuid": "digested",
+            "project_id": "digested",
             "project_version": kedro_version,
             "telemetry_version": TELEMETRY_VERSION,
             "python_version": sys.version,
@@ -555,8 +555,8 @@ class TestKedroTelemetryProjectHooks:
             return_value="user_uuid",
         )
         mocker.patch(
-            "kedro_telemetry.plugin._get_or_create_project_uuid",
-            return_value="project_uuid",
+            "kedro_telemetry.plugin._get_or_create_project_id",
+            return_value="project_id",
         )
         mocked_heap_call = mocker.patch("kedro_telemetry.plugin._send_heap_event")
         mocker.patch("kedro_telemetry.plugin.toml.load")
@@ -573,7 +573,7 @@ class TestKedroTelemetryProjectHooks:
 
         project_properties = {
             "username": "user_uuid",
-            "project_uuid": "digested",
+            "project_id": "digested",
             "project_version": kedro_version,
             "telemetry_version": TELEMETRY_VERSION,
             "python_version": sys.version,
@@ -619,8 +619,8 @@ class TestKedroTelemetryProjectHooks:
             return_value="user_uuid",
         )
         mocker.patch(
-            "kedro_telemetry.plugin._get_or_create_project_uuid",
-            return_value="project_uuid",
+            "kedro_telemetry.plugin._get_or_create_project_id",
+            return_value="project_id",
         )
         mocked_heap_call = mocker.patch("kedro_telemetry.plugin._send_heap_event")
         mocker.patch("builtins.open", mocker.mock_open(read_data=MOCK_PYPROJECT_TOOLS))
@@ -638,7 +638,7 @@ class TestKedroTelemetryProjectHooks:
 
         project_properties = {
             "username": "user_uuid",
-            "project_uuid": "digested",
+            "project_id": "digested",
             "project_version": kedro_version,
             "telemetry_version": TELEMETRY_VERSION,
             "python_version": sys.version,

--- a/kedro-telemetry/tests/test_plugin.py
+++ b/kedro-telemetry/tests/test_plugin.py
@@ -494,7 +494,7 @@ class TestKedroTelemetryProjectHooks:
 
         project_properties = {
             "username": "user_uuid",
-            "package_name": "digested",
+            "project_uuid": "digested",
             "project_version": kedro_version,
             "telemetry_version": TELEMETRY_VERSION,
             "python_version": sys.version,
@@ -553,7 +553,7 @@ class TestKedroTelemetryProjectHooks:
 
         project_properties = {
             "username": "user_uuid",
-            "package_name": "digested",
+            "project_uuid": "digested",
             "project_version": kedro_version,
             "telemetry_version": TELEMETRY_VERSION,
             "python_version": sys.version,
@@ -614,7 +614,7 @@ class TestKedroTelemetryProjectHooks:
 
         project_properties = {
             "username": "user_uuid",
-            "package_name": "digested",
+            "project_uuid": "digested",
             "project_version": kedro_version,
             "telemetry_version": TELEMETRY_VERSION,
             "python_version": sys.version,

--- a/kedro-telemetry/tests/test_plugin.py
+++ b/kedro-telemetry/tests/test_plugin.py
@@ -189,7 +189,7 @@ class TestKedroTelemetryCLIHooks:
         telemetry_hook.before_command_run(fake_metadata, command_args)
         expected_properties = {
             "username": "user_uuid",
-            "package_name": "digested",
+            "project_uuid": "digested",
             "project_version": kedro_version,
             "telemetry_version": TELEMETRY_VERSION,
             "python_version": sys.version,
@@ -237,7 +237,7 @@ class TestKedroTelemetryCLIHooks:
         telemetry_hook.before_command_run(fake_metadata, command_args)
         expected_properties = {
             "username": "user_uuid",
-            "package_name": "digested",
+            "project_uuid": "digested",
             "project_version": kedro_version,
             "telemetry_version": TELEMETRY_VERSION,
             "python_version": sys.version,
@@ -309,7 +309,7 @@ class TestKedroTelemetryCLIHooks:
         expected_properties = {
             "username": "",
             "command": "kedro --version",
-            "package_name": "digested",
+            "project_uuid": "digested",
             "project_version": kedro_version,
             "telemetry_version": TELEMETRY_VERSION,
             "python_version": sys.version,

--- a/kedro-telemetry/tests/test_plugin.py
+++ b/kedro-telemetry/tests/test_plugin.py
@@ -321,7 +321,7 @@ class TestKedroTelemetryCLIHooks:
         expected_properties = {
             "username": "",
             "command": "kedro --version",
-            "project_uuid": "digested",
+            "project_uuid": None,
             "project_version": kedro_version,
             "telemetry_version": TELEMETRY_VERSION,
             "python_version": sys.version,

--- a/kedro-telemetry/tests/test_plugin.py
+++ b/kedro-telemetry/tests/test_plugin.py
@@ -134,6 +134,10 @@ class TestKedroTelemetryCLIHooks:
             "kedro_telemetry.plugin._get_or_create_uuid",
             return_value="user_uuid",
         )
+        mocker.patch(
+            "kedro_telemetry.plugin._get_or_create_project_uuid",
+            return_value="project_uuid",
+        )
 
         mocked_heap_call = mocker.patch("kedro_telemetry.plugin._send_heap_event")
         telemetry_hook = KedroTelemetryCLIHooks()
@@ -179,6 +183,10 @@ class TestKedroTelemetryCLIHooks:
         mocker.patch(
             "kedro_telemetry.plugin._get_or_create_uuid",
             return_value="user_uuid",
+        )
+        mocker.patch(
+            "kedro_telemetry.plugin._get_or_create_project_uuid",
+            return_value="project_uuid",
         )
 
         mocked_heap_call = mocker.patch("kedro_telemetry.plugin._send_heap_event")
@@ -229,6 +237,10 @@ class TestKedroTelemetryCLIHooks:
         mocker.patch(
             "kedro_telemetry.plugin._get_or_create_uuid",
             return_value="user_uuid",
+        )
+        mocker.patch(
+            "kedro_telemetry.plugin._get_or_create_project_uuid",
+            return_value="project_uuid",
         )
 
         mocked_heap_call = mocker.patch("kedro_telemetry.plugin._send_heap_event")
@@ -481,6 +493,10 @@ class TestKedroTelemetryProjectHooks:
             "kedro_telemetry.plugin._get_or_create_uuid",
             return_value="user_uuid",
         )
+        mocker.patch(
+            "kedro_telemetry.plugin._get_or_create_project_uuid",
+            return_value="project_uuid",
+        )
 
         mocked_heap_call = mocker.patch("kedro_telemetry.plugin._send_heap_event")
         mocker.patch("kedro_telemetry.plugin.open")
@@ -537,6 +553,10 @@ class TestKedroTelemetryProjectHooks:
         mocker.patch(
             "kedro_telemetry.plugin._get_or_create_uuid",
             return_value="user_uuid",
+        )
+        mocker.patch(
+            "kedro_telemetry.plugin._get_or_create_project_uuid",
+            return_value="project_uuid",
         )
         mocked_heap_call = mocker.patch("kedro_telemetry.plugin._send_heap_event")
         mocker.patch("kedro_telemetry.plugin.toml.load")
@@ -598,6 +618,10 @@ class TestKedroTelemetryProjectHooks:
             "kedro_telemetry.plugin._get_or_create_uuid",
             return_value="user_uuid",
         )
+        mocker.patch(
+            "kedro_telemetry.plugin._get_or_create_project_uuid",
+            return_value="project_uuid",
+        )
         mocked_heap_call = mocker.patch("kedro_telemetry.plugin._send_heap_event")
         mocker.patch("builtins.open", mocker.mock_open(read_data=MOCK_PYPROJECT_TOOLS))
         mocker.patch("pathlib.Path.exists", return_value=True)
@@ -635,7 +659,9 @@ class TestKedroTelemetryProjectHooks:
             identity="user_uuid",
             properties=expected_properties,
         )
-
+        print(mocked_heap_call.call_args_list[2])
+        print("-" * 50)
+        print(expected_call)
         # CLI hook makes the first 2 calls, the 3rd one is the Project hook
         assert mocked_heap_call.call_args_list[2] == expected_call
 


### PR DESCRIPTION
## Description
FIX #507 

Related docs update https://github.com/kedro-org/kedro/pull/3897

## Development notes
Manually tested the following scenario:

1. Created a project with consent
 - `project id` does not exist - it is generated and saved in `pyproject.toml`
 - `project id` exists - it is loaded from `pyproject.toml`, joined with the `package name`, hashed and used
 - package name changes,  `project id` exists - it is loaded from `pyproject.toml`, joined with the new `package name`, hashed and used

2. Created a project without consent

 - project id is not created

3. Packaging project

- package kedro project with modified `pyproject.toml` - works without errors
- run packaged project with consent=True and existing `pyproject.toml` - `project id` is generated and saved in `pyproject.toml`
- run packaged project with consent=True without `pyproject.toml` - `project id` is None

## Checklist

- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Added a description of this change in the relevant `RELEASE.md` file
- [x] Added tests to cover my changes
