### PR TITLE
fix(telemetry): Changed logging level from error to debug to prevent extensive output

### DIFF
--- a/kedro-telemetry/kedro_telemetry/plugin.py
+++ b/kedro-telemetry/kedro_telemetry/plugin.py
@@ -110,7 +110,7 @@ def _get_or_create_project_id(pyproject_path: Path) -> str | None:
                 )
                 return None
     except OSError as exc:
-        logging.error(f"Failed to read the file: {str(pyproject_path)}.\n{str(exc)}")
+        logging.debug(f"Failed to read the file: {str(pyproject_path)}.\n{str(exc)}")
     return None
 
 


### PR DESCRIPTION
## Description
Solves https://github.com/kedro-org/kedro-plugins/issues/781

## Development notes
Changed logging level from `error` to `debug` in case of `OSError` when creating `project_id`.

The error is handled correctly, but logging it pollutes user output as now we print it when every trigger of `before_command_run`. Since the error does not break the execution, it was decided to hide this message from the user. From our side - we can filter those cases by checking that `project_id` is `None` at the heap.

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
