### PR TITLE
fix(telemetry): Set default identity value

### DIFF
--- a/kedro-telemetry/kedro_telemetry/plugin.py
+++ b/kedro-telemetry/kedro_telemetry/plugin.py
@@ -49,6 +49,7 @@ TIMESTAMP_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
 CONFIG_FILENAME = "telemetry.toml"
 PYPROJECT_CONFIG_NAME = "pyproject.toml"
 UNDEFINED_PACKAGE_NAME = "undefined_package_name"
+MISSING_USER_IDENTITY = "missing_user_identity"
 
 logger = logging.getLogger(__name__)
 
@@ -240,7 +241,7 @@ class KedroTelemetryHook:
         try:
             _send_heap_event(
                 event_name=event_name,
-                identity=self._user_uuid,
+                identity=self._user_uuid if self._user_uuid else MISSING_USER_IDENTITY,
                 properties=self._event_properties,
             )
             self._sent = True
@@ -323,9 +324,8 @@ def _send_heap_event(
         "event": event_name,
         "timestamp": datetime.now().strftime(TIMESTAMP_FORMAT),
         "properties": properties or {},
+        "identity": identity,
     }
-    if identity:
-        data["identity"] = identity
 
     try:
         resp = requests.post(

--- a/kedro-telemetry/tests/test_plugin.py
+++ b/kedro-telemetry/tests/test_plugin.py
@@ -16,8 +16,8 @@ from kedro_telemetry import __version__ as TELEMETRY_VERSION
 from kedro_telemetry.plugin import (
     _SKIP_TELEMETRY_ENV_VAR_KEYS,
     KNOWN_CI_ENV_VAR_KEYS,
-    KedroTelemetryHook,
     MISSING_USER_IDENTITY,
+    KedroTelemetryHook,
     _check_for_telemetry_consent,
     _is_known_ci_env,
 )

--- a/kedro-telemetry/tests/test_plugin.py
+++ b/kedro-telemetry/tests/test_plugin.py
@@ -17,6 +17,7 @@ from kedro_telemetry.plugin import (
     _SKIP_TELEMETRY_ENV_VAR_KEYS,
     KNOWN_CI_ENV_VAR_KEYS,
     KedroTelemetryHook,
+    MISSING_USER_IDENTITY,
     _check_for_telemetry_consent,
     _is_known_ci_env,
 )
@@ -347,7 +348,7 @@ class TestKedroTelemetryHook:
         expected_calls = [
             mocker.call(
                 event_name="CLI command",
-                identity="",
+                identity=MISSING_USER_IDENTITY,
                 properties=generic_properties,
             ),
         ]


### PR DESCRIPTION
## Description
Solves https://github.com/kedro-org/kedro-plugins/issues/815

## Development notes
The `identity` parameter is mandatory when sending data to the heap. Not passing it or setting it to `""` or `None` causes the heap server to return `response code 400`.

The problem was that we used `identity=self._user_uuid`. If we failed to read/generate `user_uuid`, it was treated as an empty string, so passing it to `identity` caused `response code 400` when sending data to the server.

To handle the above case `MISSING_USER_IDENTITY` constant was added, which is used as a default value for the `identity` in case `user_uuid` is `""` or `None`.

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
