### PR TITLE
chore(datasets): bump `pillow`

### DIFF
--- a/kedro-datasets/pyproject.toml
+++ b/kedro-datasets/pyproject.toml
@@ -118,7 +118,7 @@ pandas = [
 pickle-pickledataset = ["compress-pickle[lz4]~=2.1.0"]
 pickle = ["kedro-datasets[pickle-pickledataset]"]
 
-pillow-imagedataset = ["Pillow~=10.0"]
+pillow-imagedataset = ["Pillow>=9.0"]
 pillow = ["kedro-datasets[pillow-imagedataset]"]
 
 plotly-htmldataset = ["kedro-datasets[plotly-base]"]

--- a/kedro-datasets/pyproject.toml
+++ b/kedro-datasets/pyproject.toml
@@ -118,7 +118,7 @@ pandas = [
 pickle-pickledataset = ["compress-pickle[lz4]~=2.1.0"]
 pickle = ["kedro-datasets[pickle-pickledataset]"]
 
-pillow-imagedataset = ["Pillow~=9.0"]
+pillow-imagedataset = ["Pillow~=10.0"]
 pillow = ["kedro-datasets[pillow-imagedataset]"]
 
 plotly-htmldataset = ["kedro-datasets[plotly-base]"]
@@ -237,7 +237,7 @@ test = [
     "openpyxl>=3.0.3, <4.0",
     "pandas-gbq>=0.12.0",
     "pandas>=2.0",
-    "Pillow~=9.0",
+    "Pillow~=10.0",
     "plotly>=4.8.0, <6.0",
     "polars[xlsx2csv, deltalake]~=0.18.0",
     "pre-commit>=2.9.2",


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
Came across this while trying to run the image classification example on astro airflow. `pillow` only supports python 3.12 from version 10.0 onwards


## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
