### PR TITLE
fix(datasets): Replace deprecated GBQDataset load/save funcs

### DIFF
--- a/kedro-datasets/RELEASE.md
+++ b/kedro-datasets/RELEASE.md
@@ -14,12 +14,14 @@
 
 ## Bug fixes and other changes
 * Refactored all datasets to set `fs_args` defaults in the same way as `load_args` and `save_args` and not have hardcoded values in the save methods.
+* Fixed deprecated load and save approaches of GBQTableDataset and GBQQueryDataset by invoking save and load directly over `pandas-gbq` lib
 
 ## Breaking Changes
 ## Community contributions
 Many thanks to the following Kedroids for contributing PRs to this release:
 * [Brandon Meek](https://github.com/bpmeek)
 * [yury-fedotov](https://github.com/yury-fedotov)
+* [janickspirig](https://github.com/janickspirig)
 
 
 # Release 4.1.0

--- a/kedro-datasets/kedro_datasets/pandas/gbq_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/gbq_dataset.py
@@ -139,7 +139,7 @@ class GBQTableDataset(AbstractDataset[None, pd.DataFrame]):
 
     def _load(self) -> pd.DataFrame:
         sql = f"select * from {self._dataset}.{self._table_name}"  # nosec
-        self._load_args.setdefault("query", sql)
+        self._load_args.setdefault("query_or_table", sql)
         return pd_gbq.read_gbq(
             project_id=self._project_id,
             credentials=self._credentials,
@@ -276,7 +276,7 @@ class GBQQueryDataset(AbstractDataset[None, pd.DataFrame]):
 
         # load sql query from arg or from file
         if sql:
-            self._load_args["query"] = sql
+            self._load_args["query_or_table"] = sql
             self._filepath = None
         else:
             # filesystem for loading sql file
@@ -293,7 +293,7 @@ class GBQQueryDataset(AbstractDataset[None, pd.DataFrame]):
     def _describe(self) -> dict[str, Any]:
         load_args = copy.deepcopy(self._load_args)
         desc = {}
-        desc["sql"] = str(load_args.pop("query", None))
+        desc["sql"] = str(load_args.pop("query_or_table", None))
         desc["filepath"] = str(self._filepath)
         desc["load_args"] = str(load_args)
 

--- a/kedro-datasets/tests/pandas/test_gbq_dataset.py
+++ b/kedro-datasets/tests/pandas/test_gbq_dataset.py
@@ -148,7 +148,9 @@ class TestGBQDataset:
         )
         assert_frame_equal(dummy_dataframe, loaded_data)
 
-    @pytest.mark.parametrize("load_args", [{"query": "Select 1"}], indirect=True)
+    @pytest.mark.parametrize(
+        "load_args", [{"query_or_table": "Select 1"}], indirect=True
+    )
     def test_read_gbq_with_query(self, gbq_dataset, dummy_dataframe, mocker, load_args):
         """Test loading data set with query in the argument."""
         mocked_read_gbq = mocker.patch("kedro_datasets.pandas.gbq_dataset.pd.read_gbq")
@@ -156,7 +158,7 @@ class TestGBQDataset:
         loaded_data = gbq_dataset.load()
 
         mocked_read_gbq.assert_called_once_with(
-            project_id=PROJECT, credentials=None, query=load_args["query"]
+            project_id=PROJECT, credentials=None, query=load_args["query_or_table"]
         )
 
         assert_frame_equal(dummy_dataframe, loaded_data)
@@ -245,7 +247,7 @@ class TestGBQQueryDataset:
         loaded_data = gbq_sql_dataset.load()
 
         mocked_read_gbq.assert_called_once_with(
-            project_id=PROJECT, credentials=None, query=SQL_QUERY
+            project_id=PROJECT, credentials=None, query_or_table=SQL_QUERY
         )
 
         assert_frame_equal(dummy_dataframe, loaded_data)
@@ -258,7 +260,7 @@ class TestGBQQueryDataset:
         loaded_data = gbq_sql_file_dataset.load()
 
         mocked_read_gbq.assert_called_once_with(
-            project_id=PROJECT, credentials=None, query=SQL_QUERY
+            project_id=PROJECT, credentials=None, query_or_table=SQL_QUERY
         )
 
         assert_frame_equal(dummy_dataframe, loaded_data)

--- a/kedro-datasets/tests/pandas/test_gbq_dataset.py
+++ b/kedro-datasets/tests/pandas/test_gbq_dataset.py
@@ -95,7 +95,9 @@ class TestGBQDataset:
     def test_load_missing_file(self, gbq_dataset, mocker):
         """Check the error when trying to load missing table."""
         pattern = r"Failed while loading data from data set GBQTableDataset\(.*\)"
-        mocked_read_gbq = mocker.patch("kedro_datasets.pandas.gbq_dataset.pd.read_gbq")
+        mocked_read_gbq = mocker.patch(
+            "kedro_datasets.pandas.gbq_dataset.pd_gbq.read_gbq"
+        )
         mocked_read_gbq.side_effect = ValueError
         with pytest.raises(DatasetError, match=pattern):
             gbq_dataset.load()
@@ -133,18 +135,25 @@ class TestGBQDataset:
         """Test saving and reloading the data set."""
         sql = f"select * from {DATASET}.{TABLE_NAME}"
         table_id = f"{DATASET}.{TABLE_NAME}"
-        mocked_read_gbq = mocker.patch("kedro_datasets.pandas.gbq_dataset.pd.read_gbq")
+        mocked_to_gbq = mocker.patch("kedro_datasets.pandas.gbq_dataset.pd_gbq.to_gbq")
+        mocked_read_gbq = mocker.patch(
+            "kedro_datasets.pandas.gbq_dataset.pd_gbq.read_gbq"
+        )
         mocked_read_gbq.return_value = dummy_dataframe
         mocked_df = mocker.Mock()
 
         gbq_dataset.save(mocked_df)
         loaded_data = gbq_dataset.load()
 
-        mocked_df.to_gbq.assert_called_once_with(
-            table_id, project_id=PROJECT, credentials=None, progress_bar=False
+        mocked_to_gbq.assert_called_once_with(
+            dataframe=mocked_df,
+            destination_table=table_id,
+            project_id=PROJECT,
+            credentials=None,
+            progress_bar=False,
         )
         mocked_read_gbq.assert_called_once_with(
-            project_id=PROJECT, credentials=None, query=sql
+            project_id=PROJECT, credentials=None, query_or_table=sql
         )
         assert_frame_equal(dummy_dataframe, loaded_data)
 
@@ -153,12 +162,16 @@ class TestGBQDataset:
     )
     def test_read_gbq_with_query(self, gbq_dataset, dummy_dataframe, mocker, load_args):
         """Test loading data set with query in the argument."""
-        mocked_read_gbq = mocker.patch("kedro_datasets.pandas.gbq_dataset.pd.read_gbq")
+        mocked_read_gbq = mocker.patch(
+            "kedro_datasets.pandas.gbq_dataset.pd_gbq.read_gbq"
+        )
         mocked_read_gbq.return_value = dummy_dataframe
         loaded_data = gbq_dataset.load()
 
         mocked_read_gbq.assert_called_once_with(
-            project_id=PROJECT, credentials=None, query=load_args["query_or_table"]
+            project_id=PROJECT,
+            credentials=None,
+            query_or_table=load_args["query_or_table"],
         )
 
         assert_frame_equal(dummy_dataframe, loaded_data)
@@ -241,7 +254,9 @@ class TestGBQQueryDataset:
 
     def test_load(self, mocker, gbq_sql_dataset, dummy_dataframe):
         """Test `load` method invocation"""
-        mocked_read_gbq = mocker.patch("kedro_datasets.pandas.gbq_dataset.pd.read_gbq")
+        mocked_read_gbq = mocker.patch(
+            "kedro_datasets.pandas.gbq_dataset.pd_gbq.read_gbq"
+        )
         mocked_read_gbq.return_value = dummy_dataframe
 
         loaded_data = gbq_sql_dataset.load()
@@ -254,7 +269,9 @@ class TestGBQQueryDataset:
 
     def test_load_query_file(self, mocker, gbq_sql_file_dataset, dummy_dataframe):
         """Test `load` method invocation using a file as input query"""
-        mocked_read_gbq = mocker.patch("kedro_datasets.pandas.gbq_dataset.pd.read_gbq")
+        mocked_read_gbq = mocker.patch(
+            "kedro_datasets.pandas.gbq_dataset.pd_gbq.read_gbq"
+        )
         mocked_read_gbq.return_value = dummy_dataframe
 
         loaded_data = gbq_sql_file_dataset.load()


### PR DESCRIPTION
## Description
PR addresses https://github.com/kedro-org/kedro-plugins/issues/825

## Development notes
Adjusted read/write to use `.to_gbq()` and `.read_gbq()` directly from pandas-gbq package (`pd_gbq`) to avoid deprecation warnings

## Checklist

- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
