### PR TITLE
feat(datasets)!: expose `load` and `save` publicly

### DIFF
--- a/kedro-datasets/RELEASE.md
+++ b/kedro-datasets/RELEASE.md
@@ -21,6 +21,8 @@
 * Fixed incorrect `pandas` optional dependency
 
 ## Breaking Changes
+* Exposed `load` and `save` publicly for each dataset. This requires Kedro version 0.19.7 or higher.
+
 ## Community contributions
 Many thanks to the following Kedroids for contributing PRs to this release:
 * [Brandon Meek](https://github.com/bpmeek)

--- a/kedro-datasets/kedro_datasets/api/api_dataset.py
+++ b/kedro-datasets/kedro_datasets/api/api_dataset.py
@@ -184,7 +184,7 @@ class APIDataset(AbstractDataset[None, requests.Response]):
 
         return response
 
-    def _load(self) -> requests.Response:
+    def load(self) -> requests.Response:
         if self._request_args["method"] == "GET":
             with sessions.Session() as session:
                 return self._execute_request(session)
@@ -219,7 +219,7 @@ class APIDataset(AbstractDataset[None, requests.Response]):
             raise DatasetError("Failed to connect to the remote server") from exc
         return response
 
-    def _save(self, data: Any) -> requests.Response:  # type: ignore[override]
+    def save(self, data: Any) -> requests.Response:  # type: ignore[override]
         if self._request_args["method"] in ["PUT", "POST"]:
             if isinstance(data, list):
                 return self._execute_save_with_chunks(json_data=data)

--- a/kedro-datasets/kedro_datasets/biosequence/biosequence_dataset.py
+++ b/kedro-datasets/kedro_datasets/biosequence/biosequence_dataset.py
@@ -122,12 +122,12 @@ class BioSequenceDataset(AbstractDataset[list, list]):
             "save_args": self._save_args,
         }
 
-    def _load(self) -> list:
+    def load(self) -> list:
         load_path = get_filepath_str(self._filepath, self._protocol)
         with self._fs.open(load_path, **self._fs_open_args_load) as fs_file:
             return list(SeqIO.parse(handle=fs_file, **self._load_args))
 
-    def _save(self, data: list) -> None:
+    def save(self, data: list) -> None:
         save_path = get_filepath_str(self._filepath, self._protocol)
 
         with self._fs.open(save_path, **self._fs_open_args_save) as fs_file:

--- a/kedro-datasets/kedro_datasets/dask/csv_dataset.py
+++ b/kedro-datasets/kedro_datasets/dask/csv_dataset.py
@@ -105,12 +105,12 @@ class CSVDataset(AbstractDataset[dd.DataFrame, dd.DataFrame]):
             "save_args": self._save_args,
         }
 
-    def _load(self) -> dd.DataFrame:
+    def load(self) -> dd.DataFrame:
         return dd.read_csv(
             self._filepath, storage_options=self.fs_args, **self._load_args
         )
 
-    def _save(self, data: dd.DataFrame) -> None:
+    def save(self, data: dd.DataFrame) -> None:
         data.to_csv(self._filepath, storage_options=self.fs_args, **self._save_args)
 
     def _exists(self) -> bool:

--- a/kedro-datasets/kedro_datasets/dask/parquet_dataset.py
+++ b/kedro-datasets/kedro_datasets/dask/parquet_dataset.py
@@ -135,12 +135,12 @@ class ParquetDataset(AbstractDataset[dd.DataFrame, dd.DataFrame]):
             "save_args": self._save_args,
         }
 
-    def _load(self) -> dd.DataFrame:
+    def load(self) -> dd.DataFrame:
         return dd.read_parquet(
             self._filepath, storage_options=self.fs_args, **self._load_args
         )
 
-    def _save(self, data: dd.DataFrame) -> None:
+    def save(self, data: dd.DataFrame) -> None:
         self._process_schema()
         data.to_parquet(
             path=self._filepath, storage_options=self.fs_args, **self._save_args

--- a/kedro-datasets/kedro_datasets/databricks/managed_table_dataset.py
+++ b/kedro-datasets/kedro_datasets/databricks/managed_table_dataset.py
@@ -288,7 +288,7 @@ class ManagedTableDataset(AbstractVersionedDataset):
             exists_function=self._exists,  # type: ignore[arg-type]
         )
 
-    def _load(self) -> DataFrame | pd.DataFrame:
+    def load(self) -> DataFrame | pd.DataFrame:
         """Loads the version of data in the format defined in the init
         (spark|pandas dataframe)
 
@@ -380,7 +380,7 @@ class ManagedTableDataset(AbstractVersionedDataset):
         else:
             self._save_append(update_data)
 
-    def _save(self, data: DataFrame | pd.DataFrame) -> None:
+    def save(self, data: DataFrame | pd.DataFrame) -> None:
         """Saves the data based on the write_mode and dataframe_type in the init.
         If write_mode is pandas, Spark dataframe is created first.
         If schema is provided, data is matched to schema before saving

--- a/kedro-datasets/kedro_datasets/email/message_dataset.py
+++ b/kedro-datasets/kedro_datasets/email/message_dataset.py
@@ -160,13 +160,13 @@ class EmailMessageDataset(AbstractVersionedDataset[Message, Message]):
             "version": self._version,
         }
 
-    def _load(self) -> Message:
+    def load(self) -> Message:
         load_path = get_filepath_str(self._get_load_path(), self._protocol)
 
         with self._fs.open(load_path, **self._fs_open_args_load) as fs_file:
             return Parser(**self._parser_args).parse(fs_file, **self._load_args)
 
-    def _save(self, data: Message) -> None:
+    def save(self, data: Message) -> None:
         save_path = get_filepath_str(self._get_save_path(), self._protocol)
 
         with self._fs.open(save_path, **self._fs_open_args_save) as fs_file:

--- a/kedro-datasets/kedro_datasets/geopandas/geojson_dataset.py
+++ b/kedro-datasets/kedro_datasets/geopandas/geojson_dataset.py
@@ -126,12 +126,12 @@ class GeoJSONDataset(
         self._fs_open_args_load = _fs_open_args_load
         self._fs_open_args_save = _fs_open_args_save
 
-    def _load(self) -> gpd.GeoDataFrame | dict[str, gpd.GeoDataFrame]:
+    def load(self) -> gpd.GeoDataFrame | dict[str, gpd.GeoDataFrame]:
         load_path = get_filepath_str(self._get_load_path(), self._protocol)
         with self._fs.open(load_path, **self._fs_open_args_load) as fs_file:
             return gpd.read_file(fs_file, **self._load_args)
 
-    def _save(self, data: gpd.GeoDataFrame) -> None:
+    def save(self, data: gpd.GeoDataFrame) -> None:
         save_path = get_filepath_str(self._get_save_path(), self._protocol)
         with self._fs.open(save_path, **self._fs_open_args_save) as fs_file:
             data.to_file(fs_file, **self._save_args)

--- a/kedro-datasets/kedro_datasets/holoviews/holoviews_writer.py
+++ b/kedro-datasets/kedro_datasets/holoviews/holoviews_writer.py
@@ -110,10 +110,10 @@ class HoloviewsWriter(AbstractVersionedDataset[HoloViews, NoReturn]):
             "version": self._version,
         }
 
-    def _load(self) -> NoReturn:
+    def load(self) -> NoReturn:
         raise DatasetError(f"Loading not supported for '{self.__class__.__name__}'")
 
-    def _save(self, data: HoloViews) -> None:
+    def save(self, data: HoloViews) -> None:
         bytes_buffer = io.BytesIO()
         hv.save(data, bytes_buffer, **self._save_args)
 

