### PR TITLE
Remove _VERBOSE

### DIFF
--- a/kedro-docker/kedro_docker/plugin.py
+++ b/kedro-docker/kedro_docker/plugin.py
@@ -122,12 +122,7 @@ def docker_init(spark):
     project_path = Path.cwd()
     template_path = Path(__file__).parent / "template"
 
-    if KEDRO_VERSION.match(">=0.17.0"):
-        verbose = KedroCliError.VERBOSE_ERROR
-    else:
-        from kedro.framework.cli.cli import (
-            _VERBOSE as verbose,
-        )
+    verbose = KedroCliError.VERBOSE_ERROR
 
     docker_file_version = "spark" if spark else "simple"
     docker_file = f"Dockerfile.{docker_file_version}"


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->

Related to: https://github.com/kedro-org/kedro/issues/4526

Remove `_VERBOSE` usage from kedro-docker as it is a legacy code.

## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Updated `jsonschema/kedro-catalog-X.XX.json` if necessary
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
- [ ] Received approvals from at least half of the TSC (required for adding a new, non-experimental dataset)
