### PR TITLE
build(datasets): pin `numpy<2` 

### DIFF
--- a/kedro-datasets/pyproject.toml
+++ b/kedro-datasets/pyproject.toml
@@ -167,7 +167,7 @@ tracking-jsondataset = []
 tracking-metricsdataset = []
 tracking = ["kedro-datasets[tracking-jsondataset, tracking-metricsdataset]"]
 
-video-videodataset = ["opencv-python~=4.5.5.64"]
+video-videodataset = ["opencv-python~=4.10.0.84"]
 video = ["kedro-datasets[video-videodataset]"]
 
 yaml-yamldataset = ["kedro-datasets[pandas-base]", "PyYAML>=4.2, <7.0"]
@@ -229,7 +229,7 @@ test = [
     "memory_profiler>=0.50.0, <1.0",
     "moto==5.0.0",
     "networkx~=2.4",
-    "opencv-python~=4.5.5.64",
+    "opencv-python~=4.10.0.84",
     "openpyxl>=3.0.3, <4.0",
     "pandas-gbq>=0.12.0",
     "pandas>=2.0",

--- a/kedro-datasets/pyproject.toml
+++ b/kedro-datasets/pyproject.toml
@@ -229,6 +229,7 @@ test = [
     "memory_profiler>=0.50.0, <1.0",
     "moto==5.0.0",
     "networkx~=2.4",
+    "numpy<2",
     "opencv-python~=4.10.0.84",
     "openpyxl>=3.0.3, <4.0",
     "pandas-gbq>=0.12.0",

--- a/kedro-datasets/pyproject.toml
+++ b/kedro-datasets/pyproject.toml
@@ -167,7 +167,7 @@ tracking-jsondataset = []
 tracking-metricsdataset = []
 tracking = ["kedro-datasets[tracking-jsondataset, tracking-metricsdataset]"]
 
-video-videodataset = ["opencv-python~=4.10.0.84"]
+video-videodataset = ["opencv-python~=4.5.5.64"]
 video = ["kedro-datasets[video-videodataset]"]
 
 yaml-yamldataset = ["kedro-datasets[pandas-base]", "PyYAML>=4.2, <7.0"]
@@ -230,7 +230,7 @@ test = [
     "moto==5.0.0",
     "networkx~=2.4",
     "numpy<2",
-    "opencv-python~=4.10.0.84",
+    "opencv-python~=4.5.5.64",
     "openpyxl>=3.0.3, <4.0",
     "pandas-gbq>=0.12.0",
     "pandas>=2.0",


### PR DESCRIPTION
## Description
Temporarily pin `numpy<2` as it's causing issues in builds like:

```
ImportError: 
A module that was compiled using NumPy 1.x cannot be run in
NumPy 2.1.2 as it may crash. To support both 1.x and 2.x
versions of NumPy, modules must be compiled with NumPy 2.0.
Some module may need to rebuild instead e.g. with 'pybind11>=2.12'.

If you are a user of the module, the easiest solution will be to
downgrade to 'numpy<2' or try to upgrade the affected module.
We expect that some modules will need time to support NumPy 2.
```

and 


```
==================================== ERRORS ====================================
____________ ERROR collecting kedro_datasets/video/video_dataset.py ____________
kedro_datasets/video/video_dataset.py:15: in <module>
    import cv2
/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/site-packages/cv2/__init__.py:8: in <module>
    from .cv2 import *
E   ImportError: numpy.core.multiarray failed to import
------------------------------- Captured stderr --------------------------------
RuntimeError: module compiled against ABI version 0x1000009 but this version of numpy is 0x2000000
=========================== short test summary info ============================
ERROR kedro_datasets/video/video_dataset.py - ImportError: numpy.core.multiarray failed to import
!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
============================== 1 error in 24.53s ===============================
```

## Development notes


## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
- [ ] Received approvals from at least half of the TSC (required for adding a new, non-experimental dataset)
