### PR TITLE
feat(telemetry): Remove consent confirmation prompt for `kedro-telemetry`

### DIFF
--- a/kedro-datasets/pyproject.toml
+++ b/kedro-datasets/pyproject.toml
@@ -179,6 +179,7 @@ docs = [
 
 # Test requirements
 test = [
+    "accelerate<0.32",
     "adlfs~=2023.1",
     "bandit>=1.6.2, <2.0",
     "behave==1.2.6",
@@ -249,7 +250,7 @@ test = [
     "xlsxwriter~=1.0",
     # huggingface
     "datasets",
-    "huggingface_hub~=0.23.4",
+    "huggingface_hub",
     "transformers[torch]",
     # mypy related dependencies
     "types-cachetools",

--- a/kedro-datasets/pyproject.toml
+++ b/kedro-datasets/pyproject.toml
@@ -249,7 +249,7 @@ test = [
     "xlsxwriter~=1.0",
     # huggingface
     "datasets",
-    "huggingface_hub~=0.23.0",
+    "huggingface_hub~=0.23.4",
     "transformers[torch]",
     # mypy related dependencies
     "types-cachetools",

--- a/kedro-datasets/pyproject.toml
+++ b/kedro-datasets/pyproject.toml
@@ -249,7 +249,7 @@ test = [
     "xlsxwriter~=1.0",
     # huggingface
     "datasets",
-    "huggingface_hub",
+    "huggingface_hub~=0.23.0",
     "transformers[torch]",
     # mypy related dependencies
     "types-cachetools",

--- a/kedro-telemetry/kedro_telemetry/plugin.py
+++ b/kedro-telemetry/kedro_telemetry/plugin.py
@@ -338,9 +338,6 @@ def _send_heap_event(
                 resp.status_code,
                 resp.reason,
             )
-
-        print(resp.status_code, resp.reason)
-        print(data)
     except requests.exceptions.RequestException as exc:
         logger.warning(
             "Failed to send data to Heap. Exception of type '%s' was raised.",

--- a/kedro-telemetry/kedro_telemetry/plugin.py
+++ b/kedro-telemetry/kedro_telemetry/plugin.py
@@ -338,6 +338,9 @@ def _send_heap_event(
                 resp.status_code,
                 resp.reason,
             )
+
+        print(resp.status_code, resp.reason)
+        print(data)
     except requests.exceptions.RequestException as exc:
         logger.warning(
             "Failed to send data to Heap. Exception of type '%s' was raised.",
@@ -347,7 +350,7 @@ def _send_heap_event(
 
 def _check_for_telemetry_consent(project_path: Path) -> bool:
     """
-    Use a telemetry consent from ".telemetry" file if it exists and has a valid format.
+    Use telemetry consent from ".telemetry" file if it exists and has a valid format.
     Telemetry is considered as opt-in otherwise.
     """
     telemetry_file_path = project_path / ".telemetry"

--- a/kedro-telemetry/kedro_telemetry/plugin.py
+++ b/kedro-telemetry/kedro_telemetry/plugin.py
@@ -13,7 +13,6 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-import click
 import requests
 import toml
 import yaml

--- a/kedro-telemetry/kedro_telemetry/plugin.py
+++ b/kedro-telemetry/kedro_telemetry/plugin.py
@@ -349,7 +349,6 @@ def _check_for_telemetry_consent(project_path: Path) -> bool:
     """
     Use telemetry consent from ".telemetry" file if it exists and has a valid format.
     Telemetry is considered as opt-in otherwise.
-
     """
     telemetry_file_path = project_path / ".telemetry"
     if telemetry_file_path.exists():

--- a/kedro-telemetry/kedro_telemetry/plugin.py
+++ b/kedro-telemetry/kedro_telemetry/plugin.py
@@ -349,6 +349,7 @@ def _check_for_telemetry_consent(project_path: Path) -> bool:
     """
     Use telemetry consent from ".telemetry" file if it exists and has a valid format.
     Telemetry is considered as opt-in otherwise.
+
     """
     telemetry_file_path = project_path / ".telemetry"
     if telemetry_file_path.exists():


### PR DESCRIPTION
## Description
Partly solves https://github.com/kedro-org/kedro-plugins/issues/726

## Development notes

- `_confirm_consent` was removed
- now we use consent from the `.telemetry` file if it exists and has a valid format otherwise, we consider consent is `True`

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
