### PR TITLE
fix(datasets): default to DuckDB in in-memory mode

### DIFF
--- a/kedro-datasets/RELEASE.md
+++ b/kedro-datasets/RELEASE.md
@@ -4,9 +4,13 @@
 
 - Added the following new core datasets:
 
-| Type                | Description                                                   | Location              |
-| ------------------- | ------------------------------------------------------------- | --------------------- |
-| `ibis.TableDataset` | A dataset for loading and saving files using Ibis's backends. | `kedro_datasets.ibis` |
+| Type               | Description                                                   | Location              |
+| ------------------ | ------------------------------------------------------------- | --------------------- |
+| `ibis.FileDataset` | A dataset for loading and saving files using Ibis's backends. | `kedro_datasets.ibis` |
+
+## Bug fixes and other changes
+
+- Changed Ibis datasets to connect to an in-memory DuckDB database if connection configuration is not provided.
 
 # Release 5.0.0
 

--- a/kedro-datasets/kedro_datasets/ibis/file_dataset.py
+++ b/kedro-datasets/kedro_datasets/ibis/file_dataset.py
@@ -66,6 +66,10 @@ class FileDataset(AbstractVersionedDataset[ir.Table, ir.Table]):
 
     """
 
+    DEFAULT_CONNECTION_CONFIG: ClassVar[dict[str, Any]] = {
+        "backend": "duckdb",
+        "database": ":memory:",
+    }
     DEFAULT_LOAD_ARGS: ClassVar[dict[str, Any]] = {}
     DEFAULT_SAVE_ARGS: ClassVar[dict[str, Any]] = {}
 
@@ -107,6 +111,7 @@ class FileDataset(AbstractVersionedDataset[ir.Table, ir.Table]):
                 Defaults to writing execution results to a Parquet file.
             table_name: The name to use for the created table (on load).
             connection: Configuration for connecting to an Ibis backend.
+                If not provided, connect to DuckDB in in-memory mode.
             load_args: Additional arguments passed to the Ibis backend's
                 `read_{file_format}` method.
             save_args: Additional arguments passed to the Ibis backend's
@@ -120,7 +125,7 @@ class FileDataset(AbstractVersionedDataset[ir.Table, ir.Table]):
         """
         self._file_format = file_format
         self._table_name = table_name
-        self._connection_config = connection
+        self._connection_config = connection or self.DEFAULT_CONNECTION_CONFIG
         self.metadata = metadata
 
         super().__init__(
@@ -156,8 +161,7 @@ class FileDataset(AbstractVersionedDataset[ir.Table, ir.Table]):
             import ibis
 
             config = deepcopy(self._connection_config)
-            backend_attr = config.pop("backend") if config else None
-            backend = getattr(ibis, str(backend_attr))
+            backend = getattr(ibis, config.pop("backend"))
             cls._connections[key] = backend.connect(**config)
 
         return cls._connections[key]
@@ -178,9 +182,7 @@ class FileDataset(AbstractVersionedDataset[ir.Table, ir.Table]):
             "filepath": self._filepath,
             "file_format": self._file_format,
             "table_name": self._table_name,
-            "backend": self._connection_config.get("backend")
-            if self._connection_config
-            else None,
+            "backend": self._connection_config["backend"],
             "load_args": self._load_args,
             "save_args": self._save_args,
             "version": self._version,

--- a/kedro-datasets/kedro_datasets/ibis/table_dataset.py
+++ b/kedro-datasets/kedro_datasets/ibis/table_dataset.py
@@ -60,6 +60,10 @@ class TableDataset(AbstractDataset[ir.Table, ir.Table]):
 
     """
 
+    DEFAULT_CONNECTION_CONFIG: ClassVar[dict[str, Any]] = {
+        "backend": "duckdb",
+        "database": ":memory:",
+    }
     DEFAULT_LOAD_ARGS: ClassVar[dict[str, Any]] = {}
     DEFAULT_SAVE_ARGS: ClassVar[dict[str, Any]] = {
         "materialized": "view",
@@ -99,6 +103,7 @@ class TableDataset(AbstractDataset[ir.Table, ir.Table]):
         Args:
             table_name: The name of the table or view to read or create.
             connection: Configuration for connecting to an Ibis backend.
+                If not provided, connect to DuckDB in in-memory mode.
             load_args: Additional arguments passed to the Ibis backend's
                 `read_{file_format}` method.
             save_args: Additional arguments passed to the Ibis backend's
@@ -126,7 +131,7 @@ class TableDataset(AbstractDataset[ir.Table, ir.Table]):
         self._filepath = filepath
         self._file_format = file_format
         self._table_name = table_name
-        self._connection_config = connection
+        self._connection_config = connection or self.DEFAULT_CONNECTION_CONFIG
         self.metadata = metadata
 
         # Set load and save arguments, overwriting defaults if provided.
@@ -158,8 +163,7 @@ class TableDataset(AbstractDataset[ir.Table, ir.Table]):
             import ibis
 
             config = deepcopy(self._connection_config)
-            backend_attr = config.pop("backend") if config else None
-            backend = getattr(ibis, str(backend_attr))
+            backend = getattr(ibis, config.pop("backend"))
             cls._connections[key] = backend.connect(**config)
 
         return cls._connections[key]
@@ -186,9 +190,7 @@ class TableDataset(AbstractDataset[ir.Table, ir.Table]):
             "filepath": self._filepath,
             "file_format": self._file_format,
             "table_name": self._table_name,
-            "backend": self._connection_config.get("backend")
-            if self._connection_config
-            else None,
+            "backend": self._connection_config["backend"],
             "load_args": self._load_args,
             "save_args": self._save_args,
             "materialized": self._materialized,


### PR DESCRIPTION
## Description
https://github.com/kedro-org/kedro-plugins/pull/893#discussion_r1804632435

## Development notes
TODO: Add unit test (make sure connection caching works correctly?)

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
- [ ] Received approvals from at least half of the TSC (required for adding a new, non-experimental dataset)