--- a/kedro-datasets/kedro_datasets/huggingface/hugging_face_dataset.py
+++ b/kedro-datasets/kedro_datasets/huggingface/hugging_face_dataset.py
@@ -47,10 +47,10 @@ class HFDataset(AbstractVersionedDataset):
         self._dataset_kwargs = dataset_kwargs or {}
         self.metadata = metadata
 
-    def _load(self):
+    def load(self):
         return load_dataset(self.dataset_name, **self._dataset_kwargs)
 
-    def _save(self):
+    def save(self):
         raise NotImplementedError("Not yet implemented")
 
     def _describe(self) -> dict[str, Any]:

--- a/kedro-datasets/kedro_datasets/huggingface/transformer_pipeline_dataset.py
+++ b/kedro-datasets/kedro_datasets/huggingface/transformer_pipeline_dataset.py
@@ -62,10 +62,10 @@ class HFTransformerPipelineDataset(AbstractDataset):
             self._pipeline_kwargs.pop("task", None)
             self._pipeline_kwargs.pop("model", None)
 
-    def _load(self) -> Pipeline:
+    def load(self) -> Pipeline:
         return pipeline(self._task, model=self._model_name, **self._pipeline_kwargs)
 
-    def _save(self, pipeline: Pipeline) -> None:
+    def save(self, pipeline: Pipeline) -> None:
         raise NotImplementedError("Not yet implemented")
 
     def _describe(self) -> dict[str, t.Any]:

--- a/kedro-datasets/kedro_datasets/ibis/table_dataset.py
+++ b/kedro-datasets/kedro_datasets/ibis/table_dataset.py
@@ -163,7 +163,7 @@ class TableDataset(AbstractDataset[ir.Table, ir.Table]):
 
         return cls._connections[key]
 
-    def _load(self) -> ir.Table:
+    def load(self) -> ir.Table:
         if self._filepath is not None:
             if self._file_format is None:
                 raise NotImplementedError
@@ -173,7 +173,7 @@ class TableDataset(AbstractDataset[ir.Table, ir.Table]):
         else:
             return self.connection.table(self._table_name)
 
-    def _save(self, data: ir.Table) -> None:
+    def save(self, data: ir.Table) -> None:
         if self._table_name is None:
             raise DatasetError("Must provide `table_name` for materialization.")
 

--- a/kedro-datasets/kedro_datasets/json/json_dataset.py
+++ b/kedro-datasets/kedro_datasets/json/json_dataset.py
@@ -134,13 +134,13 @@ class JSONDataset(AbstractVersionedDataset[Any, Any]):
             "version": self._version,
         }
 
-    def _load(self) -> Any:
+    def load(self) -> Any:
         load_path = get_filepath_str(self._get_load_path(), self._protocol)
 
         with self._fs.open(load_path, **self._fs_open_args_load) as fs_file:
             return json.load(fs_file)
 
-    def _save(self, data: Any) -> None:
+    def save(self, data: Any) -> None:
         save_path = get_filepath_str(self._get_save_path(), self._protocol)
 
         with self._fs.open(save_path, **self._fs_open_args_save) as fs_file:
