### PR TITLE
build: fix paths filter for triggering TSC vote check

### DIFF
--- a/.github/workflows/check-tsc-vote.yml
+++ b/.github/workflows/check-tsc-vote.yml
@@ -2,7 +2,7 @@ name: Required Reviews
 on:
   pull_request:
     paths:
-      - 'kedro-datasets/kedro_datasets/*'
+      - 'kedro-datasets/kedro_datasets/**'
 jobs:
   required-reviews:
     name: Required Reviews


### PR DESCRIPTION
## Description
I noticed the TSC vote check wasn't triggered on PRs with changes in the core datasets (e.g. https://github.com/kedro-org/kedro-plugins/pull/881). This doesn't need a vote, but the check should run.

## Development notes


## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
- [ ] Received approvals from at least half of the TSC (required for adding a new, non-experimental dataset)
