### PR TITLE
fix(datasets): Fix spark tests (#755)

### DIFF
--- a/kedro-datasets/tests/spark/conftest.py
+++ b/kedro-datasets/tests/spark/conftest.py
@@ -40,3 +40,6 @@ def spark_session(tmp_path_factory):
         spark = _setup_spark_session()
     yield spark
     spark.stop()
+    # Ensure that the spark session is not used after it is stopped
+    # https://stackoverflow.com/a/41512072
+    spark._instantiatedContext = None

--- a/kedro-datasets/tests/spark/test_deltatable_dataset.py
+++ b/kedro-datasets/tests/spark/test_deltatable_dataset.py
@@ -7,7 +7,6 @@ from kedro.pipeline.modular_pipeline import pipeline as modular_pipeline
 from kedro.runner import ParallelRunner
 from packaging.version import Version
 from pyspark import __version__
-from pyspark.sql import SparkSession
 from pyspark.sql.types import IntegerType, StringType, StructField, StructType
 from pyspark.sql.utils import AnalysisException
 
@@ -17,7 +16,7 @@ SPARK_VERSION = Version(__version__)
 
 
 @pytest.fixture
-def sample_spark_df():
+def sample_spark_df(spark_session):
     schema = StructType(
         [
             StructField("name", StringType(), True),
@@ -27,7 +26,7 @@ def sample_spark_df():
 
     data = [("Alex", 31), ("Bob", 12), ("Clarke", 65), ("Dave", 29)]
 
-    return SparkSession.builder.getOrCreate().createDataFrame(data, schema)
+    return spark_session.createDataFrame(data, schema)
 
 
 class TestDeltaTableDataset:

--- a/kedro-datasets/tests/spark/test_spark_dataset.py
+++ b/kedro-datasets/tests/spark/test_spark_dataset.py
@@ -15,7 +15,6 @@ from kedro.runner import ParallelRunner, SequentialRunner
 from moto import mock_aws
 from packaging.version import Version as PackagingVersion
 from pyspark import __version__
-from pyspark.sql import SparkSession
 from pyspark.sql.functions import col
 from pyspark.sql.types import (
     FloatType,
@@ -102,7 +101,7 @@ def versioned_dataset_s3(version):
 
 
 @pytest.fixture
-def sample_spark_df():
+def sample_spark_df(spark_session):
     schema = StructType(
         [
             StructField("name", StringType(), True),
@@ -112,7 +111,7 @@ def sample_spark_df():
 
     data = [("Alex", 31), ("Bob", 12), ("Clarke", 65), ("Dave", 29)]
 
-    return SparkSession.builder.getOrCreate().createDataFrame(data, schema)
+    return spark_session.createDataFrame(data, schema)
 
 
 @pytest.fixture

--- a/kedro-datasets/tests/spark/test_spark_streaming_dataset.py
+++ b/kedro-datasets/tests/spark/test_spark_streaming_dataset.py
@@ -6,7 +6,6 @@ from kedro.io.core import DatasetError
 from moto import mock_aws
 from packaging.version import Version
 from pyspark import __version__
-from pyspark.sql import SparkSession
 from pyspark.sql.types import IntegerType, StringType, StructField, StructType
 from pyspark.sql.utils import AnalysisException
 
@@ -43,15 +42,13 @@ def sample_spark_df_schema() -> StructType:
 
 
 @pytest.fixture
-def sample_spark_streaming_df(tmp_path, sample_spark_df_schema):
+def sample_spark_streaming_df(spark_session, tmp_path, sample_spark_df_schema):
     """Create a sample dataframe for streaming"""
     data = [("0001", 2), ("0001", 7), ("0002", 4)]
     schema_path = (tmp_path / SCHEMA_FILE_NAME).as_posix()
     with open(schema_path, "w", encoding="utf-8") as f:
         json.dump(sample_spark_df_schema.jsonValue(), f)
-    return SparkSession.builder.getOrCreate().createDataFrame(
-        data, sample_spark_df_schema
-    )
+    return spark_session.createDataFrame(data, sample_spark_df_schema)
 
 
 @pytest.fixture

--- a/kedro-telemetry/kedro_telemetry/plugin.py
+++ b/kedro-telemetry/kedro_telemetry/plugin.py
@@ -8,7 +8,6 @@ import logging
 import os
 import sys
 import uuid
-from copy import deepcopy
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -153,102 +152,118 @@ def _generate_new_uuid(full_path: str) -> str:
         return ""
 
 
-class KedroTelemetryCLIHooks:
+class KedroTelemetryHook:
     """Hook to send CLI command data to Heap"""
+
+    def __init__(self):
+        self._consent = None
+        self._sent = False
+        self._event_properties = None
+        self._project_path = None
+        self._user_uuid = None
 
     @cli_hook_impl
     def before_command_run(
         self, project_metadata: ProjectMetadata, command_args: list[str]
     ):
         """Hook implementation to send command run data to Heap"""
+
+        if not project_metadata:  # in package mode
+            return
+
+        self._consent = _check_for_telemetry_consent(project_metadata.project_path)
+        if not self._consent:
+            self._opt_out_notification()
+            return
+
+        # get KedroCLI and its structure from actual project root
+        cli = KedroCLI(project_path=project_metadata.project_path)
+        cli_struct = _get_cli_structure(cli_obj=cli, get_help=False)
+        masked_command_args = _mask_kedro_cli(
+            cli_struct=cli_struct, command_args=command_args
+        )
+
+        self._user_uuid = _get_or_create_uuid()
+
+        event_properties = _get_project_properties(
+            self._user_uuid, project_metadata.project_path / PYPROJECT_CONFIG_NAME
+        )
+        event_properties["command"] = (
+            f"kedro {' '.join(masked_command_args)}" if masked_command_args else "kedro"
+        )
+        event_properties["main_command"] = (
+            masked_command_args[0] if masked_command_args else "kedro"
+        )
+
+        self._event_properties = event_properties
+
+    @cli_hook_impl
+    def after_command_run(self):
+        if self._consent and not self._sent:
+            self._send_telemetry_heap_event("CLI command")
+
+    @hook_impl
+    def after_context_created(self, context):
+        """Hook implementation to send project statistics data to Heap"""
+
+        if self._consent is None:
+            self._consent = _check_for_telemetry_consent(context.project_path)
+            if not self._consent:
+                self._opt_out_notification()
+        self._project_path = context.project_path
+
+    @hook_impl
+    def after_catalog_created(self, catalog):
+        if self._consent is False:
+            return
+
+        default_pipeline = pipelines.get("__default__")  # __default__
+
+        if not self._user_uuid:
+            self._user_uuid = _get_or_create_uuid()
+
+        if not self._event_properties:
+            self._event_properties = _get_project_properties(
+                self._user_uuid, self._project_path / PYPROJECT_CONFIG_NAME
+            )
+
+        project_properties = _format_project_statistics_data(
+            catalog, default_pipeline, pipelines
+        )
+        self._event_properties.update(project_properties)
+
+        self._send_telemetry_heap_event("Kedro Project Statistics")
+
+    def _opt_out_notification(self):
+        logger.info(
+            "Kedro-Telemetry is installed, but you have opted out of "
+            "sharing usage analytics so none will be collected.",
+        )
+
+    def _send_telemetry_heap_event(self, event_name: str):
+        """Hook implementation to send command run data to Heap"""
+
+        logger.info(
+            "Kedro is sending anonymous usage data with the sole purpose of improving the product. "
+            "No personal data or IP addresses are stored on our side. "
+            "If you want to opt out, set the `KEDRO_DISABLE_TELEMETRY` or `DO_NOT_TRACK` environment variables, "
+            "or create a `.telemetry` file in the current working directory with the contents `consent: false`. "
+            "Read more at https://docs.kedro.org/en/stable/configuration/telemetry.html"
+        )
+
         try:
-            if not project_metadata:  # in package mode
-                return
-
-            consent = _check_for_telemetry_consent(project_metadata.project_path)
-            if not consent:
-                logger.info(
-                    "Kedro-Telemetry is installed, but you have opted out of "
-                    "sharing usage analytics so none will be collected.",
-                )
-                return
-
-            logger.info(
-                "Kedro is sending anonymous usage data with the sole purpose of improving the product. "
-                "No personal data or IP addresses are stored on our side. "
-                "If you want to opt out, set the `KEDRO_DISABLE_TELEMETRY` or `DO_NOT_TRACK` environment variables, "
-                "or create a `.telemetry` file in the current working directory with the contents `consent: false`. "
-                "Read more at https://docs.kedro.org/en/stable/configuration/telemetry.html"
-            )
-
-            # get KedroCLI and its structure from actual project root
-            cli = KedroCLI(project_path=project_metadata.project_path)
-            cli_struct = _get_cli_structure(cli_obj=cli, get_help=False)
-            masked_command_args = _mask_kedro_cli(
-                cli_struct=cli_struct, command_args=command_args
-            )
-            main_command = masked_command_args[0] if masked_command_args else "kedro"
-
-            user_uuid = _get_or_create_uuid()
-            project_properties = _get_project_properties(
-                user_uuid, project_metadata.project_path / PYPROJECT_CONFIG_NAME
-            )
-            cli_properties = _format_user_cli_data(
-                project_properties, masked_command_args
-            )
-
             _send_heap_event(
-                event_name=f"Command run: {main_command}",
-                identity=user_uuid,
-                properties=cli_properties,
+                event_name=event_name,
+                identity=self._user_uuid,
+                properties=self._event_properties,
             )
-
-            # send generic event too, so it's easier in data processing
-            generic_properties = deepcopy(cli_properties)
-            generic_properties["main_command"] = main_command
-            _send_heap_event(
-                event_name="CLI command",
-                identity=user_uuid,
-                properties=generic_properties,
-            )
+            self._sent = True
         except Exception as exc:
             logger.warning(
                 "Something went wrong in hook implementation to send command run data to Heap. "
                 "Exception: %s",
                 exc,
             )
-
-
-class KedroTelemetryProjectHooks:
-    """Hook to send project statistics data to Heap"""
-
-    @hook_impl
-    def after_context_created(self, context):
-        """Hook implementation to send project statistics data to Heap"""
-        self.consent = _check_for_telemetry_consent(context.project_path)
-        self.project_path = context.project_path
-
-    @hook_impl
-    def after_catalog_created(self, catalog):
-        # The user notification message is sent only once per command during the before_command_run hook
-        if not self.consent:
-            return
-
-        default_pipeline = pipelines.get("__default__")  # __default__
-        user_uuid = _get_or_create_uuid()
-
-        project_properties = _get_project_properties(
-            user_uuid, self.project_path / PYPROJECT_CONFIG_NAME
-        )
-
-        project_statistics_properties = _format_project_statistics_data(
-            project_properties, catalog, default_pipeline, pipelines
-        )
-        _send_heap_event(
-            event_name="Kedro Project Statistics",
-            identity=user_uuid,
-            properties=project_statistics_properties,
-        )
 
 
 def _is_known_ci_env(known_ci_env_var_keys: set[str]):
@@ -281,33 +296,20 @@ def _get_project_properties(user_uuid: str, pyproject_path: Path) -> dict:
     return properties
 
 
-def _format_user_cli_data(
-    properties: dict,
-    command_args: list[str],
-):
-    """Add format CLI command data to send to Heap."""
-    cli_properties = properties.copy()
-    cli_properties["command"] = (
-        f"kedro {' '.join(command_args)}" if command_args else "kedro"
-    )
-    return cli_properties
-
-
 def _format_project_statistics_data(
-    properties: dict,
     catalog: DataCatalog,
     default_pipeline: Pipeline,
     project_pipelines: dict,
 ):
     """Add project statistics to send to Heap."""
-    project_statistics_properties = properties.copy()
+    project_statistics_properties = {}
     project_statistics_properties["number_of_datasets"] = sum(
         1
         for c in catalog.list()
         if not c.startswith("parameters") and not c.startswith("params:")
     )
     project_statistics_properties["number_of_nodes"] = (
-        len(default_pipeline.nodes) if default_pipeline else None
+        len(default_pipeline.nodes) if default_pipeline else None  # type: ignore
     )
     project_statistics_properties["number_of_pipelines"] = len(project_pipelines.keys())
     return project_statistics_properties
@@ -375,5 +377,4 @@ def _is_valid_syntax(telemetry: Any) -> bool:
     )
 
 
-cli_hooks = KedroTelemetryCLIHooks()
-project_hooks = KedroTelemetryProjectHooks()
+telemetry_hook = KedroTelemetryHook()

--- a/kedro-telemetry/pyproject.toml
+++ b/kedro-telemetry/pyproject.toml
@@ -43,10 +43,10 @@ test = [
 ]
 
 [project.entry-points."kedro.cli_hooks"]
-kedro-telemetry = "kedro_telemetry.plugin:cli_hooks"
+kedro-telemetry = "kedro_telemetry.plugin:telemetry_hook"
 
 [project.entry-points."kedro.hooks"]
-kedro-telemetry = "kedro_telemetry.plugin:project_hooks"
+kedro-telemetry = "kedro_telemetry.plugin:telemetry_hook"
 
 [tool.setuptools]
 include-package-data = true


### PR DESCRIPTION
## Description
Spark tests are failing randomly. This could be due that spark sessions are not properly closed, so some tests are using the one that do not correspond.

## Development notes
I replaced all SparkSession.builder.getOrCreate() calls for the fixture spark session, so we can control which spark session is used. Additionally, in the tear down of the spark session fixtures I added `spark._instantiatedContext = None`, which allegedly ensure that another spark session is created after (see [here](https://stackoverflow.com/a/41512072)).

I am not 100% sure that this is going to fix the issue. Maybe we can rerun the actions a few time just to be sure.

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
