### PR TITLE
chore: remove support for python 3.8 for kedro-telemetry

### DIFF
--- a/.github/workflows/kedro-airflow.yml
+++ b/.github/workflows/kedro-airflow.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest ]
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
     uses: ./.github/workflows/unit-tests.yml
     with:
       plugin: kedro-airflow
@@ -40,7 +40,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
     uses: ./.github/workflows/e2e-tests.yml
     with:
       plugin: kedro-airflow

--- a/.github/workflows/kedro-docker.yml
+++ b/.github/workflows/kedro-docker.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest ]
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
     uses: ./.github/workflows/unit-tests.yml
     with:
       plugin: kedro-docker
@@ -40,7 +40,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
     uses: ./.github/workflows/e2e-tests.yml
     with:
       plugin: kedro-docker

--- a/.github/workflows/kedro-telemetry.yml
+++ b/.github/workflows/kedro-telemetry.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
     uses: ./.github/workflows/unit-tests.yml
     with:
       plugin: kedro-telemetry

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,7 +60,7 @@ repos:
         exclude: ^(?!kedro-telemetry/kedro_telemetry/).*\.py$
         pass_filenames: false
         stages: [manual]
-        entry: ruff kedro-telemetry --fix --exit-non-zero-on-fix
+        entry: ruff check kedro-telemetry --fix --exit-non-zero-on-fix
 
       - id: black-kedro-datasets
         name: "Black"

--- a/kedro-telemetry/README.md
+++ b/kedro-telemetry/README.md
@@ -1,6 +1,6 @@
 # Kedro-Telemetry
 
-[![Python Version](https://img.shields.io/badge/python-3.8%20%7C%203.9%20%7C%203.10%20%7C%203.11%20%7C%203.12-blue.svg)](https://pypi.org/project/kedro-telemetry/)
+[![Python Version](https://img.shields.io/badge/python-3.9%20%7C%203.10%20%7C%203.11%20%7C%203.12-blue.svg)](https://pypi.org/project/kedro-telemetry/)
 [![PyPI version](https://badge.fury.io/py/kedro-telemetry.svg)](https://pypi.org/project/kedro-telemetry/)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Code Style: Black](https://img.shields.io/badge/code%20style-black-black.svg)](https://github.com/ambv/black)

--- a/kedro-telemetry/RELEASE.md
+++ b/kedro-telemetry/RELEASE.md
@@ -1,5 +1,8 @@
 # Upcoming release
 
+# Release 0.7.0
+* Removed support for Python 3.8
+
 # Release 0.6.1
 * Changed Kedro CLI loading method to improve loading times.
 * Changed logging level from error to debug for most logging messages.

--- a/kedro-telemetry/kedro_telemetry/masking.py
+++ b/kedro-telemetry/kedro_telemetry/masking.py
@@ -1,4 +1,5 @@
 """Module containing command masking functionality."""
+
 from __future__ import annotations
 
 from typing import Any

--- a/kedro-telemetry/pyproject.toml
+++ b/kedro-telemetry/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
     {name = "Kedro"}
 ]
 description = "Kedro-Telemetry"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = {text = "Apache Software License (Apache 2.0)"}
 dependencies = [
     "kedro>=0.18.0",

--- a/kedro-telemetry/tests/integration/dummy-project/src/dummy_project/__main__.py
+++ b/kedro-telemetry/tests/integration/dummy-project/src/dummy_project/__main__.py
@@ -1,6 +1,7 @@
 """dummy_project file for ensuring the package is executable
 as `dummy-project` and `python -m dummy_project`
 """
+
 import importlib
 from pathlib import Path
 

--- a/kedro-telemetry/tests/integration/dummy-project/src/dummy_project/pipeline_registry.py
+++ b/kedro-telemetry/tests/integration/dummy-project/src/dummy_project/pipeline_registry.py
@@ -1,11 +1,10 @@
 """Project pipelines."""
-from typing import Dict
 
 from kedro.framework.project import find_pipelines
 from kedro.pipeline import Pipeline
 
 
-def register_pipelines() -> Dict[str, Pipeline]:
+def register_pipelines() -> dict[str, Pipeline]:
     """Register the project's pipelines.
 
     Returns:


### PR DESCRIPTION
## Description
This is in regards to #872, dropping python 3.8 support for kedro-telemetry. Intends to resolve #875.

## Development notes
- removed python 3.8 from github actions matrix
- updated pyproject.toml
- updated python syntax to conform with python 3.9 and above

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