@@ -172,6 +172,6 @@ class JSONDataset(AbstractVersionedDataset[Any, Any]):
         Returns:
             A string representing the JSON data for previewing.
         """
-        data = self._load()
+        data = self.load.__wrapped__(self)  # type: ignore[attr-defined]
 
         return JSONPreview(json.dumps(data))

--- a/kedro-datasets/kedro_datasets/matlab/matlab_dataset.py
+++ b/kedro-datasets/kedro_datasets/matlab/matlab_dataset.py
@@ -125,7 +125,7 @@ class MatlabDataset(AbstractVersionedDataset[np.ndarray, np.ndarray]):
             "version": self._version,
         }
 
-    def _load(self) -> np.ndarray:
+    def load(self) -> np.ndarray:
         """
         Access the specific variable in the .mat file, e.g, data['variable_name']
         """
@@ -134,7 +134,7 @@ class MatlabDataset(AbstractVersionedDataset[np.ndarray, np.ndarray]):
             data = io.loadmat(f)
             return data
 
-    def _save(self, data: np.ndarray) -> None:
+    def save(self, data: np.ndarray) -> None:
         save_path = get_filepath_str(self._get_save_path(), self._protocol)
         with self._fs.open(save_path, **self._fs_open_args_save) as f:
             io.savemat(f, {"data": data})

--- a/kedro-datasets/kedro_datasets/matplotlib/matplotlib_writer.py
+++ b/kedro-datasets/kedro_datasets/matplotlib/matplotlib_writer.py
@@ -197,10 +197,10 @@ class MatplotlibWriter(
             "version": self._version,
         }
 
-    def _load(self) -> NoReturn:
+    def load(self) -> NoReturn:
         raise DatasetError(f"Loading not supported for '{self.__class__.__name__}'")
 
-    def _save(self, data: Figure | (list[Figure] | dict[str, Figure])) -> None:
+    def save(self, data: Figure | (list[Figure] | dict[str, Figure])) -> None:
         save_path = self._get_save_path()
 
         if isinstance(data, (list, dict)) and self._overwrite and self._exists():

--- a/kedro-datasets/kedro_datasets/networkx/gml_dataset.py
+++ b/kedro-datasets/kedro_datasets/networkx/gml_dataset.py
@@ -116,13 +116,13 @@ class GMLDataset(AbstractVersionedDataset[networkx.Graph, networkx.Graph]):
             **(_fs_open_args_save or {}),
         }
 
-    def _load(self) -> networkx.Graph:
+    def load(self) -> networkx.Graph:
         load_path = get_filepath_str(self._get_load_path(), self._protocol)
         with self._fs.open(load_path, **self._fs_open_args_load) as fs_file:
             data = networkx.read_gml(fs_file, **self._load_args)
         return data
 
-    def _save(self, data: networkx.Graph) -> None:
+    def save(self, data: networkx.Graph) -> None:
         save_path = get_filepath_str(self._get_save_path(), self._protocol)
         with self._fs.open(save_path, **self._fs_open_args_save) as fs_file:
             networkx.write_gml(data, fs_file, **self._save_args)

--- a/kedro-datasets/kedro_datasets/networkx/graphml_dataset.py
+++ b/kedro-datasets/kedro_datasets/networkx/graphml_dataset.py
@@ -115,12 +115,12 @@ class GraphMLDataset(AbstractVersionedDataset[networkx.Graph, networkx.Graph]):
             **(_fs_open_args_save or {}),
         }
 
-    def _load(self) -> networkx.Graph:
+    def load(self) -> networkx.Graph:
         load_path = get_filepath_str(self._get_load_path(), self._protocol)
         with self._fs.open(load_path, **self._fs_open_args_load) as fs_file:
             return networkx.read_graphml(fs_file, **self._load_args)
 
-    def _save(self, data: networkx.Graph) -> None:
+    def save(self, data: networkx.Graph) -> None:
         save_path = get_filepath_str(self._get_save_path(), self._protocol)
         with self._fs.open(save_path, **self._fs_open_args_save) as fs_file:
             networkx.write_graphml(data, fs_file, **self._save_args)

--- a/kedro-datasets/kedro_datasets/networkx/json_dataset.py
+++ b/kedro-datasets/kedro_datasets/networkx/json_dataset.py
@@ -112,14 +112,14 @@ class JSONDataset(AbstractVersionedDataset[networkx.Graph, networkx.Graph]):
             **(_fs_open_args_save or {}),
         }
 
-    def _load(self) -> networkx.Graph:
+    def load(self) -> networkx.Graph:
         load_path = get_filepath_str(self._get_load_path(), self._protocol)
         with self._fs.open(load_path, **self._fs_open_args_load) as fs_file:
             json_payload = json.load(fs_file)
 
         return networkx.node_link_graph(json_payload, **self._load_args)
 
-    def _save(self, data: networkx.Graph) -> None:
+    def save(self, data: networkx.Graph) -> None:
         save_path = get_filepath_str(self._get_save_path(), self._protocol)
 
         json_graph = networkx.node_link_data(data, **self._save_args)

--- a/kedro-datasets/kedro_datasets/pandas/csv_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/csv_dataset.py
@@ -162,7 +162,7 @@ class CSVDataset(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
             "version": self._version,
         }
 
-    def _load(self) -> pd.DataFrame:
+    def load(self) -> pd.DataFrame:
         load_path = str(self._get_load_path())
         if self._protocol == "file":
             # file:// protocol seems to misbehave on Windows
@@ -176,7 +176,7 @@ class CSVDataset(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
             load_path, storage_options=self._storage_options, **self._load_args
         )
 
-    def _save(self, data: pd.DataFrame) -> None:
+    def save(self, data: pd.DataFrame) -> None:
         save_path = get_filepath_str(self._get_save_path(), self._protocol)
 
         with self._fs.open(save_path, **self._fs_open_args_save) as fs_file:

--- a/kedro-datasets/kedro_datasets/pandas/deltatable_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/deltatable_dataset.py
@@ -219,10 +219,10 @@ class DeltaTableDataset(AbstractDataset):
         """Returns the version of the DeltaTableDataset that is currently loaded."""
         return self._delta_table.version() if self._delta_table else None
 
-    def _load(self) -> pd.DataFrame:
+    def load(self) -> pd.DataFrame:
         return self._delta_table.to_pandas() if self._delta_table else None
 
-    def _save(self, data: pd.DataFrame) -> None:
+    def save(self, data: pd.DataFrame) -> None:
         if self.is_empty_dir:
             # first time creation of delta table
             write_deltalake(

--- a/kedro-datasets/kedro_datasets/pandas/excel_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/excel_dataset.py
@@ -222,7 +222,7 @@ class ExcelDataset(
             "version": self._version,
         }
 
-    def _load(self) -> pd.DataFrame | dict[str, pd.DataFrame]:
+    def load(self) -> pd.DataFrame | dict[str, pd.DataFrame]:
         load_path = str(self._get_load_path())
         if self._protocol == "file":
             # file:// protocol seems to misbehave on Windows
@@ -236,7 +236,7 @@ class ExcelDataset(
             load_path, storage_options=self._storage_options, **self._load_args
         )
 
-    def _save(self, data: pd.DataFrame | dict[str, pd.DataFrame]) -> None:
+    def save(self, data: pd.DataFrame | dict[str, pd.DataFrame]) -> None:
         save_path = get_filepath_str(self._get_save_path(), self._protocol)
 
         with self._fs.open(save_path, **self._fs_open_args_save) as fs_file:

--- a/kedro-datasets/kedro_datasets/pandas/feather_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/feather_dataset.py
@@ -161,7 +161,7 @@ class FeatherDataset(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
             "version": self._version,
         }
 
-    def _load(self) -> pd.DataFrame:
+    def load(self) -> pd.DataFrame:
         load_path = str(self._get_load_path())
         if self._protocol == "file":
             # file:// protocol seems to misbehave on Windows
@@ -175,7 +175,7 @@ class FeatherDataset(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
             load_path, storage_options=self._storage_options, **self._load_args
         )
 
-    def _save(self, data: pd.DataFrame) -> None:
+    def save(self, data: pd.DataFrame) -> None:
         save_path = get_filepath_str(self._get_save_path(), self._protocol)
 
         with self._fs.open(save_path, **self._fs_open_args_save) as fs_file:

--- a/kedro-datasets/kedro_datasets/pandas/gbq_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/gbq_dataset.py
@@ -137,7 +137,7 @@ class GBQTableDataset(AbstractDataset[None, pd.DataFrame]):
             "save_args": self._save_args,
         }
 
-    def _load(self) -> pd.DataFrame:
+    def load(self) -> pd.DataFrame:
         sql = f"select * from {self._dataset}.{self._table_name}"  # nosec
         self._load_args.setdefault("query_or_table", sql)
         return pd_gbq.read_gbq(
@@ -146,7 +146,7 @@ class GBQTableDataset(AbstractDataset[None, pd.DataFrame]):
             **self._load_args,
         )
 
-    def _save(self, data: pd.DataFrame) -> None:
+    def save(self, data: pd.DataFrame) -> None:
         pd_gbq.to_gbq(
             dataframe=data,
             destination_table=f"{self._dataset}.{self._table_name}",
@@ -299,7 +299,7 @@ class GBQQueryDataset(AbstractDataset[None, pd.DataFrame]):
 
         return desc
 
-    def _load(self) -> pd.DataFrame:
+    def load(self) -> pd.DataFrame:
         load_args = copy.deepcopy(self._load_args)
 
         if self._filepath:
@@ -313,5 +313,5 @@ class GBQQueryDataset(AbstractDataset[None, pd.DataFrame]):
             **load_args,
         )
 
-    def _save(self, data: None) -> NoReturn:
+    def save(self, data: None) -> NoReturn:
         raise DatasetError("'save' is not supported on GBQQueryDataset")

--- a/kedro-datasets/kedro_datasets/pandas/generic_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/generic_dataset.py
@@ -190,7 +190,7 @@ class GenericDataset(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
                 f"does not support a filepath target/source."
             )
 
-    def _load(self) -> pd.DataFrame:
+    def load(self) -> pd.DataFrame:
         self._ensure_file_system_target()
 
         load_path = get_filepath_str(self._get_load_path(), self._protocol)
@@ -204,7 +204,7 @@ class GenericDataset(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
             "https://pandas.pydata.org/docs/reference/io.html"
         )
 
-    def _save(self, data: pd.DataFrame) -> None:
+    def save(self, data: pd.DataFrame) -> None:
         self._ensure_file_system_target()
 
         save_path = get_filepath_str(self._get_save_path(), self._protocol)

--- a/kedro-datasets/kedro_datasets/pandas/hdf_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/hdf_dataset.py
@@ -152,7 +152,7 @@ class HDFDataset(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
             "version": self._version,
         }
 
-    def _load(self) -> pd.DataFrame:
+    def load(self) -> pd.DataFrame:
         load_path = get_filepath_str(self._get_load_path(), self._protocol)
 
         with self._fs.open(load_path, **self._fs_open_args_load) as fs_file:
@@ -171,7 +171,7 @@ class HDFDataset(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
             ) as store:
                 return store[self._key]
 
-    def _save(self, data: pd.DataFrame) -> None:
+    def save(self, data: pd.DataFrame) -> None:
         save_path = get_filepath_str(self._get_save_path(), self._protocol)
 
         with HDFDataset._lock:

--- a/kedro-datasets/kedro_datasets/pandas/json_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/json_dataset.py
@@ -158,7 +158,7 @@ class JSONDataset(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
             "version": self._version,
         }
 
-    def _load(self) -> pd.DataFrame:
+    def load(self) -> pd.DataFrame:
         load_path = str(self._get_load_path())
         if self._protocol == "file":
             # file:// protocol seems to misbehave on Windows
@@ -172,7 +172,7 @@ class JSONDataset(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
             load_path, storage_options=self._storage_options, **self._load_args
         )
 
-    def _save(self, data: pd.DataFrame) -> None:
+    def save(self, data: pd.DataFrame) -> None:
         save_path = get_filepath_str(self._get_save_path(), self._protocol)
 
         with self._fs.open(save_path, **self._fs_open_args_save) as fs_file:
@@ -212,7 +212,7 @@ class JSONDataset(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
         dataset_copy = self._copy()
         dataset_copy._load_args.setdefault("lines", True)  # type: ignore[attr-defined]
         dataset_copy._load_args["nrows"] = nrows  # type: ignore[attr-defined]
-        preview_df = dataset_copy._load()  # type: ignore
+        preview_df = dataset_copy.load.__wrapped__(dataset_copy)  # type: ignore[attr-defined]
 
         preview_dict = preview_df.to_dict(orient="split")
 

--- a/kedro-datasets/kedro_datasets/pandas/parquet_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/parquet_dataset.py
@@ -173,7 +173,7 @@ class ParquetDataset(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
             "version": self._version,
         }
 
-    def _load(self) -> pd.DataFrame:
+    def load(self) -> pd.DataFrame:
         load_path = str(self._get_load_path())
         if self._protocol == "file":
             # file:// protocol seems to misbehave on Windows
@@ -187,7 +187,7 @@ class ParquetDataset(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
             load_path, storage_options=self._storage_options, **self._load_args
         )
 
-    def _save(self, data: pd.DataFrame) -> None:
+    def save(self, data: pd.DataFrame) -> None:
         save_path = get_filepath_str(self._get_save_path(), self._protocol)
 
         if Path(save_path).is_dir():

--- a/kedro-datasets/kedro_datasets/pandas/sql_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/sql_dataset.py
@@ -262,10 +262,10 @@ class SQLTableDataset(AbstractDataset[pd.DataFrame, pd.DataFrame]):
             "save_args": save_args,
         }
 
-    def _load(self) -> pd.DataFrame:
+    def load(self) -> pd.DataFrame:
         return pd.read_sql_table(con=self.engine, **self._load_args)
 
-    def _save(self, data: pd.DataFrame) -> None:
+    def save(self, data: pd.DataFrame) -> None:
         data.to_sql(con=self.engine, **self._save_args)
 
     def _exists(self) -> bool:
@@ -560,7 +560,7 @@ class SQLQueryDataset(AbstractDataset[None, pd.DataFrame]):
             "execution_options": str(self._execution_options),
         }
 
-    def _load(self) -> pd.DataFrame:
+    def load(self) -> pd.DataFrame:
         load_args = copy.deepcopy(self._load_args)
 
         if self._filepath:
@@ -572,7 +572,7 @@ class SQLQueryDataset(AbstractDataset[None, pd.DataFrame]):
             con=self.engine.execution_options(**self._execution_options), **load_args
         )
 
-    def _save(self, data: None) -> NoReturn:
+    def save(self, data: None) -> NoReturn:
         raise DatasetError("'save' is not supported on SQLQueryDataset")
 
     # For mssql only

--- a/kedro-datasets/kedro_datasets/pandas/xml_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/xml_dataset.py
@@ -140,7 +140,7 @@ class XMLDataset(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
             "version": self._version,
         }
 
-    def _load(self) -> pd.DataFrame:
+    def load(self) -> pd.DataFrame:
         load_path = str(self._get_load_path())
         if self._protocol == "file":
             # file:// protocol seems to misbehave on Windows
@@ -154,7 +154,7 @@ class XMLDataset(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
             load_path, storage_options=self._storage_options, **self._load_args
         )
 
-    def _save(self, data: pd.DataFrame) -> None:
+    def save(self, data: pd.DataFrame) -> None:
         save_path = get_filepath_str(self._get_save_path(), self._protocol)
 
         with self._fs.open(save_path, **self._fs_open_args_save) as fs_file:

--- a/kedro-datasets/kedro_datasets/partitions/incremental_dataset.py
+++ b/kedro-datasets/kedro_datasets/partitions/incremental_dataset.py
@@ -215,7 +215,7 @@ class IncrementalDataset(PartitionedDataset):
         except DatasetError:
             return None
 
-    def _load(self) -> dict[str, Callable[[], Any]]:
+    def load(self) -> dict[str, Callable[[], Any]]:
         partitions: dict[str, Any] = {}
 
         for partition in self._list_partitions():

--- a/kedro-datasets/kedro_datasets/partitions/partitioned_dataset.py
+++ b/kedro-datasets/kedro_datasets/partitions/partitioned_dataset.py
@@ -284,7 +284,7 @@ class PartitionedDataset(AbstractDataset[dict[str, Any], dict[str, Callable[[], 
             path = path[: -len(self._filename_suffix)]
         return path
 
-    def _load(self) -> dict[str, Callable[[], Any]]:
+    def load(self) -> dict[str, Callable[[], Any]]:
         partitions = {}
 
         for partition in self._list_partitions():
@@ -300,7 +300,7 @@ class PartitionedDataset(AbstractDataset[dict[str, Any], dict[str, Callable[[], 
 
         return partitions
 
-    def _save(self, data: dict[str, Any]) -> None:
+    def save(self, data: dict[str, Any]) -> None:
         if self._overwrite and self._filesystem.exists(self._normalized_path):
             self._filesystem.rm(self._normalized_path, recursive=True)
 

--- a/kedro-datasets/kedro_datasets/pickle/pickle_dataset.py
+++ b/kedro-datasets/kedro_datasets/pickle/pickle_dataset.py
@@ -215,14 +215,14 @@ class PickleDataset(AbstractVersionedDataset[Any, Any]):
             "version": self._version,
         }
 
-    def _load(self) -> Any:
+    def load(self) -> Any:
         load_path = get_filepath_str(self._get_load_path(), self._protocol)
 
         with self._fs.open(load_path, **self._fs_open_args_load) as fs_file:
             imported_backend = importlib.import_module(self._backend)
             return imported_backend.load(fs_file, **self._load_args)  # type: ignore
 
-    def _save(self, data: Any) -> None:
+    def save(self, data: Any) -> None:
         save_path = get_filepath_str(self._get_save_path(), self._protocol)
 
         with self._fs.open(save_path, **self._fs_open_args_save) as fs_file:

--- a/kedro-datasets/kedro_datasets/pillow/image_dataset.py
+++ b/kedro-datasets/kedro_datasets/pillow/image_dataset.py
@@ -125,13 +125,13 @@ class ImageDataset(AbstractVersionedDataset[Image.Image, Image.Image]):
             "version": self._version,
         }
 
-    def _load(self) -> Image.Image:
+    def load(self) -> Image.Image:
         load_path = get_filepath_str(self._get_load_path(), self._protocol)
 
         with self._fs.open(load_path, **self._fs_open_args_load) as fs_file:
             return Image.open(fs_file).copy()
 
-    def _save(self, data: Image.Image) -> None:
+    def save(self, data: Image.Image) -> None:
         save_path = self._get_save_path()
 
         with self._fs.open(

--- a/kedro-datasets/kedro_datasets/plotly/html_dataset.py
+++ b/kedro-datasets/kedro_datasets/plotly/html_dataset.py
@@ -129,10 +129,10 @@ class HTMLDataset(
             "version": self._version,
         }
 
-    def _load(self) -> NoReturn:
+    def load(self) -> NoReturn:
         raise DatasetError(f"Loading not supported for '{self.__class__.__name__}'")
 
-    def _save(self, data: go.Figure) -> None:
+    def save(self, data: go.Figure) -> None:
         save_path = get_filepath_str(self._get_save_path(), self._protocol)
 
         with self._fs.open(save_path, **self._fs_open_args_save) as fs_file:

--- a/kedro-datasets/kedro_datasets/plotly/json_dataset.py
+++ b/kedro-datasets/kedro_datasets/plotly/json_dataset.py
@@ -145,7 +145,7 @@ class JSONDataset(
             "version": self._version,
         }
 
-    def _load(self) -> go.Figure | go.FigureWidget:
+    def load(self) -> go.Figure | go.FigureWidget:
         load_path = get_filepath_str(self._get_load_path(), self._protocol)
 
         with self._fs.open(load_path, **self._fs_open_args_load) as fs_file:
@@ -153,7 +153,7 @@ class JSONDataset(
             # the file, decode it manually and pass to the low-level from_json instead.
             return pio.from_json(str(fs_file.read(), "utf-8"), **self._load_args)
 
-    def _save(self, data: go.Figure) -> None:
+    def save(self, data: go.Figure) -> None:
         save_path = get_filepath_str(self._get_save_path(), self._protocol)
 
         with self._fs.open(save_path, **self._fs_open_args_save) as fs_file:

--- a/kedro-datasets/kedro_datasets/plotly/plotly_dataset.py
+++ b/kedro-datasets/kedro_datasets/plotly/plotly_dataset.py
@@ -149,9 +149,9 @@ class PlotlyDataset(JSONDataset):
     def _describe(self) -> dict[str, Any]:
         return {**super()._describe(), "plotly_args": self._plotly_args}
 
-    def _save(self, data: pd.DataFrame) -> None:
+    def save(self, data: pd.DataFrame) -> None:
         fig = self._plot_dataframe(data)
-        super()._save(fig)
+        super().save.__wrapped__(self, fig)  # type: ignore[attr-defined]
 
     def _plot_dataframe(self, data: pd.DataFrame) -> go.Figure:
         plot_type = self._plotly_args.get("type")

--- a/kedro-datasets/kedro_datasets/polars/csv_dataset.py
+++ b/kedro-datasets/kedro_datasets/polars/csv_dataset.py
@@ -163,7 +163,7 @@ class CSVDataset(AbstractVersionedDataset[pl.DataFrame, pl.DataFrame]):
             "version": self._version,
         }
 
-    def _load(self) -> pl.DataFrame:
+    def load(self) -> pl.DataFrame:
         load_path = str(self._get_load_path())
         if self._protocol == "file":
             # file:// protocol seems to misbehave on Windows
@@ -177,7 +177,7 @@ class CSVDataset(AbstractVersionedDataset[pl.DataFrame, pl.DataFrame]):
             load_path, storage_options=self._storage_options, **self._load_args
         )
 
-    def _save(self, data: pl.DataFrame) -> None:
+    def save(self, data: pl.DataFrame) -> None:
         save_path = get_filepath_str(self._get_save_path(), self._protocol)
 
         with self._fs.open(save_path, **self._fs_open_args_save) as fs_file:

--- a/kedro-datasets/kedro_datasets/polars/eager_polars_dataset.py
+++ b/kedro-datasets/kedro_datasets/polars/eager_polars_dataset.py
@@ -145,7 +145,7 @@ class EagerPolarsDataset(AbstractVersionedDataset[pl.DataFrame, pl.DataFrame]):
         self._fs_open_args_load = _fs_open_args_load
         self._fs_open_args_save = _fs_open_args_save
 
-    def _load(self) -> pl.DataFrame:
+    def load(self) -> pl.DataFrame:
         load_path = get_filepath_str(self._get_load_path(), self._protocol)
         load_method = getattr(pl, f"read_{self._file_format}", None)
 
@@ -160,7 +160,7 @@ class EagerPolarsDataset(AbstractVersionedDataset[pl.DataFrame, pl.DataFrame]):
         with self._fs.open(load_path, **self._fs_open_args_load) as fs_file:
             return load_method(fs_file, **self._load_args)
 
-    def _save(self, data: pl.DataFrame) -> None:
+    def save(self, data: pl.DataFrame) -> None:
         save_path = get_filepath_str(self._get_save_path(), self._protocol)
         save_method = getattr(data, f"write_{self._file_format}", None)
 

--- a/kedro-datasets/kedro_datasets/polars/lazy_polars_dataset.py
+++ b/kedro-datasets/kedro_datasets/polars/lazy_polars_dataset.py
@@ -195,7 +195,7 @@ class LazyPolarsDataset(AbstractVersionedDataset[pl.LazyFrame, PolarsFrame]):
             "version": self._version,
         }
 
-    def _load(self) -> pl.LazyFrame:
+    def load(self) -> pl.LazyFrame:
         load_path = str(self._get_load_path())
 
         if self._protocol == "file":
@@ -209,7 +209,7 @@ class LazyPolarsDataset(AbstractVersionedDataset[pl.LazyFrame, PolarsFrame]):
         )
         return pl.scan_pyarrow_dataset(dataset)
 
-    def _save(self, data: pl.DataFrame | pl.LazyFrame) -> None:
+    def save(self, data: pl.DataFrame | pl.LazyFrame) -> None:
         save_path = get_filepath_str(self._get_save_path(), self._protocol)
 
         collected_data = None

--- a/kedro-datasets/kedro_datasets/redis/redis_dataset.py
+++ b/kedro-datasets/kedro_datasets/redis/redis_dataset.py
@@ -166,7 +166,7 @@ class PickleDataset(AbstractDataset[Any, Any]):
 
     # `redis_db` mypy does not work since it is optional and optional is not
     # accepted by pickle.loads.
-    def _load(self) -> Any:
+    def load(self) -> Any:
         if not self.exists():
             raise DatasetError(f"The provided key {self._key} does not exists.")
         imported_backend = importlib.import_module(self._backend)
@@ -174,7 +174,7 @@ class PickleDataset(AbstractDataset[Any, Any]):
             self._redis_db.get(self._key), **self._load_args
         )  # type: ignore
 
-    def _save(self, data: Any) -> None:
+    def save(self, data: Any) -> None:
         try:
             imported_backend = importlib.import_module(self._backend)
             self._redis_db.set(

--- a/kedro-datasets/kedro_datasets/snowflake/snowpark_dataset.py
+++ b/kedro-datasets/kedro_datasets/snowflake/snowpark_dataset.py
@@ -209,7 +209,7 @@ class SnowparkTableDataset(AbstractDataset):
     def _session(self) -> sp.Session:
         return self._get_session(self._connection_parameters)
 
-    def _load(self) -> sp.DataFrame:
+    def load(self) -> sp.DataFrame:
         table_name: list = [
             self._database,
             self._schema,
@@ -219,7 +219,7 @@ class SnowparkTableDataset(AbstractDataset):
         sp_df = self._session.table(".".join(table_name))
         return sp_df
 
-    def _save(self, data: sp.DataFrame) -> None:
+    def save(self, data: sp.DataFrame) -> None:
         table_name = [
             self._database,
             self._schema,

--- a/kedro-datasets/kedro_datasets/spark/deltatable_dataset.py
+++ b/kedro-datasets/kedro_datasets/spark/deltatable_dataset.py
@@ -87,11 +87,11 @@ class DeltaTableDataset(AbstractDataset[None, DeltaTable]):
         self._filepath = PurePosixPath(filepath)
         self.metadata = metadata
 
-    def _load(self) -> DeltaTable:
+    def load(self) -> DeltaTable:
         load_path = self._fs_prefix + str(self._filepath)
         return DeltaTable.forPath(_get_spark(), load_path)
 
-    def _save(self, data: None) -> NoReturn:
+    def save(self, data: None) -> NoReturn:
         raise DatasetError(f"{self.__class__.__name__} is a read only dataset type")
 
     def _exists(self) -> bool:

--- a/kedro-datasets/kedro_datasets/spark/spark_dataset.py
+++ b/kedro-datasets/kedro_datasets/spark/spark_dataset.py
@@ -413,7 +413,7 @@ class SparkDataset(AbstractVersionedDataset[DataFrame, DataFrame]):
             "version": self._version,
         }
 
-    def _load(self) -> DataFrame:
+    def load(self) -> DataFrame:
         load_path = _strip_dbfs_prefix(self._fs_prefix + str(self._get_load_path()))
         read_obj = _get_spark().read
 
@@ -423,7 +423,7 @@ class SparkDataset(AbstractVersionedDataset[DataFrame, DataFrame]):
 
         return read_obj.load(load_path, self._file_format, **self._load_args)
 
-    def _save(self, data: DataFrame) -> None:
+    def save(self, data: DataFrame) -> None:
         save_path = _strip_dbfs_prefix(self._fs_prefix + str(self._get_save_path()))
         data.write.save(save_path, self._file_format, **self._save_args)
 

--- a/kedro-datasets/kedro_datasets/spark/spark_hive_dataset.py
+++ b/kedro-datasets/kedro_datasets/spark/spark_hive_dataset.py
@@ -148,14 +148,14 @@ class SparkHiveDataset(AbstractDataset[DataFrame, DataFrame]):
             **self._save_args,
         )
 
-    def _load(self) -> DataFrame:
+    def load(self) -> DataFrame:
         return _get_spark().read.table(self._full_table_address)
 
-    def _save(self, data: DataFrame) -> None:
+    def save(self, data: DataFrame) -> None:
         self._validate_save(data)
         if self._write_mode == "upsert":
             # check if _table_pk is a subset of df columns
-            if not set(self._table_pk) <= set(self._load().columns):
+            if not set(self._table_pk) <= set(self.load.__wrapped__(self).columns):  # type: ignore[attr-defined]
                 raise DatasetError(
                     f"Columns {str(self._table_pk)} selected as primary key(s) not found in "
                     f"table {self._full_table_address}"
@@ -165,13 +165,13 @@ class SparkHiveDataset(AbstractDataset[DataFrame, DataFrame]):
             self._create_hive_table(data=data)
 
     def _upsert_save(self, data: DataFrame) -> None:
-        if not self._exists() or self._load().rdd.isEmpty():
+        if not self._exists() or self.load.__wrapped__(self).rdd.isEmpty():  # type: ignore[attr-defined]
             self._create_hive_table(data=data, mode="overwrite")
         else:
             _tmp_colname = "tmp_colname"
             _tmp_row = "tmp_row"
             _w = Window.partitionBy(*self._table_pk).orderBy(col(_tmp_colname).desc())
-            df_old = self._load().select("*", lit(1).alias(_tmp_colname))
+            df_old = self.load.__wrapped__(self).select("*", lit(1).alias(_tmp_colname))  # type: ignore[attr-defined]
             df_new = data.select("*", lit(2).alias(_tmp_colname))
             df_stacked = df_new.unionByName(df_old).select(
                 "*", row_number().over(_w).alias(_tmp_row)
@@ -188,7 +188,7 @@ class SparkHiveDataset(AbstractDataset[DataFrame, DataFrame]):
         # or if the `write_mode` is set to overwrite
         if (not self._exists()) or self._write_mode == "overwrite":
             return
-        hive_dtypes = set(self._load().dtypes)
+        hive_dtypes = set(self.load.__wrapped__(self).dtypes)  # type: ignore[attr-defined]
         data_dtypes = set(data.dtypes)
         if data_dtypes != hive_dtypes:
             new_cols = data_dtypes - hive_dtypes

--- a/kedro-datasets/kedro_datasets/spark/spark_jdbc_dataset.py
+++ b/kedro-datasets/kedro_datasets/spark/spark_jdbc_dataset.py
@@ -166,8 +166,8 @@ class SparkJDBCDataset(AbstractDataset[DataFrame, DataFrame]):
             "save_args": save_args,
         }
 
-    def _load(self) -> DataFrame:
+    def load(self) -> DataFrame:
         return _get_spark().read.jdbc(self._url, self._table, **self._load_args)
 
-    def _save(self, data: DataFrame) -> None:
+    def save(self, data: DataFrame) -> None:
         return data.write.jdbc(self._url, self._table, **self._save_args)

--- a/kedro-datasets/kedro_datasets/spark/spark_streaming_dataset.py
+++ b/kedro-datasets/kedro_datasets/spark/spark_streaming_dataset.py
@@ -104,7 +104,7 @@ class SparkStreamingDataset(AbstractDataset):
             "save_args": self._save_args,
         }
 
-    def _load(self) -> DataFrame:
+    def load(self) -> DataFrame:
         """Loads data from filepath.
         If the connector type is kafka then no file_path is required, schema needs to be
         seperated from load_args.
