### PR TITLE
ci(datasets): pin `accelerate`

### DIFF
--- a/kedro-datasets/pyproject.toml
+++ b/kedro-datasets/pyproject.toml
@@ -179,6 +179,7 @@ docs = [
 
 # Test requirements
 test = [
+    "accelerate<0.32", # Temporary pin
     "adlfs~=2023.1",
     "bandit>=1.6.2, <2.0",
     "behave==1.2.6",


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
Fix #740 temporarily

## Development notes
Copied from https://github.com/kedro-org/kedro-plugins/pull/750#issuecomment-2210458062

The docs test failure is because of some shenanigans with fsspec in #750.

It's a bug in datasets version<2.15. The unpinning of gcsfs brings the fsspec version up to date but the later versions of datasets is not compatible with later versions of fsspec. They merged support a few days ago https://github.com/huggingface/datasets/pull/7017 but not released yet. 
I think gcsfs will be okay to unpin when the release is out but we can pin accelerate for now and unblock the CI - https://github.com/kedro-org/kedro-plugins/pull/751

In our CI we run on an older version of 
## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
