### PR TITLE
Improved Dependency Management for Spark-based Datasets

### DIFF
--- a/kedro-datasets/kedro_datasets/_utils/databricks_utils.py
+++ b/kedro-datasets/kedro_datasets/_utils/databricks_utils.py
@@ -1,0 +1,86 @@
+from fnmatch import fnmatch
+import os
+from pathlib import PurePosixPath
+from typing import Any
+
+from pyspark.sql import SparkSession
+
+from kedro_datasets._utils.file_utils import _parse_glob_pattern
+
+
+def _strip_dbfs_prefix(path: str, prefix: str = "/dbfs") -> str:
+    return path[len(prefix) :] if path.startswith(prefix) else path
+
+
+def dbfs_glob(pattern: str, dbutils: Any) -> list[str]:
+    """Perform a custom glob search in DBFS using the provided pattern.
+    It is assumed that version paths are managed by Kedro only.
+
+    Args:
+        pattern: Glob pattern to search for.
+        dbutils: dbutils instance to operate with DBFS.
+
+    Returns:
+            List of DBFS paths prefixed with '/dbfs' that satisfy the glob pattern.
+    """
+    pattern = _strip_dbfs_prefix(pattern)
+    prefix = _parse_glob_pattern(pattern)
+    matched = set()
+    filename = pattern.split("/")[-1]
+
+    for file_info in dbutils.fs.ls(prefix):
+        if file_info.isDir():
+            path = str(
+                PurePosixPath(_strip_dbfs_prefix(file_info.path, "dbfs:")) / filename
+            )
+            if fnmatch(path, pattern):
+                path = "/dbfs" + path
+                matched.add(path)
+    return sorted(matched)
+
+
+def get_dbutils(spark: SparkSession) -> Any:
+    """Get the instance of 'dbutils' or None if the one could not be found."""
+    dbutils = globals().get("dbutils")
+    if dbutils:
+        return dbutils
+
+    try:
+        from pyspark.dbutils import DBUtils
+
+        dbutils = DBUtils(spark)
+    except ImportError:
+        try:
+            import IPython
+        except ImportError:
+            pass
+        else:
+            ipython = IPython.get_ipython()
+            dbutils = ipython.user_ns.get("dbutils") if ipython else None
+
+    return dbutils
+
+
+def dbfs_exists(pattern: str, dbutils: Any) -> bool:
+    """Perform an `ls` list operation in DBFS using the provided pattern.
+    It is assumed that version paths are managed by Kedro.
+    Broad `Exception` is present due to `dbutils.fs.ExecutionError` that
+    cannot be imported directly.
+    Args:
+        pattern: Filepath to search for.
+        dbutils: dbutils instance to operate with DBFS.
+    Returns:
+        Boolean value if filepath exists.
+    """
+    pattern = _strip_dbfs_prefix(pattern)
+    file = _parse_glob_pattern(pattern)
+    try:
+        dbutils.fs.ls(file)
+        return True
+    except Exception:
+        return False
+
+
+def deployed_on_databricks() -> bool:
+    """Check if running on Databricks."""
+    return "DATABRICKS_RUNTIME_VERSION" in os.environ

--- a/kedro-datasets/kedro_datasets/_utils/databricks_utils.py
+++ b/kedro-datasets/kedro_datasets/_utils/databricks_utils.py
@@ -8,7 +8,7 @@ from pyspark.sql import SparkSession
 from kedro_datasets._utils.file_utils import parse_glob_pattern
 
 
-def _strip_dbfs_prefix(path: str, prefix: str = "/dbfs") -> str:
+def strip_dbfs_prefix(path: str, prefix: str = "/dbfs") -> str:
     return path[len(prefix) :] if path.startswith(prefix) else path
 
 
