### PR TITLE
chore: replace deprecated `pre-commit` stage names

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 
-default_stages: [commit, manual]
+default_stages: [pre-commit, manual]
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
## Description
top-level `default_stages` uses deprecated stage names (commit) which will be removed in a future version.

## Development notes
run: `pre-commit migrate-config` to automatically fix this.