@@ -120,7 +120,7 @@ class SparkStreamingDataset(AbstractDataset):
         )
         return data_stream_reader.load(load_path)
 
-    def _save(self, data: DataFrame) -> None:
+    def save(self, data: DataFrame) -> None:
         """Saves pyspark dataframe.
         Args:
             data: PySpark streaming dataframe for saving

--- a/kedro-datasets/kedro_datasets/svmlight/svmlight_dataset.py
+++ b/kedro-datasets/kedro_datasets/svmlight/svmlight_dataset.py
@@ -174,12 +174,12 @@ class SVMLightDataset(AbstractVersionedDataset[_DI, _DO]):
             "version": self._version,
         }
 
-    def _load(self) -> _DO:
+    def load(self) -> _DO:
         load_path = get_filepath_str(self._get_load_path(), self._protocol)
         with self._fs.open(load_path, **self._fs_open_args_load) as fs_file:
             return load_svmlight_file(fs_file, **self._load_args)
 
-    def _save(self, data: _DI) -> None:
+    def save(self, data: _DI) -> None:
         save_path = get_filepath_str(self._get_save_path(), self._protocol)
         with self._fs.open(save_path, **self._fs_open_args_save) as fs_file:
             dump_svmlight_file(data[0], data[1], fs_file, **self._save_args)

--- a/kedro-datasets/kedro_datasets/tensorflow/tensorflow_model_dataset.py
+++ b/kedro-datasets/kedro_datasets/tensorflow/tensorflow_model_dataset.py
@@ -134,7 +134,7 @@ class TensorFlowModelDataset(AbstractVersionedDataset[tf.keras.Model, tf.keras.M
 
         self._is_h5 = self._save_args.get("save_format") == "h5"
 
-    def _load(self) -> tf.keras.Model:
+    def load(self) -> tf.keras.Model:
         load_path = get_filepath_str(self._get_load_path(), self._protocol)
 
         with tempfile.TemporaryDirectory(prefix=self._tmp_prefix) as tempdir:
@@ -155,7 +155,7 @@ class TensorFlowModelDataset(AbstractVersionedDataset[tf.keras.Model, tf.keras.M
                 model = tf.keras.models.load_model(path, **self._load_args)
             return model
 
-    def _save(self, data: tf.keras.Model) -> None:
+    def save(self, data: tf.keras.Model) -> None:
         save_path = get_filepath_str(self._get_save_path(), self._protocol)
 
         with tempfile.TemporaryDirectory(prefix=self._tmp_prefix) as tempdir:

--- a/kedro-datasets/kedro_datasets/text/text_dataset.py
+++ b/kedro-datasets/kedro_datasets/text/text_dataset.py
@@ -124,13 +124,13 @@ class TextDataset(AbstractVersionedDataset[str, str]):
             "version": self._version,
         }
 
-    def _load(self) -> str:
+    def load(self) -> str:
         load_path = get_filepath_str(self._get_load_path(), self._protocol)
 
         with self._fs.open(load_path, **self._fs_open_args_load) as fs_file:
             return fs_file.read()
 
-    def _save(self, data: str) -> None:
+    def save(self, data: str) -> None:
         save_path = get_filepath_str(self._get_save_path(), self._protocol)
 
         with self._fs.open(save_path, **self._fs_open_args_save) as fs_file:

--- a/kedro-datasets/kedro_datasets/tracking/json_dataset.py
+++ b/kedro-datasets/kedro_datasets/tracking/json_dataset.py
@@ -45,7 +45,7 @@ class JSONDataset(json_dataset.JSONDataset):
 
     versioned = True
 
-    def _load(self) -> NoReturn:
+    def load(self) -> NoReturn:
         raise DatasetError(f"Loading not supported for '{self.__class__.__name__}'")
 
     def preview(self) -> JSONTrackingPreview:  # type: ignore[override]

--- a/kedro-datasets/kedro_datasets/tracking/metrics_dataset.py
+++ b/kedro-datasets/kedro_datasets/tracking/metrics_dataset.py
@@ -46,10 +46,10 @@ class MetricsDataset(json_dataset.JSONDataset):
 
     versioned = True
 
-    def _load(self) -> NoReturn:
+    def load(self) -> NoReturn:
         raise DatasetError(f"Loading not supported for '{self.__class__.__name__}'")
 
-    def _save(self, data: dict[str, float]) -> None:
+    def save(self, data: dict[str, float]) -> None:
         """Converts all values in the data from a ``MetricsDataset`` to float to make sure
         they are numeric values which can be displayed in Kedro Viz and then saves the dataset.
         """

--- a/kedro-datasets/kedro_datasets/video/video_dataset.py
+++ b/kedro-datasets/kedro_datasets/video/video_dataset.py
@@ -302,7 +302,7 @@ class VideoDataset(AbstractDataset[AbstractVideo, AbstractVideo]):
         self._fs = fsspec.filesystem(self._protocol, **self._storage_options)
         self.metadata = metadata
 
-    def _load(self) -> AbstractVideo:
+    def load(self) -> AbstractVideo:
         """Loads data from the video file.
 
         Returns:
