### PR TITLE
build(datasets): pin PyArrow until `19.0.1` is out

### DIFF
--- a/kedro-datasets/pyproject.toml
+++ b/kedro-datasets/pyproject.toml
@@ -236,7 +236,7 @@ test = [
     "polars[deltalake,xlsx2csv]>=1.0",
     "pyarrow>=1.0; python_version < '3.11'",
     "pyarrow>=7.0; python_version >= '3.11'",  # Adding to avoid numpy build errors
-    "pyarrow<19.0.0",  # Temporary pin until https://github.com/apache/arrow/issues/45283 is fixed
+    "pyarrow!=19.0.0",  # Temporary pin until https://github.com/apache/arrow/issues/45283 is fixed
     "pyodbc~=5.0",
     "pyspark>=3.0; python_version < '3.11'",
     "pyspark>=3.4; python_version >= '3.11'",

--- a/kedro-datasets/pyproject.toml
+++ b/kedro-datasets/pyproject.toml
@@ -200,7 +200,7 @@ docs = [
 
 # Test requirements
 test = [
-    "accelerate<0.32", # Temporary pin
+    "accelerate<0.32",  # Temporary pin
     "adlfs~=2023.1",
     "behave==1.2.6",
     "biopython~=1.73",
@@ -236,6 +236,7 @@ test = [
     "polars[deltalake,xlsx2csv]>=1.0",
     "pyarrow>=1.0; python_version < '3.11'",
     "pyarrow>=7.0; python_version >= '3.11'",  # Adding to avoid numpy build errors
+    "pyarrow<19.0.0",  # Temporary pin until https://github.com/apache/arrow/issues/45283 is fixed
     "pyodbc~=5.0",
     "pyspark>=3.0; python_version < '3.11'",
     "pyspark>=3.4; python_version >= '3.11'",


### PR DESCRIPTION
## Description
PyArrow 19.0.0 broke stuff.

## Development notes
This fixes the doctest broken by PyArrow 19.0.0, but not the one broken by Ibis 10.0 (fixed in #1005). Would appreciate if these can be merged separately, so that there's a clearer commit history + we can easily rever the PyArrow pin.

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Updated `jsonschema/kedro-catalog-X.XX.json` if necessary
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
- [ ] Received approvals from at least half of the TSC (required for adding a new, non-experimental dataset)
