### PR TITLE
fix(telemetry): Avoid eager loading the whole KedroCLI for masking

### DIFF
--- a/kedro-telemetry/kedro_telemetry/masking.py
+++ b/kedro-telemetry/kedro_telemetry/masking.py
@@ -81,16 +81,17 @@ def _get_cli_structure(
     return output
 
 
-def _mask_kedro_cli(
-    cli_struct: dict[str | None, Any], command_args: list[str]
-) -> list[str]:
+def _mask_kedro_cli(KedroCLI, command_args: list[str]) -> list[str]:
     """Takes a dynamic vocabulary (based on `KedroCLI`) and returns
     a masked CLI input"""
     output = []
+    cli_struct = _get_cli_structure(
+        KedroCLI.get_command(ctx=None, cmd_name=command_args[0])
+    )
 
     # Preserve the initial part of the command until parameters sections begin
     arg_index = 0
-    current_CLI = cli_struct.get("kedro", {})
+    current_CLI = cli_struct
     while (
         arg_index < len(command_args)
         and not command_args[arg_index].startswith("-")

--- a/kedro-telemetry/kedro_telemetry/masking.py
+++ b/kedro-telemetry/kedro_telemetry/masking.py
@@ -76,7 +76,8 @@ def _get_cli_structure(
     `click.Context` and return a `dict`.
     """
     output: dict[str | None, Any] = {}
-    _recurse_cli(cli_obj, None, output, get_help)
+    with click.Context(cli_obj) as ctx:  # type: ignore
+        _recurse_cli(cli_obj, ctx, output, get_help)
     return output
 
 
@@ -85,8 +86,8 @@ def _mask_kedro_cli(KedroCLI, command_args: list[str]) -> list[str]:
     a masked CLI input"""
     output = []
     arg_index = 0
-    cmd = command_args[0]
-    if cmd == "--help":
+    cmd = command_args[0] if command_args else ""
+    if cmd in {"--help", "--version", "-h", "-v", ""}:
         return command_args
     click_cmd = KedroCLI.get_command(None, cmd)
     if click_cmd is None:

--- a/kedro-telemetry/kedro_telemetry/masking.py
+++ b/kedro-telemetry/kedro_telemetry/masking.py
@@ -1,7 +1,7 @@
 """Module containing command masking functionality."""
 from __future__ import annotations
 
-from typing import Any, Iterator
+from typing import Any
 
 import click
 
@@ -81,7 +81,7 @@ def _get_cli_structure(
     return output
 
 
-def _mask_kedro_cli(KedroCLI, command_args: list[str]) -> list[str]:
+def _mask_kedro_cli(cli: click.CommandCollection, command_args: list[str]) -> list[str]:
     """Takes a dynamic vocabulary (based on `KedroCLI`) and returns
     a masked CLI input"""
     output = []
@@ -89,7 +89,7 @@ def _mask_kedro_cli(KedroCLI, command_args: list[str]) -> list[str]:
     cmd = command_args[0] if command_args else ""
     if cmd in {"--help", "--version", "-h", "-v", ""}:
         return command_args
-    click_cmd = KedroCLI.get_command(None, cmd)
+    click_cmd = cli.get_command(ctx=None, cmd_name=cmd)  # type: ignore
     if click_cmd is None:
         return [MASK]
 
@@ -119,13 +119,3 @@ def _mask_kedro_cli(KedroCLI, command_args: list[str]) -> list[str]:
             output.append(MASK)
 
     return output
-
-
-def _recursive_items(dictionary: dict[Any, Any]) -> Iterator[Any]:
-    for key, value in dictionary.items():
-        if isinstance(value, dict):
-            yield key
-            yield from _recursive_items(value)
-        else:
-            yield key
-            yield value

--- a/kedro-telemetry/kedro_telemetry/plugin.py
+++ b/kedro-telemetry/kedro_telemetry/plugin.py
@@ -26,7 +26,7 @@ from kedro.io.data_catalog import DataCatalog
 from kedro.pipeline import Pipeline
 
 from kedro_telemetry import __version__ as TELEMETRY_VERSION
-from kedro_telemetry.masking import _get_cli_structure, _mask_kedro_cli
+from kedro_telemetry.masking import _mask_kedro_cli
 
 HEAP_APPID_PROD = "2388822444"
 HEAP_ENDPOINT = "https://heapanalytics.com/api/track"
@@ -176,10 +176,7 @@ class KedroTelemetryHook:
 
         # get KedroCLI and its structure from actual project root
         cli = KedroCLI(project_path=project_path if project_path else Path.cwd())
-        cli_struct = _get_cli_structure(cli_obj=cli, get_help=False)
-        masked_command_args = _mask_kedro_cli(
-            cli_struct=cli_struct, command_args=command_args
-        )
+        masked_command_args = _mask_kedro_cli(cli, command_args=command_args)
 
         self._user_uuid = _get_or_create_uuid()
 

--- a/kedro-telemetry/tests/test_masking.py
+++ b/kedro-telemetry/tests/test_masking.py
@@ -13,7 +13,6 @@ from kedro_telemetry.masking import (
     MASK,
     _get_cli_structure,
     _mask_kedro_cli,
-    _recursive_items,
 )
 
 REPO_NAME = "cli_tools_dummy_project"
@@ -152,31 +151,6 @@ class TestCLIMasking:
                 assert v.startswith("Usage:  [OPTIONS]")
 
     @pytest.mark.parametrize(
-        "input_dict, expected_output_count",
-        [
-            ({}, 0),
-            ({"a": "foo"}, 2),
-            ({"a": {"b": "bar"}, "c": {"baz"}}, 5),
-            (
-                {
-                    "a": {"b": "bar"},
-                    "c": None,
-                    "d": {"e": "fizz"},
-                    "f": {"g": {"h": "buzz"}},
-                },
-                12,
-            ),
-        ],
-    )
-    def test_recursive_items(self, input_dict, expected_output_count):
-        assert expected_output_count == len(
-            list(_recursive_items(dictionary=input_dict))
-        )
-
-    def test_recursive_items_empty(self):
-        assert len(list(_recursive_items({}))) == 0
-
-    @pytest.mark.parametrize(
         "input_command_args, expected_masked_args",
         [
             ([], []),
@@ -220,5 +194,5 @@ class TestCLIMasking:
         )
         kedro_cli = KedroCLI(fake_metadata.project_path)
         assert expected_masked_args == _mask_kedro_cli(
-            kedro_cli, command_args=input_command_args
+            cli=kedro_cli, command_args=input_command_args
         )


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
Resolve #794 

## Development notes
<!-- What have you changed, and how has this been tested? -->
* Instead of recursively loading **all the commands** from `KedroCLI` (which are lazy now) to generate a `dict` CLI structure, only load the structure for the command that is called to perform masking.
* I've also updated the test to actually check masking with real Kedro commands since `_mask_kedro_cli` needs the actual `KedroCLI` object.
* Removed the `_recursive_items()` function and associated unit tests since it wasn't being used anywhere. 

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