@@ -315,7 +315,7 @@ class VideoDataset(AbstractDataset[AbstractVideo, AbstractVideo]):
         ) as fs_file:
             return FileVideo(fs_file.name)
 
-    def _save(self, data: AbstractVideo) -> None:
+    def save(self, data: AbstractVideo) -> None:
         """Saves video data to the specified filepath."""
         if self._protocol == "file":
             # Write directly to the local file destination

--- a/kedro-datasets/kedro_datasets/yaml/yaml_dataset.py
+++ b/kedro-datasets/kedro_datasets/yaml/yaml_dataset.py
@@ -134,13 +134,13 @@ class YAMLDataset(AbstractVersionedDataset[dict, dict]):
             "version": self._version,
         }
 
-    def _load(self) -> dict:
+    def load(self) -> dict:
         load_path = get_filepath_str(self._get_load_path(), self._protocol)
 
         with self._fs.open(load_path, **self._fs_open_args_load) as fs_file:
             return yaml.safe_load(fs_file)
 
-    def _save(self, data: dict) -> None:
+    def save(self, data: dict) -> None:
         save_path = get_filepath_str(self._get_save_path(), self._protocol)
         with self._fs.open(save_path, **self._fs_open_args_save) as fs_file:
             yaml.dump(data, fs_file, **self._save_args)
