### PR TITLE
fix(datasets): mask credentials in ibis dataset when printed

### DIFF
--- a/kedro-datasets/RELEASE.md
+++ b/kedro-datasets/RELEASE.md
@@ -4,6 +4,14 @@
 ## Breaking Changes
 ## Community contributions
 
+# Release 4.0.1
+## Major features and improvements
+## Bug fixes and other changes
+- Updated `ibis.TableDataset` to make sure credentials are not printed in interactive environment.
+
+## Breaking Changes
+## Community contributions
+
 # Release 4.0.0
 ## Major features and improvements
 

--- a/kedro-datasets/kedro_datasets/ibis/table_dataset.py
+++ b/kedro-datasets/kedro_datasets/ibis/table_dataset.py
@@ -186,7 +186,9 @@ class TableDataset(AbstractDataset[ir.Table, ir.Table]):
             "filepath": self._filepath,
             "file_format": self._file_format,
             "table_name": self._table_name,
-            "backend": self._connection_config.get("backend") if self._connection_config else None,
+            "backend": self._connection_config.get("backend")
+            if self._connection_config
+            else None,
             "load_args": self._load_args,
             "save_args": self._save_args,
             "materialized": self._materialized,

--- a/kedro-datasets/kedro_datasets/ibis/table_dataset.py
+++ b/kedro-datasets/kedro_datasets/ibis/table_dataset.py
@@ -186,7 +186,7 @@ class TableDataset(AbstractDataset[ir.Table, ir.Table]):
             "filepath": self._filepath,
             "file_format": self._file_format,
             "table_name": self._table_name,
-            "connection_config": self._connection_config,
+            "connection_config": self._connection_config.get("backend"),
             "load_args": self._load_args,
             "save_args": self._save_args,
             "materialized": self._materialized,

--- a/kedro-datasets/kedro_datasets/ibis/table_dataset.py
+++ b/kedro-datasets/kedro_datasets/ibis/table_dataset.py
@@ -186,7 +186,7 @@ class TableDataset(AbstractDataset[ir.Table, ir.Table]):
             "filepath": self._filepath,
             "file_format": self._file_format,
             "table_name": self._table_name,
-            "connection_config": self._connection_config.get("backend"),
+            "backend": self._connection_config.get("backend") if self._connection_config else None,
             "load_args": self._load_args,
             "save_args": self._save_args,
             "materialized": self._materialized,

--- a/kedro-datasets/kedro_datasets/pandas/json_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/json_dataset.py
@@ -207,7 +207,7 @@ class JSONDataset(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
         dataset_copy = self._copy()
         dataset_copy._load_args.setdefault("lines", True)  # type: ignore[attr-defined]
         dataset_copy._load_args["nrows"] = nrows  # type: ignore[attr-defined]
-        preview_df = dataset_copy._load()
+        preview_df = dataset_copy._load()  # type: ignore
 
         preview_dict = preview_df.to_dict(orient="split")
 


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
As the `_describe` method will be used more often to print dataset (i.e. notebook). We want to make sure credentials are not printed to the terminal. 

From my understanding the `connection` is unique to individual backend and they don't share specific arguments. The only thing that is common is `backend` so I only expose this in the `describe` method.

## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
