### PR TITLE
fix(datasets): Use `put()` and `get()` instead of `copy` in `TensorFlowModelDataset`'s `_save` and `_load` methods.

### DIFF
--- a/kedro-datasets/RELEASE.md
+++ b/kedro-datasets/RELEASE.md
@@ -14,13 +14,14 @@
 
 ## Bug fixes and other changes
 * Refactored all datasets to set `fs_args` defaults in the same way as `load_args` and `save_args` and not have hardcoded values in the save methods.
+* Fixed bug related to loading/saving models from/to remote storage using `TensorFlowModelDataset`.
 
 ## Breaking Changes
 ## Community contributions
 Many thanks to the following Kedroids for contributing PRs to this release:
 * [Brandon Meek](https://github.com/bpmeek)
 * [yury-fedotov](https://github.com/yury-fedotov)
-
+* [gitgud5000](https://github.com/gitgud5000)
 
 # Release 4.1.0
 ## Major features and improvements

--- a/kedro-datasets/kedro_datasets/tensorflow/tensorflow_model_dataset.py
+++ b/kedro-datasets/kedro_datasets/tensorflow/tensorflow_model_dataset.py
@@ -144,7 +144,7 @@ class TensorFlowModelDataset(AbstractVersionedDataset[tf.keras.Model, tf.keras.M
                 # We assume .keras
                 path = str(PurePath(tempdir) / TEMPORARY_KERAS_FILE)  # noqa: PLW2901
 
-            self._fs.copy(load_path, path)
+            self._fs.get(load_path, path)
 
             # Pass the local temporary directory/file path to keras.load_model
             device_name = self._load_args.pop("tf_device", None)
@@ -169,7 +169,7 @@ class TensorFlowModelDataset(AbstractVersionedDataset[tf.keras.Model, tf.keras.M
 
             # Use fsspec to take from local tempfile directory/file and
             # put in ArbitraryFileSystem
-            self._fs.copy(path, save_path)
+            self._fs.put(path, save_path)
 
     def _exists(self) -> bool:
         try:


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
This PR resolves the issue in [#839](https://github.com/kedro-org/kedro-plugins/issues/839), where saving `TensorFlowModelDataset` to Azure Blob Storage fails due to incorrect use of `.copy()` from the `fsspec.filesystem` interface.

## Development notes
<!-- What have you changed, and how has this been tested? -->
The issue occurs in the `_save` and `_load` methods on lines 147 and 172, where `.copy()` is used. According to the [fsspec documentation](https://filesystem-spec.readthedocs.io/en/latest/copying.html), `.copy()` is intended for remote-to-remote transfers. Since this involves copying from a local filesystem to remote storage, `.put()` should be used for saving and `.get()` for loading.

The code has been updated to use `.put()` and `.get()` accordingly, replacing the use of `.copy()`. 

Both methods work for local-to-local and local-to-remote(& vice versa) transfers based on testing.
## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
