### PR TITLE
Add GH action to check for TSC votes on core dataset changes

### DIFF
--- a/.github/reviewers.json
+++ b/.github/reviewers.json
@@ -1,0 +1,36 @@
+{
+    "teams": {
+      "everyone": {
+        "description": "A team that contains all TSC members.",
+        "users": [
+          "ankatiyar",
+          "astrojuanlu",
+          "datajoely",
+          "deepyaman",
+          "DimedS",
+          "Galileo-Galilei",
+          "Huongg",
+          "idanov",
+          "jitu5",
+          "lrcouto",
+          "marrrcin",
+          "merelcht",
+          "noklam",
+          "rashidakanchwala",
+          "ravi-kumar-pilla",
+          "SajidAlamQB",
+          "sbrugman",
+          "stephkaiser",
+          "tynandebold",
+          "yetudada"
+        ]
+      }
+    },
+    "reviewers": {
+        "kedro-datasets/kedro_datasets/": {
+            "description": "Require at least 1/2 TSC approval on new core dataset contributions.",
+            "teams": ["everyone"],
+            "requiredApproverCount": 10
+        }
+    }
+}

--- a/.github/workflows/check-tsc-vote.yml
+++ b/.github/workflows/check-tsc-vote.yml
@@ -1,0 +1,13 @@
+name: Required Reviews
+on:
+  pull_request: {}
+  pull_request_review: {}
+jobs:
+  required-reviews:
+    name: Required Reviews
+    runs-on: ubuntu-latest
+    steps:
+      - name: required-reviewers
+        uses: theoremlp/required-reviews@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description
Add an automated check to get 1/2 TSC approvals on core dataset changes.

## Development notes
This solution isn't perfect, because it will also trigger on any changes to existing datasets and we only need an official votes for new datasets being contributed to the core datasets. 

I suggest we don't make this a mandatory check, but it will serve as an automatic reminder to check if we need a TSC vote.

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
- [ ] Received approvals from at least half of the TSC (required for adding a new, non-experimental dataset)
