### PR TITLE
feat(datasets): Update `__repr__` for `PartitionedDataset`

### DIFF
--- a/kedro-datasets/RELEASE.md
+++ b/kedro-datasets/RELEASE.md
@@ -1,5 +1,7 @@
 # Upcoming Release
 ## Major features and improvements
+* Improved PartitionedDataset representation when printing.
+
 ## Bug fixes and other changes
 ## Breaking Changes
 ## Community contributions

--- a/kedro-datasets/kedro_datasets/partitions/partitioned_dataset.py
+++ b/kedro-datasets/kedro_datasets/partitions/partitioned_dataset.py
@@ -333,7 +333,7 @@ class PartitionedDataset(AbstractDataset[dict[str, Any], dict[str, Callable[[], 
         # Dummy object to call _pretty_repr
         # Only clean_dataset_config parameters are exposed
         kwargs = deepcopy(self._dataset_config)
-        kwargs[self._filepath_arg] = self._join_protocol("")
+        kwargs[self._filepath_arg] = ""
         dataset = self._dataset_type(**kwargs)  # type: ignore
 
         object_description_repr = {

--- a/kedro-datasets/kedro_datasets/partitions/partitioned_dataset.py
+++ b/kedro-datasets/kedro_datasets/partitions/partitioned_dataset.py
@@ -329,8 +329,18 @@ class PartitionedDataset(AbstractDataset[dict[str, Any], dict[str, Callable[[], 
 
     def __repr__(self) -> str:
         object_description = self._describe()
-        object_description_repr = {"filepath": object_description["path"]}
-        object_description_repr.update(object_description["dataset_config"])
+
+        # Dummy object to call _pretty_repr
+        # Only clean_dataset_config parameters are exposed
+        kwargs = deepcopy(self._dataset_config)
+        kwargs[self._filepath_arg] = self._join_protocol("")
+        dataset = self._dataset_type(**kwargs)  # type: ignore
+
+        object_description_repr = {
+            "filepath": object_description["path"],
+            "dataset": dataset._pretty_repr(object_description["dataset_config"]),
+        }
+
         return self._pretty_repr(object_description_repr)
 
     def _invalidate_caches(self) -> None:

--- a/kedro-datasets/kedro_datasets/partitions/partitioned_dataset.py
+++ b/kedro-datasets/kedro_datasets/partitions/partitioned_dataset.py
@@ -327,6 +327,12 @@ class PartitionedDataset(AbstractDataset[dict[str, Any], dict[str, Callable[[], 
             "dataset_config": clean_dataset_config,
         }
 
+    def __repr__(self) -> str:
+        object_description = self._describe()
+        object_description_repr = {"filepath": object_description["path"]}
+        object_description_repr.update(object_description["dataset_config"])
+        return self._pretty_repr(object_description_repr)
+
     def _invalidate_caches(self) -> None:
         self._partition_cache.clear()
         self._filesystem.invalidate_cache(self._normalized_path)

--- a/kedro-datasets/tests/partitions/test_partitioned_dataset.py
+++ b/kedro-datasets/tests/partitions/test_partitioned_dataset.py
@@ -57,6 +57,15 @@ class FakeDataset:  # pylint: disable=too-few-public-methods
 
 
 class TestPartitionedDatasetLocal:
+    @pytest.mark.parametrize("dataset", ["pandas.ParquetDataset", ParquetDataset])
+    def test_repr(self, dataset, local_csvs):
+        pds = PartitionedDataset(path=str(local_csvs), dataset=dataset)
+        assert (
+            repr(pds)
+            == f"""kedro_datasets.partitions.partitioned_dataset.PartitionedDataset(filepath='{str(local_csvs)}', """
+            """dataset='kedro_datasets.pandas.parquet_dataset.ParquetDataset()')"""
+        )
+
     @pytest.mark.parametrize("dataset", LOCAL_DATASET_DEFINITION)
     @pytest.mark.parametrize(
         "suffix,expected_num_parts", [("", 5), (".csv", 3), ("p4", 1)]

--- a/kedro-datasets/tests/partitions/test_partitioned_dataset.py
+++ b/kedro-datasets/tests/partitions/test_partitioned_dataset.py
@@ -62,7 +62,7 @@ class TestPartitionedDatasetLocal:
         pds = PartitionedDataset(path="", dataset=dataset)
         assert (
             repr(pds)
-            == f"""kedro_datasets.partitions.partitioned_dataset.PartitionedDataset(filepath='', """
+            == """kedro_datasets.partitions.partitioned_dataset.PartitionedDataset(filepath='', """
             """dataset='kedro_datasets.pandas.parquet_dataset.ParquetDataset()')"""
         )
 

--- a/kedro-datasets/tests/partitions/test_partitioned_dataset.py
+++ b/kedro-datasets/tests/partitions/test_partitioned_dataset.py
@@ -58,16 +58,11 @@ class FakeDataset:  # pylint: disable=too-few-public-methods
 
 class TestPartitionedDatasetLocal:
     @pytest.mark.parametrize("dataset", ["pandas.ParquetDataset", ParquetDataset])
-    def test_repr(self, dataset, local_csvs):
-        pds = PartitionedDataset(path=str(local_csvs), dataset=dataset)
-        print(repr(pds))
-        print(
-            f"""kedro_datasets.partitions.partitioned_dataset.PartitionedDataset(filepath='{str(local_csvs)}', """
-            """dataset='kedro_datasets.pandas.parquet_dataset.ParquetDataset()')"""
-        )
+    def test_repr(self, dataset):
+        pds = PartitionedDataset(path="", dataset=dataset)
         assert (
             repr(pds)
-            == f"""kedro_datasets.partitions.partitioned_dataset.PartitionedDataset(filepath='{str(local_csvs)}', """
+            == f"""kedro_datasets.partitions.partitioned_dataset.PartitionedDataset(filepath='', """
             """dataset='kedro_datasets.pandas.parquet_dataset.ParquetDataset()')"""
         )
 

--- a/kedro-datasets/tests/partitions/test_partitioned_dataset.py
+++ b/kedro-datasets/tests/partitions/test_partitioned_dataset.py
@@ -60,6 +60,11 @@ class TestPartitionedDatasetLocal:
     @pytest.mark.parametrize("dataset", ["pandas.ParquetDataset", ParquetDataset])
     def test_repr(self, dataset, local_csvs):
         pds = PartitionedDataset(path=str(local_csvs), dataset=dataset)
+        print(repr(pds))
+        print(
+            f"""kedro_datasets.partitions.partitioned_dataset.PartitionedDataset(filepath='{str(local_csvs)}', """
+            """dataset='kedro_datasets.pandas.parquet_dataset.ParquetDataset()')"""
+        )
         assert (
             repr(pds)
             == f"""kedro_datasets.partitions.partitioned_dataset.PartitionedDataset(filepath='{str(local_csvs)}', """


### PR DESCRIPTION
## Description
Solves https://github.com/kedro-org/kedro-plugins/issues/769

## Development notes
Implemented `__repr__` for `PartitionedDataset`, so it's aligned with `CachedDataset ` [representation](https://github.com/kedro-org/kedro-plugins/issues/769#issue-2416279032).

Old representation:
![Screenshot 2024-07-09 at 12 23 18](https://github.com/user-attachments/assets/8d9343a4-ff6d-4192-a135-15c6165df4a1)

New representation:
![Screenshot 2024-07-24 at 16 58 37](https://github.com/user-attachments/assets/b645de99-cd37-4a4d-9633-91653347c122)

The current solution includes creating a dummy `dataset` object in order to call `dataset._pretty_repr()`, however only filtered parameters are exposed. The alternative solution is to modify `_pretty_repr()` on the [framework side](https://github.com/kedro-org/kedro/blob/5e1504487d9c5c0d210bc231669f68049c0ca213/kedro/io/core.py#L260), so it's not a class method but a function.

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
