### PR TITLE
fix(datasets): share the cache of Ibis connections

### DIFF
--- a/kedro-datasets/RELEASE.md
+++ b/kedro-datasets/RELEASE.md
@@ -1,22 +1,25 @@
 # Upcoming Release 6.0.0
 
 ## Major features and improvements
-- Added functionality to save Pandas DataFrame directly to Snowflake, facilitating seemless `.csv` ingestion
-- Added Python 3.9, 3.10 and 3.11 support for SnowflakeTableDataset
+
+- Added functionality to save pandas DataFrames directly to Snowflake, facilitating seamless `.csv` ingestion.
+- Added Python 3.9, 3.10 and 3.11 support for `snowflake.SnowflakeTableDataset`.
+- Enabled connection sharing between `ibis.FileDataset` and `ibis.TableDataset` instances, thereby allowing nodes to save data loaded by one to the other (as long as they share the same connection configuration).
 - Added the following new **experimental** datasets:
 
-| Type                              | Description                                            | Location                                 |
-| --------------------------------- | ------------------------------------------------------ | ---------------------------------------- |
-| `databricks.ExternalTableDataset` | A dataset for accessing external tables in Databricks. | `kedro_datasets_experimental.databricks` |
+| Type                              | Description                                                                | Location                                  |
+| --------------------------------- | -------------------------------------------------------------------------- | ----------------------------------------- |
+| `databricks.ExternalTableDataset` | A dataset for accessing external tables in Databricks.                     | `kedro_datasets_experimental.databricks`  |
 | `safetensors.SafetensorsDataset`  | A dataset for securely saving and loading files in the SafeTensors format. | `kedro_datasets_experimental.safetensors` |
 
-
 ## Bug fixes and other changes
-- Implemented Snowflake's (local testing framework)[https://docs.snowflake.com/en/developer-guide/snowpark/python/testing-locally] for testing purposes
+
+- Implemented Snowflake's [local testing framework](https://docs.snowflake.com/en/developer-guide/snowpark/python/testing-locally) for testing purposes.
 - Improved the dependency management for Spark-based datasets by refactoring the Spark and Databricks utility functions used across the datasets.
-- Add deprecation warning for `tracking.MetricsDataset` and `tracking.JSONDataset`.
+- Added deprecation warning for `tracking.MetricsDataset` and `tracking.JSONDataset`.
 
 ## Breaking Changes
+
 - Demoted `video.VideoDataset` from core to experimental dataset.
 
 ## Community contributions

--- a/kedro-datasets/kedro_datasets/_utils/__init__.py
+++ b/kedro-datasets/kedro_datasets/_utils/__init__.py
@@ -1,0 +1,1 @@
+from .connection_mixin import ConnectionMixin  # noqa: F401

--- a/kedro-datasets/kedro_datasets/_utils/connection_mixin.py
+++ b/kedro-datasets/kedro_datasets/_utils/connection_mixin.py
@@ -1,0 +1,23 @@
+from collections.abc import Hashable
+from typing import Any, ClassVar
+
+
+class ConnectionMixin:
+    _connections: ClassVar[dict[Hashable, Any]] = {}
+
+    @property
+    def _connection(self) -> Any:
+        def hashable(value: Any) -> Hashable:
+            """Return a hashable key for a potentially-nested object."""
+            if isinstance(value, dict):
+                return tuple((k, hashable(v)) for k, v in sorted(value.items()))
+            if isinstance(value, list):
+                return tuple(hashable(x) for x in value)
+            return value
+
+        cls = type(self)
+        key = self._CONNECTION_GROUP, hashable(self._connection_config)
+        if key not in cls._connections:
+            cls._connections[key] = self._connect()
+
+        return cls._connections[key]

--- a/kedro-datasets/kedro_datasets/_utils/connection_mixin.py
+++ b/kedro-datasets/kedro_datasets/_utils/connection_mixin.py
@@ -1,9 +1,18 @@
+from abc import ABC, abstractmethod
 from collections.abc import Hashable
 from typing import Any, ClassVar
 
 
-class ConnectionMixin:
+class ConnectionMixin(ABC):
+    _CONNECTION_GROUP: ClassVar[str]
+
+    _connection_config: dict[str, Any]
+
     _connections: ClassVar[dict[Hashable, Any]] = {}
