### PR TITLE
fix(datasets): Fix spark tests

### DIFF
--- a/kedro-datasets/tests/spark/conftest.py
+++ b/kedro-datasets/tests/spark/conftest.py
@@ -27,7 +27,7 @@ def _setup_spark_session():
     ).getOrCreate()
 
 
-@pytest.fixture(scope="module", autouse=True)
+@pytest.fixture(scope="module")
 def spark_session(tmp_path_factory):
     # When running these spark tests with pytest-xdist, we need to make sure
     # that the spark session setup on each test process don't interfere with each other.
@@ -40,3 +40,6 @@ def spark_session(tmp_path_factory):
         spark = _setup_spark_session()
     yield spark
     spark.stop()
+    # Ensure that the spark session is not used after it is stopped
+    # https://stackoverflow.com/a/41512072
+    spark._instantiatedContext = None

--- a/kedro-datasets/tests/spark/test_deltatable_dataset.py
+++ b/kedro-datasets/tests/spark/test_deltatable_dataset.py
@@ -7,7 +7,6 @@ from kedro.pipeline.modular_pipeline import pipeline as modular_pipeline
 from kedro.runner import ParallelRunner
 from packaging.version import Version
 from pyspark import __version__
-from pyspark.sql import SparkSession
 from pyspark.sql.types import IntegerType, StringType, StructField, StructType
 from pyspark.sql.utils import AnalysisException
 
@@ -17,7 +16,7 @@ SPARK_VERSION = Version(__version__)
 
 
 @pytest.fixture
-def sample_spark_df():
+def sample_spark_df(spark_session):
     schema = StructType(
         [
             StructField("name", StringType(), True),
@@ -27,7 +26,7 @@ def sample_spark_df():
 
     data = [("Alex", 31), ("Bob", 12), ("Clarke", 65), ("Dave", 29)]
 
-    return SparkSession.builder.getOrCreate().createDataFrame(data, schema)
+    return spark_session.createDataFrame(data, schema)
 
 
 class TestDeltaTableDataset:

--- a/kedro-datasets/tests/spark/test_spark_dataset.py
+++ b/kedro-datasets/tests/spark/test_spark_dataset.py
@@ -15,7 +15,6 @@ from kedro.runner import ParallelRunner, SequentialRunner
 from moto import mock_aws
 from packaging.version import Version as PackagingVersion
 from pyspark import __version__
-from pyspark.sql import SparkSession
 from pyspark.sql.functions import col
 from pyspark.sql.types import (
     FloatType,
@@ -102,7 +101,7 @@ def versioned_dataset_s3(version):
 
 
 @pytest.fixture
-def sample_spark_df():
+def sample_spark_df(spark_session):
     schema = StructType(
         [
             StructField("name", StringType(), True),
@@ -112,7 +111,7 @@ def sample_spark_df():
 
     data = [("Alex", 31), ("Bob", 12), ("Clarke", 65), ("Dave", 29)]
 
-    return SparkSession.builder.getOrCreate().createDataFrame(data, schema)
+    return spark_session.createDataFrame(data, schema)
 
 
 @pytest.fixture

--- a/kedro-datasets/tests/spark/test_spark_streaming_dataset.py
+++ b/kedro-datasets/tests/spark/test_spark_streaming_dataset.py
@@ -6,7 +6,6 @@ from kedro.io.core import DatasetError
 from moto import mock_aws
 from packaging.version import Version
 from pyspark import __version__
-from pyspark.sql import SparkSession
 from pyspark.sql.types import IntegerType, StringType, StructField, StructType
 from pyspark.sql.utils import AnalysisException
 
@@ -43,15 +42,13 @@ def sample_spark_df_schema() -> StructType:
 
 
 @pytest.fixture
-def sample_spark_streaming_df(tmp_path, sample_spark_df_schema):
+def sample_spark_streaming_df(spark_session, tmp_path, sample_spark_df_schema):
     """Create a sample dataframe for streaming"""
     data = [("0001", 2), ("0001", 7), ("0002", 4)]
     schema_path = (tmp_path / SCHEMA_FILE_NAME).as_posix()
     with open(schema_path, "w", encoding="utf-8") as f:
         json.dump(sample_spark_df_schema.jsonValue(), f)
-    return SparkSession.builder.getOrCreate().createDataFrame(
-        data, sample_spark_df_schema
-    )
+    return spark_session.createDataFrame(data, sample_spark_df_schema)
 
 
 @pytest.fixture


### PR DESCRIPTION
## Description
Spark tests are failing randomly. This could be due that spark sessions are not properly closed, so some tests are using the one that do not correspond. See #755 

## Development notes
I replaced all SparkSession.builder.getOrCreate() calls for the fixture spark session, so we can control which spark session is used. Additionally, in the tear down of the spark session fixtures I added `spark._instantiatedContext = None`, which allegedly ensure that another spark session is created after (see [here](https://stackoverflow.com/a/41512072)).

I am not 100% sure that this is going to fix the issue. Maybe we can rerun the actions a few time just to be sure.

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