@@ -23,7 +23,7 @@ def dbfs_glob(pattern: str, dbutils: Any) -> list[str]:
     Returns:
             List of DBFS paths prefixed with '/dbfs' that satisfy the glob pattern.
     """
-    pattern = _strip_dbfs_prefix(pattern)
+    pattern = strip_dbfs_prefix(pattern)
     prefix = parse_glob_pattern(pattern)
     matched = set()
     filename = pattern.split("/")[-1]
@@ -31,7 +31,7 @@ def dbfs_glob(pattern: str, dbutils: Any) -> list[str]:
     for file_info in dbutils.fs.ls(prefix):
         if file_info.isDir():
             path = str(
-                PurePosixPath(_strip_dbfs_prefix(file_info.path, "dbfs:")) / filename
+                PurePosixPath(strip_dbfs_prefix(file_info.path, "dbfs:")) / filename
             )
             if fnmatch(path, pattern):
                 path = "/dbfs" + path
@@ -72,7 +72,7 @@ def dbfs_exists(pattern: str, dbutils: Any) -> bool:
     Returns:
         Boolean value if filepath exists.
     """
-    pattern = _strip_dbfs_prefix(pattern)
+    pattern = strip_dbfs_prefix(pattern)
     file = parse_glob_pattern(pattern)
     try:
         dbutils.fs.ls(file)

--- a/kedro-datasets/kedro_datasets/_utils/databricks_utils.py
+++ b/kedro-datasets/kedro_datasets/_utils/databricks_utils.py
@@ -5,7 +5,7 @@ from typing import Any
 
 from pyspark.sql import SparkSession
 
-from kedro_datasets._utils.file_utils import _parse_glob_pattern
+from kedro_datasets._utils.file_utils import parse_glob_pattern
 
 
 def _strip_dbfs_prefix(path: str, prefix: str = "/dbfs") -> str:
@@ -24,7 +24,7 @@ def dbfs_glob(pattern: str, dbutils: Any) -> list[str]:
             List of DBFS paths prefixed with '/dbfs' that satisfy the glob pattern.
     """
     pattern = _strip_dbfs_prefix(pattern)
-    prefix = _parse_glob_pattern(pattern)
+    prefix = parse_glob_pattern(pattern)
     matched = set()
     filename = pattern.split("/")[-1]
 
@@ -73,7 +73,7 @@ def dbfs_exists(pattern: str, dbutils: Any) -> bool:
         Boolean value if filepath exists.
     """
     pattern = _strip_dbfs_prefix(pattern)
-    file = _parse_glob_pattern(pattern)
+    file = parse_glob_pattern(pattern)
     try:
         dbutils.fs.ls(file)
         return True

--- a/kedro-datasets/kedro_datasets/_utils/file_utils.py
+++ b/kedro-datasets/kedro_datasets/_utils/file_utils.py
@@ -1,0 +1,18 @@
+import os
+
+
+def parse_glob_pattern(pattern: str) -> str:
+    special = ("*", "?", "[")
+    clean = []
+    for part in pattern.split("/"):
+        if any(char in part for char in special):
+            break
+        clean.append(part)
+    return "/".join(clean)
+
+
+def split_filepath(filepath: str | os.PathLike) -> tuple[str, str]:
+    split_ = str(filepath).split("://", 1)
+    if len(split_) == 2:  # noqa: PLR2004
+        return split_[0] + "://", split_[1]
+    return "", split_[0]

--- a/kedro-datasets/kedro_datasets/_utils/spark_utils.py
+++ b/kedro-datasets/kedro_datasets/_utils/spark_utils.py
@@ -1,0 +1,26 @@
+from typing import Any
+
+from pyspark.sql import SparkSession
+
+
+def get_spark() -> Any:
+    """
+    Returns the SparkSession. In case databricks-connect is available we use it for
+    extended configuration mechanisms and notebook compatibility,
+    otherwise we use classic pyspark.
+    """
+    try:
+        # When using databricks-connect >= 13.0.0 (a.k.a databricks-connect-v2)
+        # the remote session is instantiated using the databricks module
+        # If the databricks-connect module is installed, we use a remote session
+        from databricks.connect import DatabricksSession
+
+        # We can't test this as there's no Databricks test env available
+        spark = DatabricksSession.builder.getOrCreate()  # pragma: no cover
+
+    except ImportError:
+        # For "normal" spark sessions that don't use databricks-connect
+        # we get spark normally
+        spark = SparkSession.builder.getOrCreate()
+
+    return spark

