### PR TITLE
ci(airflow): Replace type hints with CatalogProtocol

### DIFF
--- a/kedro-airflow/kedro_airflow/grouping.py
+++ b/kedro-airflow/kedro_airflow/grouping.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from kedro.io import DataCatalog
+from kedro.io import CatalogProtocol
 from kedro.pipeline.node import Node
 from kedro.pipeline.pipeline import Pipeline
 
@@ -11,7 +11,7 @@ def _is_memory_dataset(catalog, dataset_name: str) -> bool:
     return False
 
 
-def get_memory_datasets(catalog: DataCatalog, pipeline: Pipeline) -> set[str]:
+def get_memory_datasets(catalog: CatalogProtocol, pipeline: Pipeline) -> set[str]:
     """Gather all datasets in the pipeline that are of type MemoryDataset, excluding 'parameters'."""
     return {
         dataset_name
@@ -21,7 +21,7 @@ def get_memory_datasets(catalog: DataCatalog, pipeline: Pipeline) -> set[str]:
 
 
 def create_adjacency_list(
-    catalog: DataCatalog, pipeline: Pipeline
+    catalog: CatalogProtocol, pipeline: Pipeline
 ) -> tuple[dict[str, set], dict[str, set]]:
     """
     Builds adjacency list (adj_list) to search connected components - undirected graph,
@@ -48,7 +48,7 @@ def create_adjacency_list(
 
 
 def group_memory_nodes(
-    catalog: DataCatalog, pipeline: Pipeline
+    catalog: CatalogProtocol, pipeline: Pipeline
 ) -> tuple[dict[str, list[Node]], dict[str, list[str]]]:
     """
     Nodes that are connected through MemoryDatasets cannot be distributed across

--- a/kedro-airflow/kedro_airflow/grouping.py
+++ b/kedro-airflow/kedro_airflow/grouping.py
@@ -1,8 +1,15 @@
 from __future__ import annotations
 
-from kedro.io import CatalogProtocol
+from typing import Any
+
+from kedro.io import DataCatalog
 from kedro.pipeline.node import Node
 from kedro.pipeline.pipeline import Pipeline
+
+try:
+    from kedro.io import CatalogProtocol
+except ImportError:  # pragma: no cover
+    pass
 
 
 def _is_memory_dataset(catalog, dataset_name: str) -> bool:
@@ -11,7 +18,9 @@ def _is_memory_dataset(catalog, dataset_name: str) -> bool:
     return False
 
 
-def get_memory_datasets(catalog: CatalogProtocol, pipeline: Pipeline) -> set[str]:
+def get_memory_datasets(
+    catalog: CatalogProtocol[Any] | DataCatalog, pipeline: Pipeline
+) -> set[str]:
     """Gather all datasets in the pipeline that are of type MemoryDataset, excluding 'parameters'."""
     return {
         dataset_name
@@ -21,7 +30,7 @@ def get_memory_datasets(catalog: CatalogProtocol, pipeline: Pipeline) -> set[str
 
 
 def create_adjacency_list(
-    catalog: CatalogProtocol, pipeline: Pipeline
+    catalog: CatalogProtocol[Any] | DataCatalog, pipeline: Pipeline
 ) -> tuple[dict[str, set], dict[str, set]]:
     """
     Builds adjacency list (adj_list) to search connected components - undirected graph,
@@ -48,7 +57,7 @@ def create_adjacency_list(
 
 
 def group_memory_nodes(
-    catalog: CatalogProtocol, pipeline: Pipeline
+    catalog: CatalogProtocol[Any] | DataCatalog, pipeline: Pipeline
 ) -> tuple[dict[str, list[Node]], dict[str, list[str]]]:
     """
     Nodes that are connected through MemoryDatasets cannot be distributed across

--- a/kedro-airflow/kedro_airflow/grouping.py
+++ b/kedro-airflow/kedro_airflow/grouping.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Any
-
 from kedro.io import DataCatalog
 from kedro.pipeline.node import Node
 from kedro.pipeline.pipeline import Pipeline
@@ -19,7 +17,7 @@ def _is_memory_dataset(catalog, dataset_name: str) -> bool:
 
 
 def get_memory_datasets(
-    catalog: CatalogProtocol[Any] | DataCatalog, pipeline: Pipeline
+    catalog: CatalogProtocol | DataCatalog, pipeline: Pipeline
 ) -> set[str]:
     """Gather all datasets in the pipeline that are of type MemoryDataset, excluding 'parameters'."""
     return {
@@ -30,7 +28,7 @@ def get_memory_datasets(
 
 
 def create_adjacency_list(
-    catalog: CatalogProtocol[Any] | DataCatalog, pipeline: Pipeline
+    catalog: CatalogProtocol | DataCatalog, pipeline: Pipeline
 ) -> tuple[dict[str, set], dict[str, set]]:
     """
     Builds adjacency list (adj_list) to search connected components - undirected graph,
@@ -57,7 +55,7 @@ def create_adjacency_list(
 
 
 def group_memory_nodes(
-    catalog: CatalogProtocol[Any] | DataCatalog, pipeline: Pipeline
+    catalog: CatalogProtocol | DataCatalog, pipeline: Pipeline
 ) -> tuple[dict[str, list[Node]], dict[str, list[str]]]:
     """
     Nodes that are connected through MemoryDatasets cannot be distributed across

--- a/kedro-datasets/kedro_datasets_experimental/pytorch/pytorch_dataset.py
+++ b/kedro-datasets/kedro_datasets_experimental/pytorch/pytorch_dataset.py
@@ -96,11 +96,11 @@ class PyTorchDataset(AbstractVersionedDataset[Any, Any]):
 
     def _load(self) -> Any:
         load_path = get_filepath_str(self._get_load_path(), self._protocol)
-        return torch.load(load_path, **self._fs_open_args_load)
+        return torch.load(load_path, **self._fs_open_args_load)  #nosec: B614
 
     def _save(self, data: torch.nn.Module) -> None:
         save_path = get_filepath_str(self._get_save_path(), self._protocol)
-        torch.save(data.state_dict(), save_path, **self._fs_open_args_save)
+        torch.save(data.state_dict(), save_path, **self._fs_open_args_save)  #nosec: B614
 
         self._invalidate_cache()
 


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
Fix https://github.com/kedro-org/kedro-plugins/issues/840

## Development notes
<!-- What have you changed, and how has this been tested? -->
Replace `DataCatalog` with `CatalogProtocol`

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