@@ -171,6 +171,6 @@ class YAMLDataset(AbstractVersionedDataset[dict, dict]):
         Returns:
             A string representing the YAML data for previewing.
         """
-        data = self._load()
+        data = self.load.__wrapped__(self)  # type: ignore[attr-defined]
 
         return JSONPreview(json.dumps(data))

--- a/kedro-datasets/kedro_datasets_experimental/langchain/_anthropic.py
+++ b/kedro-datasets/kedro_datasets_experimental/langchain/_anthropic.py
@@ -40,13 +40,13 @@ class ChatAnthropicDataset(AbstractDataset[None, ChatAnthropic]):
         >>> from kedro_datasets_experimental.langchain import ChatAnthropicDataset
         >>> llm = ChatAnthropicDataset(
         ...     credentials={
-        ...         "anthropic_api_url": "xxx"
+        ...         "anthropic_api_url": "xxx",
         ...         "anthropic_api_key": "xxx",
         ...     },
         ...     kwargs={
         ...         "model": "claude-instant-1",
         ...         "temperature": 0.0,
-        ...     }
+        ...     },
         ... ).load()
         >>>
         >>> # See: https://python.langchain.com/docs/integrations/chat/anthropic
@@ -67,10 +67,10 @@ class ChatAnthropicDataset(AbstractDataset[None, ChatAnthropic]):
     def _describe(self) -> dict[str, Any]:
         return {**self.kwargs}
 
-    def _save(self, data: None) -> NoReturn:
+    def save(self, data: None) -> NoReturn:
         raise DatasetError(f"{self.__class__.__name__} is a read only data set type")
 
-    def _load(self) -> ChatAnthropic:
+    def load(self) -> ChatAnthropic:
         return ChatAnthropic(
             anthropic_api_url=self.anthropic_api_url,
             anthropic_api_key=self.anthropic_api_key,

--- a/kedro-datasets/kedro_datasets_experimental/langchain/_cohere.py
+++ b/kedro-datasets/kedro_datasets_experimental/langchain/_cohere.py
@@ -48,7 +48,7 @@ class ChatCohereDataset(AbstractDataset[None, ChatCohere]):
         ...     kwargs={
         ...         "model": "command",
         ...         "temperature": 0.0,
-        ...     }
+        ...     },
         ... ).load()
         >>>
         >>> # See: https://python.langchain.com/v0.1/docs/integrations/chat/cohere/
@@ -69,8 +69,8 @@ class ChatCohereDataset(AbstractDataset[None, ChatCohere]):
     def _describe(self) -> dict[str, Any]:
         return {**self.kwargs}
 
-    def _save(self, data: None) -> NoReturn:
+    def save(self, data: None) -> NoReturn:
         raise DatasetError(f"{self.__class__.__name__} is a read only data set type")
 
-    def _load(self) -> ChatCohere:
+    def load(self) -> ChatCohere:
         return ChatCohere(cohere_api_key=self.cohere_api_key, base_url=self.cohere_api_url, **self.kwargs)

--- a/kedro-datasets/kedro_datasets_experimental/langchain/_openai.py
+++ b/kedro-datasets/kedro_datasets_experimental/langchain/_openai.py
@@ -31,10 +31,10 @@ class OpenAIDataset(AbstractDataset[None, OPENAI_TYPE], Generic[OPENAI_TYPE]):
     def _describe(self) -> dict[str, Any]:
         return {**self.kwargs}
 
-    def _save(self, data: None) -> NoReturn:
+    def save(self, data: None) -> NoReturn:
         raise DatasetError(f"{self.__class__.__name__} is a read only data set type")
 
-    def _load(self) -> OPENAI_TYPE:
+    def load(self) -> OPENAI_TYPE:
         return self.constructor(
             openai_api_base=self.openai_api_base,
             openai_api_key=self.openai_api_key,

--- a/kedro-datasets/kedro_datasets_experimental/netcdf/netcdf_dataset.py
+++ b/kedro-datasets/kedro_datasets_experimental/netcdf/netcdf_dataset.py
@@ -137,7 +137,7 @@ class NetCDFDataset(AbstractDataset):
             True if "*" in str(PurePosixPath(self._filepath).stem) else False
         )
 
-    def _load(self) -> xr.Dataset:
+    def load(self) -> xr.Dataset:
         load_path = self._filepath
         multi_load_path = load_path
 
@@ -159,7 +159,7 @@ class NetCDFDataset(AbstractDataset):
 
         return data
 
-    def _save(self, data: xr.Dataset):
+    def save(self, data: xr.Dataset):
         if self._is_multifile:
             raise DatasetError(
                 "Globbed multifile datasets with '*' in filepath cannot be saved. "

--- a/kedro-datasets/kedro_datasets_experimental/prophet/prophet_dataset.py
+++ b/kedro-datasets/kedro_datasets_experimental/prophet/prophet_dataset.py
@@ -96,7 +96,7 @@ class ProphetModelDataset(JSONDataset):
             metadata=metadata,
         )
 
-    def _load(self) -> Prophet:
+    def load(self) -> Prophet:
         """Loads a Prophet model from a JSON file.
 
         Returns:
