### PR TITLE
build: Add wizard GH action to remove label or close info needed issues

### DIFF
--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -1,0 +1,20 @@
+name: No Response
+
+on:
+  issue_comment:
+    types: [created]
+  schedule:
+    # Schedule for five minutes after the hour, every hour
+    - cron: '5 * * * *'
+
+jobs:
+  noResponse:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: lee-dohm/no-response@v0.5.0
+        with:
+          token: ${{ github.token }}
+          responseRequiredLabel: "support: needs more info"
+          daysUntilClose: 28
+          closeComment: >-
+            This issue has been closed due to lack of information. Feel free to re-open this issue if you're facing a similar problem. Please provide as much information as possible so we can help resolve your issue.

--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: lee-dohm/no-response@v0.5.0
         with:
-          token: ${{ github.token }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           responseRequiredLabel: "support: needs more info"
           daysUntilClose: 28
           closeComment: >-

--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -4,8 +4,8 @@ on:
   issue_comment:
     types: [created]
   schedule:
-    # Schedule for five minutes after the hour, every hour
-    - cron: '5 * * * *'
+    # Run every day at 9am (UTC time)
+    - cron: '0 9 * * *'
 
 jobs:
   noResponse:


### PR DESCRIPTION
## Description
Mirroring https://github.com/kedro-org/kedro/pull/4294 and https://github.com/kedro-org/kedro/pull/4304 on `kedro` to automatically close issues labelled with `support: needs more info` if the author doesn't reply within 28 days or remove the label if the author has responded.


## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
- [ ] Received approvals from at least half of the TSC (required for adding a new, non-experimental dataset)
