### PR TITLE
fix(datasets): use kwarg for Ibis `read_*` methods

### DIFF
--- a/kedro-datasets/RELEASE.md
+++ b/kedro-datasets/RELEASE.md
@@ -7,6 +7,7 @@
 ## Bug fixes and other changes
 
 - Fix polars.CSVDataset `save` method on Windows using `utf-8` as default encoding.
+- Made `table_name` a keyword argument in the `ibis.FileDataset` implementation to be compatible with Ibis 10.0.
 
 ## Breaking Changes
 

--- a/kedro-datasets/kedro_datasets/ibis/file_dataset.py
+++ b/kedro-datasets/kedro_datasets/ibis/file_dataset.py
@@ -160,7 +160,7 @@ class FileDataset(ConnectionMixin, AbstractVersionedDataset[ir.Table, ir.Table])
     def load(self) -> ir.Table:
         load_path = self._get_load_path()
         reader = getattr(self.connection, f"read_{self._file_format}")
-        return reader(load_path, self._table_name, **self._load_args)
+        return reader(load_path, table_name=self._table_name, **self._load_args)
 
     def save(self, data: ir.Table) -> None:
         save_path = self._get_save_path()


### PR DESCRIPTION
## Description
Ibis 10.0 made a lot of arguments keyword-only, including `table_name` for `read_*` method.

## Development notes
This fixes the `ibis.FileDataset` doctest.

This doesn't fix the PyArrow issue, which I've separated into #1006. Would appreciate if these can be merged separately (despite CI failure) to maintain a cleaner commit history (for when the PyArrow pin should be reverted).

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Updated `jsonschema/kedro-catalog-X.XX.json` if necessary
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
- [ ] Received approvals from at least half of the TSC (required for adding a new, non-experimental dataset)