--- a/kedro-datasets/kedro_datasets/databricks/_base_table_dataset.py
+++ b/kedro-datasets/kedro_datasets/databricks/_base_table_dataset.py
@@ -19,7 +19,7 @@ from pyspark.sql import DataFrame
 from pyspark.sql.types import StructType
 from pyspark.sql.utils import AnalysisException, ParseException
 
-from kedro_datasets.spark.spark_dataset import _get_spark
+from kedro_datasets._utils.spark_utils import get_spark
 
 logger = logging.getLogger(__name__)
 pd.DataFrame.iteritems = pd.DataFrame.items
@@ -183,7 +183,7 @@ class BaseTable:
         """
         if self.catalog:
             try:
-                _get_spark().sql(f"USE CATALOG `{self.catalog}`")
+                get_spark().sql(f"USE CATALOG `{self.catalog}`")
             except (ParseException, AnalysisException) as exc:
                 logger.warning(
                     "catalog %s not found or unity not enabled. Error message: %s",
@@ -192,7 +192,7 @@ class BaseTable:
                 )
         try:
             return (
-                _get_spark()
+                get_spark()
                 .sql(f"SHOW TABLES IN `{self.database}`")
                 .filter(f"tableName = '{self.table}'")
                 .count()
@@ -359,7 +359,7 @@ class BaseTableDataset(AbstractVersionedDataset):
         if self._version and self._version.load >= 0:
             try:
                 data = (
-                    _get_spark()
+                    get_spark()
                     .read.format("delta")
                     .option("versionAsOf", self._version.load)
                     .table(self._table.full_table_location())
@@ -367,7 +367,7 @@ class BaseTableDataset(AbstractVersionedDataset):
             except Exception as exc:
                 raise VersionNotFoundError(self._version.load) from exc
         else:
-            data = _get_spark().table(self._table.full_table_location())
+            data = get_spark().table(self._table.full_table_location())
         if self._table.dataframe_type == "pandas":
             data = data.toPandas()
         return data
@@ -391,13 +391,13 @@ class BaseTableDataset(AbstractVersionedDataset):
         if schema:
             cols = schema.fieldNames()
             if self._table.dataframe_type == "pandas":
-                data = _get_spark().createDataFrame(
+                data = get_spark().createDataFrame(
                     data.loc[:, cols], schema=self._table.schema()
                 )
             else:
                 data = data.select(*cols)
         elif self._table.dataframe_type == "pandas":
-            data = _get_spark().createDataFrame(data)
+            data = get_spark().createDataFrame(data)
 
         method = getattr(self, f"_save_{self._table.write_mode}", None)
         if method:
@@ -456,7 +456,7 @@ class BaseTableDataset(AbstractVersionedDataset):
             update_data (DataFrame): The Spark dataframe to upsert.
         """
         if self._exists():
-            base_data = _get_spark().table(self._table.full_table_location())
+            base_data = get_spark().table(self._table.full_table_location())
             base_columns = base_data.columns
             update_columns = update_data.columns
 
@@ -479,11 +479,11 @@ class BaseTableDataset(AbstractVersionedDataset):
                 )
 
             update_data.createOrReplaceTempView("update")
-            _get_spark().conf.set("fullTableAddress", self._table.full_table_location())
-            _get_spark().conf.set("whereExpr", where_expr)
+            get_spark().conf.set("fullTableAddress", self._table.full_table_location())
+            get_spark().conf.set("whereExpr", where_expr)
             upsert_sql = """MERGE INTO ${fullTableAddress} base USING update ON ${whereExpr}
                 WHEN MATCHED THEN UPDATE SET * WHEN NOT MATCHED THEN INSERT *"""
