### PR TITLE
fix(datasets): Update deprecated parameter in `pandas.DeltaTableDataset` test

### DIFF
--- a/kedro-datasets/tests/pandas/test_deltatable_dataset.py
+++ b/kedro-datasets/tests/pandas/test_deltatable_dataset.py
@@ -52,7 +52,7 @@ class TestDeltaTableDataset:
         with pytest.raises(DatasetError, match=pattern):
             deltatable_dataset_from_path.save(new_df)
 
-    @pytest.mark.parametrize("save_args", [{"overwrite_schema": True}], indirect=True)
+    @pytest.mark.parametrize("save_args", [{"schema_mode": "overwrite"}], indirect=True)
     def test_overwrite_both_data_and_schema(
         self, deltatable_dataset_from_path, dummy_df
     ):


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
Fix https://github.com/kedro-org/kedro-plugins/issues/719

## Development notes
<!-- What have you changed, and how has this been tested? -->
Reason - https://github.com/delta-io/delta-rs/commit/dc10adabf7b162f50ce19310f64d8fdff527fbba

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
