### PR TITLE
chore: remove support for python 3.9

### DIFF
--- a/.github/workflows/kedro-datasets.yml
+++ b/.github/workflows/kedro-datasets.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest ]
-        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.10", "3.11", "3.12" ]
     uses: ./.github/workflows/unit-tests.yml
     with:
       plugin: kedro-datasets

--- a/kedro-datasets/CONTRIBUTING.md
+++ b/kedro-datasets/CONTRIBUTING.md
@@ -41,7 +41,7 @@ Core datasets are maintained by the [Kedro Technical Steering Committee (TSC)](h
 3. Must have working doctests (unless complex cloud/DB setup required, which can be discussed in the review).
 4. Must run as part of the regular CI/CD jobs.
 5. Must have 100% test coverage.
-6. Should support all Python versions under NEP 29 (3.9+ currently).
+6. Should support all Python versions under NEP 29 (3.10+ currently).
 7. Should work on Linux, macOS, and Windows.
 
 #### Experimental datasets

--- a/kedro-datasets/README.md
+++ b/kedro-datasets/README.md
@@ -3,7 +3,7 @@
 <!-- Note that the contents of this file are also used in the documentation, see docs/source/index.md -->
 
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![Python Version](https://img.shields.io/badge/python-3.9%20%7C%203.10%20%7C%203.11%20%7C%203.12-blue.svg)](https://pypi.org/project/kedro-datasets/)
+[![Python Version](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12-blue.svg)](https://pypi.org/project/kedro-datasets/)
 [![PyPI Version](https://badge.fury.io/py/kedro-datasets.svg)](https://pypi.org/project/kedro-datasets/)
 [![Code Style: Black](https://img.shields.io/badge/code%20style-black-black.svg)](https://github.com/ambv/black)
 

--- a/kedro-datasets/RELEASE.md
+++ b/kedro-datasets/RELEASE.md
@@ -1,5 +1,6 @@
 # Upcoming Release
 ## Major features and improvements
+* Removed support for Python 3.9
 * Added the following new **experimental** datasets:
 
 | Type                                | Description                                               | Location                                |

--- a/kedro-datasets/RELEASE.md
+++ b/kedro-datasets/RELEASE.md
@@ -32,6 +32,7 @@ Many thanks to the following Kedroids for contributing PRs to this release:
 * [janickspirig](https://github.com/janickspirig)
 * [Galen Seilis](https://github.com/galenseilis)
 * [Mariusz Wojakowski](https://github.com/mariusz89016)
+* [Felix Scherz](https://github.com/felixscherz)
 
 
 # Release 4.1.0

--- a/kedro-datasets/docs/source/conf.py
+++ b/kedro-datasets/docs/source/conf.py
@@ -145,7 +145,6 @@ type_targets = {
     ),
     "py:data": (
         "typing.Any",
-        "typing.Union",
         "typing.Optional",
         "typing.Tuple",
     ),

--- a/kedro-datasets/docs/source/conf.py
+++ b/kedro-datasets/docs/source/conf.py
@@ -97,7 +97,7 @@ exclude_patterns = [
 
 intersphinx_mapping = {
     "kedro": ("https://docs.kedro.org/en/stable/", None),
-    "python": ("https://docs.python.org/3.9/", None),
+    "python": ("https://docs.python.org/3.10/", None),
 }
 
 type_targets = {

--- a/kedro-datasets/kedro_datasets/databricks/managed_table_dataset.py
+++ b/kedro-datasets/kedro_datasets/databricks/managed_table_dataset.py
@@ -297,7 +297,7 @@ class ManagedTableDataset(AbstractVersionedDataset):
                 the init doesn't exist
 
         Returns:
-            Union[DataFrame, pd.DataFrame]: Returns a dataframe
+            DataFrame | pd.DataFrame: Returns a dataframe
                 in the format defined in the init
         """
         if self._version and self._version.load >= 0:

--- a/kedro-datasets/kedro_datasets/geopandas/geojson_dataset.py
+++ b/kedro-datasets/kedro_datasets/geopandas/geojson_dataset.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import copy
 from pathlib import PurePosixPath
-from typing import Any, Union
+from typing import Any
 
 import fsspec
 import geopandas as gpd
@@ -21,7 +21,7 @@ from kedro.io.core import (
 
 class GeoJSONDataset(
     AbstractVersionedDataset[
-        gpd.GeoDataFrame, Union[gpd.GeoDataFrame, dict[str, gpd.GeoDataFrame]]
+        gpd.GeoDataFrame, gpd.GeoDataFrame | dict[str, gpd.GeoDataFrame]
     ]
 ):
     """``GeoJSONDataset`` loads/saves data to a GeoJSON file using an underlying filesystem

--- a/kedro-datasets/kedro_datasets/matplotlib/matplotlib_writer.py
+++ b/kedro-datasets/kedro_datasets/matplotlib/matplotlib_writer.py
@@ -203,7 +203,7 @@ class MatplotlibWriter(
     def save(self, data: Figure | (list[Figure] | dict[str, Figure])) -> None:
         save_path = self._get_save_path()
 
-        if isinstance(data, (list, dict)) and self._overwrite and self._exists():
+        if isinstance(data, list | dict) and self._overwrite and self._exists():
             self._fs.rm(get_filepath_str(save_path, self._protocol), recursive=True)
 
         if isinstance(data, list):

--- a/kedro-datasets/kedro_datasets/matplotlib/matplotlib_writer.py
+++ b/kedro-datasets/kedro_datasets/matplotlib/matplotlib_writer.py
@@ -6,7 +6,7 @@ import base64
 import io
 from copy import deepcopy
 from pathlib import PurePosixPath
-from typing import Any, NoReturn, Union
+from typing import Any, NoReturn
 from warnings import warn
 
 import fsspec
@@ -24,7 +24,7 @@ from kedro_datasets._typing import ImagePreview
 
 
 class MatplotlibWriter(
-    AbstractVersionedDataset[Union[Figure, list[Figure], dict[str, Figure]], NoReturn]
+    AbstractVersionedDataset[Figure | list[Figure] | dict[str, Figure], NoReturn]
 ):
     """``MatplotlibWriter`` saves one or more Matplotlib objects as
     image files to an underlying filesystem (e.g. local, S3, GCS).

--- a/kedro-datasets/kedro_datasets/pandas/excel_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/excel_dataset.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import logging
 from copy import deepcopy
 from pathlib import PurePosixPath
-from typing import Any, Union
+from typing import Any
 
 import fsspec
 import pandas as pd
@@ -26,8 +26,8 @@ logger = logging.getLogger(__name__)
 
 class ExcelDataset(
     AbstractVersionedDataset[
-        Union[pd.DataFrame, dict[str, pd.DataFrame]],
-        Union[pd.DataFrame, dict[str, pd.DataFrame]],
+        pd.DataFrame | dict[str, pd.DataFrame],
+        pd.DataFrame | dict[str, pd.DataFrame],
     ]
 ):
     """``ExcelDataset`` loads/saves data from/to a Excel file using an underlying

--- a/kedro-datasets/kedro_datasets/partitions/incremental_dataset.py
+++ b/kedro-datasets/kedro_datasets/partitions/incremental_dataset.py
@@ -9,8 +9,9 @@ new partitions past the checkpoint.It also uses `fsspec` for filesystem level op
 from __future__ import annotations
 
 import operator
+from collections.abc import Callable
 from copy import deepcopy
-from typing import Any, Callable
+from typing import Any
 
 from cachetools import cachedmethod
 from kedro.io.core import (

--- a/kedro-datasets/kedro_datasets/partitions/partitioned_dataset.py
+++ b/kedro-datasets/kedro_datasets/partitions/partitioned_dataset.py
@@ -5,9 +5,10 @@ underlying dataset definition. It also uses `fsspec` for filesystem level operat
 from __future__ import annotations
 
 import operator
+from collections.abc import Callable
 from copy import deepcopy
 from pathlib import PurePosixPath
-from typing import Any, Callable
+from typing import Any
 from urllib.parse import urlparse
 from warnings import warn
 

--- a/kedro-datasets/kedro_datasets/plotly/html_dataset.py
+++ b/kedro-datasets/kedro_datasets/plotly/html_dataset.py
@@ -18,9 +18,7 @@ from kedro.io.core import (
 from plotly import graph_objects as go
 
 
-class HTMLDataset(
-    AbstractVersionedDataset[go.Figure, go.Figure | go.FigureWidget]
-):
+class HTMLDataset(AbstractVersionedDataset[go.Figure, go.Figure | go.FigureWidget]):
     """``HTMLDataset`` saves a plotly figure to an HTML file using an
     underlying filesystem (e.g.: local, S3, GCS).
 

--- a/kedro-datasets/kedro_datasets/plotly/html_dataset.py
+++ b/kedro-datasets/kedro_datasets/plotly/html_dataset.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 from copy import deepcopy
 from pathlib import PurePosixPath
-from typing import Any, NoReturn, Union
+from typing import Any, NoReturn
 
 import fsspec
 from kedro.io.core import (
@@ -19,7 +19,7 @@ from plotly import graph_objects as go
 
 
 class HTMLDataset(
-    AbstractVersionedDataset[go.Figure, Union[go.Figure, go.FigureWidget]]
+    AbstractVersionedDataset[go.Figure, go.Figure | go.FigureWidget]
 ):
     """``HTMLDataset`` saves a plotly figure to an HTML file using an
     underlying filesystem (e.g.: local, S3, GCS).

--- a/kedro-datasets/kedro_datasets/plotly/json_dataset.py
+++ b/kedro-datasets/kedro_datasets/plotly/json_dataset.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import json
 from copy import deepcopy
 from pathlib import PurePosixPath
-from typing import Any, Union
+from typing import Any
 
 import fsspec
 import plotly.io as pio
@@ -22,7 +22,7 @@ from kedro_datasets._typing import PlotlyPreview
 
 
 class JSONDataset(
-    AbstractVersionedDataset[go.Figure, Union[go.Figure, go.FigureWidget]]
+    AbstractVersionedDataset[go.Figure, go.Figure | go.FigureWidget]
 ):
     """``JSONDataset`` loads/saves a plotly figure from/to a JSON file using an
     underlying filesystem (e.g.: local, S3, GCS).

--- a/kedro-datasets/kedro_datasets/plotly/json_dataset.py
+++ b/kedro-datasets/kedro_datasets/plotly/json_dataset.py
@@ -21,9 +21,7 @@ from plotly import graph_objects as go
 from kedro_datasets._typing import PlotlyPreview
 
 
-class JSONDataset(
-    AbstractVersionedDataset[go.Figure, go.Figure | go.FigureWidget]
-):
+class JSONDataset(AbstractVersionedDataset[go.Figure, go.Figure | go.FigureWidget]):
     """``JSONDataset`` loads/saves a plotly figure from/to a JSON file using an
     underlying filesystem (e.g.: local, S3, GCS).
 

--- a/kedro-datasets/kedro_datasets/polars/lazy_polars_dataset.py
+++ b/kedro-datasets/kedro_datasets/polars/lazy_polars_dataset.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import logging
 from copy import deepcopy
 from pathlib import PurePosixPath
-from typing import Any, ClassVar, Union
+from typing import Any, ClassVar
 
 import fsspec
 import polars as pl
@@ -22,7 +22,7 @@ from kedro.io.core import (
 
 ACCEPTED_FILE_FORMATS = ["csv", "parquet"]
 
-PolarsFrame = Union[pl.LazyFrame, pl.DataFrame]
+PolarsFrame = pl.LazyFrame | pl.DataFrame
 
 logger = logging.getLogger(__name__)
 

--- a/kedro-datasets/kedro_datasets/svmlight/svmlight_dataset.py
+++ b/kedro-datasets/kedro_datasets/svmlight/svmlight_dataset.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from copy import deepcopy
 from pathlib import PurePosixPath
-from typing import Any, Union
+from typing import Any
 
 import fsspec
 from kedro.io.core import (
@@ -25,7 +25,7 @@ from sklearn.datasets import dump_svmlight_file, load_svmlight_file
 # in kedro-plugins (https://github.com/kedro-org/kedro-plugins)
 
 # Type of data input
-_DI = tuple[Union[ndarray, csr_matrix], ndarray]
+_DI = tuple[ndarray | csr_matrix, ndarray]
 # Type of data output
 _DO = tuple[csr_matrix, ndarray]
 

--- a/kedro-datasets/pyproject.toml
+++ b/kedro-datasets/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
     {name = "Kedro"}
 ]
 description = "Kedro-Datasets is where you can find all of Kedro's data connectors."
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = {text = "Apache Software License (Apache 2.0)"}
 dependencies = [
     "kedro>=0.19.7",

--- a/kedro-datasets/pyproject.toml
+++ b/kedro-datasets/pyproject.toml
@@ -227,8 +227,7 @@ test = [
     "jupyterlab>=3.0",
     "jupyter~=1.0",
     "lxml~=4.6",
-    "matplotlib>=3.0.3, <3.4; python_version < '3.10'",  # 3.4.0 breaks holoviews
-    "matplotlib>=3.5, <3.6; python_version >= '3.10'",
+    "matplotlib>=3.5, <3.6",
     "memory_profiler>=0.50.0, <1.0",
     "moto==5.0.0",
     "mypy~=1.0",

--- a/kedro-datasets/tests/conftest.py
+++ b/kedro-datasets/tests/conftest.py
@@ -5,7 +5,7 @@ discover them automatically. More info here:
 https://docs.pytest.org/en/latest/fixture.html
 """
 
-from typing import Callable
+from collections.abc import Callable
 from unittest.mock import MagicMock
 
 import aiobotocore.awsrequest

--- a/kedro-datasets/tests/spark/conftest.py
+++ b/kedro-datasets/tests/spark/conftest.py
@@ -9,10 +9,7 @@ import pytest
 from delta import configure_spark_with_delta_pip
 from filelock import FileLock
 
-try:
-    from pyspark.sql import SparkSession
-except ImportError:  # pragma: no cover
-    pass  # this is only for test discovery to succeed on Python 3.8, 3.9
+from pyspark.sql import SparkSession
 
 
 def _setup_spark_session():

--- a/kedro-datasets/tests/spark/conftest.py
+++ b/kedro-datasets/tests/spark/conftest.py
@@ -8,7 +8,6 @@ https://docs.pytest.org/en/latest/fixture.html
 import pytest
 from delta import configure_spark_with_delta_pip
 from filelock import FileLock
-
 from pyspark.sql import SparkSession
 
 


### PR DESCRIPTION
## Description
Hi, this is removing support for python 3.9 and updates the python syntax accordingly. Intended to resolve #818. 

## Development notes
- removed `typing.Union` in favor of `|` operator
- removed `typing.Callable` in favor of `collections.abc.Callable`
- removed python 3.9 from unit test matrix in CI

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