-            _get_spark().sql(upsert_sql)
+            get_spark().sql(upsert_sql)
         else:
             self._save_append(update_data)
 

--- a/kedro-datasets/kedro_datasets/spark/spark_dataset.py
+++ b/kedro-datasets/kedro_datasets/spark/spark_dataset.py
@@ -29,8 +29,8 @@ from pyspark.sql.types import StructType
 from pyspark.sql.utils import AnalysisException
 from s3fs import S3FileSystem
 
-from kedro_datasets._utils.file_utils import parse_glob_pattern, split_filepath
 from kedro_datasets._utils.databricks_utils import dbfs_glob, dbfs_exists, deployed_on_databricks, get_dbutils
+from kedro_datasets._utils.file_utils import parse_glob_pattern, split_filepath
 from kedro_datasets._utils.spark_utils import get_spark
 
 logger = logging.getLogger(__name__)

--- a/kedro-datasets/kedro_datasets/spark/spark_hive_dataset.py
+++ b/kedro-datasets/kedro_datasets/spark/spark_hive_dataset.py
@@ -11,7 +11,7 @@ from kedro.io.core import AbstractDataset, DatasetError
 from pyspark.sql import DataFrame, Window
 from pyspark.sql.functions import col, lit, row_number
 
-from kedro_datasets.spark.spark_dataset import _get_spark
+from kedro_datasets._utils.spark_utils import get_spark
 
 
 class SparkHiveDataset(AbstractDataset[DataFrame, DataFrame]):
@@ -149,7 +149,7 @@ class SparkHiveDataset(AbstractDataset[DataFrame, DataFrame]):
         )
 
     def load(self) -> DataFrame:
-        return _get_spark().read.table(self._full_table_address)
+        return get_spark().read.table(self._full_table_address)
 
     def save(self, data: DataFrame) -> None:
         self._validate_save(data)
@@ -201,7 +201,7 @@ class SparkHiveDataset(AbstractDataset[DataFrame, DataFrame]):
 
     def _exists(self) -> bool:
         return (
-            _get_spark()
+            get_spark()
             ._jsparkSession.catalog()
             .tableExists(self._database, self._table)
         )

--- a/kedro-datasets/kedro_datasets/spark/spark_jdbc_dataset.py
+++ b/kedro-datasets/kedro_datasets/spark/spark_jdbc_dataset.py
@@ -6,7 +6,7 @@ from typing import Any
 from kedro.io.core import AbstractDataset, DatasetError
 from pyspark.sql import DataFrame
 
-from kedro_datasets.spark.spark_dataset import _get_spark
+from kedro_datasets._utils.spark_utils import get_spark
 
 
 class SparkJDBCDataset(AbstractDataset[DataFrame, DataFrame]):
@@ -167,7 +167,7 @@ class SparkJDBCDataset(AbstractDataset[DataFrame, DataFrame]):
         }
 
     def load(self) -> DataFrame:
-        return _get_spark().read.jdbc(self._url, self._table, **self._load_args)
+        return get_spark().read.jdbc(self._url, self._table, **self._load_args)
 
     def save(self, data: DataFrame) -> None:
         return data.write.jdbc(self._url, self._table, **self._save_args)


### PR DESCRIPTION
## Description

This PR a `_utils` sub-package to house modules with common utility functions that are used across Spark-based datasets. This avoids the need for `pyspark` to be installed for datasets that will run on Databricks.

Fixes https://github.com/kedro-org/kedro-plugins/issues/849

## Development notes
The new `_utils` package organized the utility functions in three main modules,
1. databricks_utils.py
2. file_utils.py
3. spark_utils.py

Additional modules can be added to this sub-package to house code that is used in multiple datasets.

These changes have been tested,
~~1. Manually, by running the code locally to load and save tensors from and to Safetensors files.~~
~~2. Via the existing and newly added unit tests.~~

## Checklist

- [X] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
- [ ] Received approvals from at least half of the TSC (required for adding a new, non-experimental dataset)