### PR TITLE
feat(datasets): add deprecation warning for tracking datatsets

### DIFF
--- a/kedro-datasets/RELEASE.md
+++ b/kedro-datasets/RELEASE.md
@@ -14,6 +14,7 @@
 ## Bug fixes and other changes
 - Implemented Snowflake's (local testing framework)[https://docs.snowflake.com/en/developer-guide/snowpark/python/testing-locally] for testing purposes
 - Improved the dependency management for Spark-based datasets by refactoring the Spark and Databricks utility functions used across the datasets.
+- Add deprecation warning for MetricsTrackingDataset and JSONTrackingDataset.
 
 ## Breaking Changes
 - Demoted `video.VideoDataset` from core to experimental dataset.

--- a/kedro-datasets/RELEASE.md
+++ b/kedro-datasets/RELEASE.md
@@ -14,7 +14,7 @@
 ## Bug fixes and other changes
 - Implemented Snowflake's (local testing framework)[https://docs.snowflake.com/en/developer-guide/snowpark/python/testing-locally] for testing purposes
 - Improved the dependency management for Spark-based datasets by refactoring the Spark and Databricks utility functions used across the datasets.
-- Add deprecation warning for MetricsTrackingDataset and JSONTrackingDataset.
+- Add deprecation warning for `tracking.MetricsDataset` and `tracking.JSONDataset`.
 
 ## Breaking Changes
 - Demoted `video.VideoDataset` from core to experimental dataset.

--- a/kedro-datasets/kedro_datasets/tracking/__init__.py
+++ b/kedro-datasets/kedro_datasets/tracking/__init__.py
@@ -1,10 +1,10 @@
 """Dataset implementations to save data for Kedro Experiment Tracking."""
 
+import warnings
 from typing import Any
 
 import lazy_loader as lazy
 
-import warnings
 from kedro_datasets import KedroDeprecationWarning
 
 # https://github.com/pylint-dev/pylint/issues/4300#issuecomment-1043601901

--- a/kedro-datasets/kedro_datasets/tracking/__init__.py
+++ b/kedro-datasets/kedro_datasets/tracking/__init__.py
@@ -4,6 +4,9 @@ from typing import Any
 
 import lazy_loader as lazy
 
+import warnings
+from kedro_datasets import KedroDeprecationWarning
+
 # https://github.com/pylint-dev/pylint/issues/4300#issuecomment-1043601901
 JSONDataset: Any
 MetricsDataset: Any
@@ -14,4 +17,10 @@ __getattr__, __dir__, __all__ = lazy.attach(
         "json_dataset": ["JSONDataset"],
         "metrics_dataset": ["MetricsDataset"],
     },
+)
+
+warnings.warn(
+    "`tracking.JSONDataset` and `tracking.MetricsDataset` are deprecated. These datasets will be removed in kedro-datasets 7.0.0",
+    KedroDeprecationWarning,
+    stacklevel=2,
 )


### PR DESCRIPTION
## Description
Fixes #954 

This PR is to add the deprecation warning for MetricsTrackingDataset and JSONTrackingDataset as it will be removed soon in the next release

## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
- [ ] Received approvals from at least half of the TSC (required for adding a new, non-experimental dataset)
