### PR TITLE
fix(datasets): make `GBQTableDataset` serializable

### DIFF
--- a/kedro-datasets/RELEASE.md
+++ b/kedro-datasets/RELEASE.md
@@ -15,6 +15,8 @@
 
 ## Bug fixes and other changes
 
+- Delayed backend connection for `pandas.GBQTableDataset`. In practice, this means that a dataset's connection details aren't used (or validated) until the dataset is accessed. On the plus side, the cost of connection isn't incurred regardless of when or whether the dataset is used. Furthermore, this makes the dataset object serializable (e.g. for use with `ParallelRunner`), because the unserializable client isn't part of it.
+- Removed the unused BigQuery client created in `pandas.GBQQueryDataset`. This makes the dataset object serializable (e.g. for use with `ParallelRunner`) by removing the unserializable object.
 - Implemented Snowflake's [local testing framework](https://docs.snowflake.com/en/developer-guide/snowpark/python/testing-locally) for testing purposes.
 - Improved the dependency management for Spark-based datasets by refactoring the Spark and Databricks utility functions used across the datasets.
 - Added deprecation warning for `tracking.MetricsDataset` and `tracking.JSONDataset`.

--- a/kedro-datasets/tests/pandas/test_gbq_dataset.py
+++ b/kedro-datasets/tests/pandas/test_gbq_dataset.py
@@ -141,6 +141,7 @@ class TestGBQDataset:
         )
         mocked_read_gbq.return_value = dummy_dataframe
         mocked_df = mocker.Mock()
+        gbq_dataset._connection._credentials = None
 
         gbq_dataset.save(mocked_df)
         loaded_data = gbq_dataset.load()
@@ -205,8 +206,8 @@ class TestGBQDataset:
             credentials=credentials,
             project=PROJECT,
         )
+        dataset.exists()  # Do something to trigger the client creation.
 
-        assert dataset._credentials == credentials_obj
         mocked_credentials.assert_called_once_with(**credentials)
         mocked_bigquery.Client.assert_called_once_with(
             project=PROJECT, credentials=credentials_obj, location=None
@@ -238,7 +239,6 @@ class TestGBQQueryDataset:
             "kedro_datasets.pandas.gbq_dataset.Credentials",
             return_value=credentials_obj,
         )
-        mocked_bigquery = mocker.patch("kedro_datasets.pandas.gbq_dataset.bigquery")
 
         dataset = GBQQueryDataset(
             sql=SQL_QUERY,
@@ -248,9 +248,6 @@ class TestGBQQueryDataset:
 
         assert dataset._credentials == credentials_obj
         mocked_credentials.assert_called_once_with(**credentials)
-        mocked_bigquery.Client.assert_called_once_with(
-            project=PROJECT, credentials=credentials_obj, location=None
-        )
 
     def test_load(self, mocker, gbq_sql_dataset, dummy_dataframe):
         """Test `load` method invocation"""


### PR DESCRIPTION
## Description

Resolve https://kedro.hall.community/using-pandas-with-bigquery-and-parallel-runners-hTdF7LG3995h#a921cd9d-aa25-4752-9307-1862590a833d by delaying `bigquery.Client()` creation, as done in similar datasets.

## Development notes

Also, as it stands now, the `GBQQueryDataset` doesn't need a `bigquery.Client()`? I think it would make sense to potentially implement `GBQQueryDataset.exists()` (`if not query_or_table._is_query()`, checked with something like https://github.com/googleapis/python-bigquery-pandas/blob/78aa01e3f039500c9fabbcdd8d8dcfa3e5c42b73/pandas_gbq/gbq.py#L71), but I haven't done that in this PR. (You'd need to figure out what to do if it isn't a table; would you return `True` but raise a warning?)

## Checklist

- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Added a description of this change in the relevant `RELEASE.md` file
- [x] Added tests to cover my changes
- [ ] Received approvals from at least half of the TSC (required for adding a new, non-experimental dataset)