+
+    @abstractmethod
+    def _connect(self) -> Any:
+        ...
 
     @property
     def _connection(self) -> Any:

--- a/kedro-datasets/kedro_datasets/_utils/connection_mixin.py
+++ b/kedro-datasets/kedro_datasets/_utils/connection_mixin.py
@@ -12,7 +12,7 @@ class ConnectionMixin(ABC):
 
     @abstractmethod
     def _connect(self) -> Any:
-        ...
+        ...  # pragma: no cover
 
     @property
     def _connection(self) -> Any:

--- a/kedro-datasets/kedro_datasets/ibis/table_dataset.py
+++ b/kedro-datasets/kedro_datasets/ibis/table_dataset.py
@@ -9,12 +9,13 @@ import ibis.expr.types as ir
 from kedro.io import AbstractDataset, DatasetError
 
 from kedro_datasets import KedroDeprecationWarning
+from kedro_datasets._utils import ConnectionMixin
 
 if TYPE_CHECKING:
     from ibis import BaseBackend
 
 
-class TableDataset(AbstractDataset[ir.Table, ir.Table]):
+class TableDataset(ConnectionMixin, AbstractDataset[ir.Table, ir.Table]):
     """``TableDataset`` loads/saves data from/to Ibis table expressions.
 
     Example usage for the
@@ -70,7 +71,7 @@ class TableDataset(AbstractDataset[ir.Table, ir.Table]):
         "overwrite": True,
     }
 
-    _connections: ClassVar[dict[tuple[tuple[str, str]], BaseBackend]] = {}
+    _CONNECTION_GROUP: ClassVar[str] = "ibis"
 
     def __init__(  # noqa: PLR0913
         self,
@@ -145,28 +146,17 @@ class TableDataset(AbstractDataset[ir.Table, ir.Table]):
 
         self._materialized = self._save_args.pop("materialized")
 
+    def _connect(self) -> BaseBackend:
+        import ibis
+
+        config = deepcopy(self._connection_config)
+        backend = getattr(ibis, config.pop("backend"))
+        return backend.connect(**config)
+
     @property
     def connection(self) -> BaseBackend:
         """The ``Backend`` instance for the connection configuration."""
-
-        def hashable(value):
-            """Return a hashable key for a potentially-nested object."""
-            if isinstance(value, dict):
-                return tuple((k, hashable(v)) for k, v in sorted(value.items()))
-            if isinstance(value, list):
-                return tuple(hashable(x) for x in value)
-            return value
-
-        cls = type(self)
-        key = hashable(self._connection_config)
-        if key not in cls._connections:
-            import ibis
-
-            config = deepcopy(self._connection_config)
-            backend = getattr(ibis, config.pop("backend"))
-            cls._connections[key] = backend.connect(**config)
-
-        return cls._connections[key]
+        return self._connection
 
     def load(self) -> ir.Table:
         if self._filepath is not None:

--- a/kedro-datasets/tests/ibis/test_file_dataset.py
+++ b/kedro-datasets/tests/ibis/test_file_dataset.py
@@ -59,7 +59,7 @@ def dummy_table():
 
 
 class TestFileDataset:
-    def test_save_and_load(self, file_dataset, dummy_table, database):
+    def test_save_and_load(self, file_dataset, dummy_table):
         """Test saving and reloading the data set."""
         file_dataset.save(dummy_table)
         reloaded = file_dataset.load()
@@ -127,7 +127,7 @@ class TestFileDataset:
         )
         mocker.patch(f"ibis.{backend}")
         file_dataset.load()
-        assert key in file_dataset._connections
+        assert ("ibis", key) in file_dataset._connections
 
 
 class TestFileDatasetVersioned:


### PR DESCRIPTION
## Description
Close #935

## Development notes
The `ConnectionMixin` can also be used by something like `pandas.SQLQueryDataset` and `pandas.SQLTableDataset` to share a single connection cache. While this has some value (prevent storing the connections twice, if the user is using both datasets), it's less functionally important as in this specific Ibis case.

## Checklist

- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
- [ ] Received approvals from at least half of the TSC (required for adding a new, non-experimental dataset)