@@ -107,7 +107,7 @@ class ProphetModelDataset(JSONDataset):
         with self._fs.open(load_path, **self._fs_open_args_load) as fs_file:
             return model_from_json(fs_file.read())
 
-    def _save(self, data: Prophet) -> None:
+    def save(self, data: Prophet) -> None:
         """Saves a Prophet model to a JSON file.
 
         Args:

--- a/kedro-datasets/kedro_datasets_experimental/pytorch/pytorch_dataset.py
+++ b/kedro-datasets/kedro_datasets_experimental/pytorch/pytorch_dataset.py
@@ -94,11 +94,11 @@ class PyTorchDataset(AbstractVersionedDataset[Any, Any]):
             "version": self._version,
         }
 
-    def _load(self) -> Any:
+    def load(self) -> Any:
         load_path = get_filepath_str(self._get_load_path(), self._protocol)
         return torch.load(load_path, **self._fs_open_args_load)  #nosec: B614
 
-    def _save(self, data: torch.nn.Module) -> None:
+    def save(self, data: torch.nn.Module) -> None:
         save_path = get_filepath_str(self._get_save_path(), self._protocol)
         torch.save(data.state_dict(), save_path, **self._fs_open_args_save)  #nosec: B614
 

--- a/kedro-datasets/kedro_datasets_experimental/rioxarray/geotiff_dataset.py
+++ b/kedro-datasets/kedro_datasets_experimental/rioxarray/geotiff_dataset.py
@@ -50,7 +50,7 @@ class GeoTIFFDataset(AbstractVersionedDataset[xarray.DataArray, xarray.DataArray
         >>> data = xr.DataArray(
         ...     np.random.randn(2, 3, 2),
         ...     dims=("band", "y", "x"),
-        ...     coords={"band": [1, 2], "y": [0.5, 1.5, 2.5], "x": [0.5, 1.5]}
+        ...     coords={"band": [1, 2], "y": [0.5, 1.5, 2.5], "x": [0.5, 1.5]},
         ... )
         >>> data_crs = data.rio.write_crs("epsg:4326")
         >>> data_spatial_dims = data_crs.rio.set_spatial_dims("x", "y")
@@ -117,7 +117,7 @@ class GeoTIFFDataset(AbstractVersionedDataset[xarray.DataArray, xarray.DataArray
             "version": self._version,
         }
 
-    def _load(self) -> xarray.DataArray:
+    def load(self) -> xarray.DataArray:
         load_path = self._get_load_path().as_posix()
         with rasterio.open(load_path) as data:
             tags = data.tags()
@@ -127,7 +127,7 @@ class GeoTIFFDataset(AbstractVersionedDataset[xarray.DataArray, xarray.DataArray
         logger.info(f"found coordinate rerence system {data.rio.crs}")
         return data
 
-    def _save(self, data: xarray.DataArray) -> None:
+    def save(self, data: xarray.DataArray) -> None:
         self._sanity_check(data)
         save_path = get_filepath_str(self._get_save_path(), self._protocol)
         if not save_path.endswith(tuple(SUPPORTED_FILE_FORMATS)):

--- a/kedro-datasets/pyproject.toml
+++ b/kedro-datasets/pyproject.toml
@@ -11,7 +11,7 @@ description = "Kedro-Datasets is where you can find all of Kedro's data connecto
 requires-python = ">=3.9"
 license = {text = "Apache Software License (Apache 2.0)"}
 dependencies = [
-    "kedro>=0.19",
+    "kedro>=0.19.7",
     "lazy_loader",
 ]
 dynamic = ["readme", "version"]

--- a/kedro-datasets/tests/api/test_api_dataset.py
+++ b/kedro-datasets/tests/api/test_api_dataset.py
@@ -301,7 +301,7 @@ class TestAPIDataset:
                 status_code=requests.codes.ok,
                 json=json_callback,
             )
-            response = api_dataset._save(data)
+            response = api_dataset.save.__wrapped__(api_dataset, data)
             assert isinstance(response, requests.Response)
             assert response.json() == TEST_SAVE_DATA
 
@@ -312,7 +312,7 @@ class TestAPIDataset:
                 save_args={"params": TEST_PARAMS, "headers": TEST_HEADERS},
             )
             with pytest.raises(DatasetError, match="Use PUT or POST methods for save"):
-                api_dataset._save(TEST_SAVE_DATA)
+                api_dataset.save.__wrapped__(api_dataset, TEST_SAVE_DATA)
         else:
             with pytest.raises(
                 ValueError,
@@ -343,16 +343,16 @@ class TestAPIDataset:
             headers=TEST_HEADERS,
             json=json_callback,
         )
-        response_list = api_dataset._save(TEST_SAVE_DATA)
+        response_list = api_dataset.save.__wrapped__(api_dataset, TEST_SAVE_DATA)
         assert isinstance(response_list, requests.Response)
         # check that the data was sent in the correct format
         assert response_list.json() == TEST_SAVE_DATA
 
-        response_dict = api_dataset._save({"item1": "key1"})
+        response_dict = api_dataset.save.__wrapped__(api_dataset, {"item1": "key1"})
         assert isinstance(response_dict, requests.Response)
         assert response_dict.json() == {"item1": "key1"}
 
-        response_json = api_dataset._save(TEST_SAVE_DATA[0])
+        response_json = api_dataset.save.__wrapped__(api_dataset, TEST_SAVE_DATA[0])
         assert isinstance(response_json, requests.Response)
         assert response_json.json() == TEST_SAVE_DATA[0]
 

--- a/kedro-datasets/tests/partitions/test_incremental_dataset.py
+++ b/kedro-datasets/tests/partitions/test_incremental_dataset.py
@@ -49,10 +49,10 @@ class DummyDataset(AbstractDataset):  # pragma: no cover
     def _describe(self) -> dict[str, Any]:
         return {"dummy": True}
 
-    def _load(self) -> Any:
+    def load(self) -> Any:
         pass
 
-    def _save(self, data: Any) -> None:
+    def save(self, data: Any) -> None:
         pass
 
 


### PR DESCRIPTION
## Description
Take advantage of the ability to define public `load` and `save` methods.

Also resolves #793 

## Development notes
This is not compatible with Kedro before 0.19.7.

If Kedro-Datasets required `kedro>=0.18` or something before this, I'd be more concerned about bumping the lower bound; right now, it's just a minor bump.

## Checklist

- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
