### PR TITLE
build: Bump matplotlib test dependency

### DIFF
--- a/kedro-datasets/pyproject.toml
+++ b/kedro-datasets/pyproject.toml
@@ -225,7 +225,7 @@ test = [
     "jupyterlab>=3.0",
     "jupyter~=1.0",
     "lxml~=4.6",
-    "matplotlib>=3.5, <3.6",
+    "matplotlib>=3.5, <4.0",
     "memory_profiler>=0.50.0, <1.0",
     "moto==5.0.0",
     "networkx~=2.4",

--- a/kedro-datasets/tests/matplotlib/test_matplotlib_writer.py
+++ b/kedro-datasets/tests/matplotlib/test_matplotlib_writer.py
@@ -129,7 +129,7 @@ def cleanup_plt():
 
 
 class TestMatplotlibWriter:
-    @pytest.mark.parametrize("save_args", [{"k1": "v1"}], indirect=True)
+    @pytest.mark.parametrize("save_args", [{"format": "png"}], indirect=True)
     def test_save_data(
         self, tmp_path, mock_single_plot, plot_writer, mocked_s3_bucket, save_args
     ):


### PR DESCRIPTION
## Description
It's been a while since I tried installing all `kedro-dataset` dependencies and when I did it failed on installing `matplotlib`. I bumped it to the same version as specified here: https://github.com/kedro-org/kedro-plugins/blob/main/kedro-datasets/pyproject.toml#L81 and was then able to install everything.

## Development notes


## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
- [ ] Received approvals from at least half of the TSC (required for adding a new, non-experimental dataset)
