### PR TITLE
fix(datasets): Session handling for `SnowParkDataset`

### DIFF
--- a/kedro-datasets/RELEASE.md
+++ b/kedro-datasets/RELEASE.md
@@ -1,4 +1,4 @@
-# Upcoming Release
+# Upcoming Release 7.0.0
 
 ## Major features and improvements
 
@@ -9,6 +9,7 @@
 
 - Fixed `polars.CSVDataset` `save` method on Windows using `utf-8` as default encoding.
 - Made `table_name` a keyword argument in the `ibis.FileDataset` implementation to be compatible with Ibis 10.0.
+- Fixed how sessions are handled in the `snowflake.SnowflakeTableDataset` implementation.
 
 ## Breaking Changes
 

--- a/kedro-datasets/kedro_datasets/snowflake/snowpark_dataset.py
+++ b/kedro-datasets/kedro_datasets/snowflake/snowpark_dataset.py
@@ -232,11 +232,7 @@ class SnowparkTableDataset(AbstractDataset):
         Returns:
             DataFrame: The loaded data as a Snowpark DataFrame.
         """
-        if self._session is None:
-            raise DatasetError(
-                "No active session. Please initialise a Snowpark session before loading data."
-            )
-        return self._session.table(self._validate_and_get_table_name())
+        return self.session.table(self._validate_and_get_table_name())
 
     def save(self, data: pd.DataFrame | DataFrame) -> None:
         """
@@ -246,12 +242,8 @@ class SnowparkTableDataset(AbstractDataset):
         Args:
             data (pd.DataFrame | DataFrame): The data to save.
         """
-        if self._session is None:
-            raise DatasetError(
-                "No active session. Please initialise a Snowpark session before loading data."
-            )
         if isinstance(data, pd.DataFrame):
-            snowpark_df = self._session.create_dataframe(data)
+            snowpark_df = self.session.create_dataframe(data)
         elif isinstance(data, DataFrame):
             snowpark_df = data
         else:
@@ -270,12 +262,8 @@ class SnowparkTableDataset(AbstractDataset):
         Returns:
             bool: True if the table exists, False otherwise.
         """
-        if self._session is None:
-            raise DatasetError(
-                "No active session. Please initialise a Snowpark session before loading data."
-            )
         try:
-            self._session.table(
+            self.session.table(
                 f"{self._database}.{self._schema}.{self._table_name}"
             ).show()
             return True


### PR DESCRIPTION
## Description
Solves issues reported in https://github.com/kedro-org/kedro-plugins/issues/972 and http://github.com/kedro-org/kedro-plugins/issues/1034

## Development notes
The check for none was added by me in https://github.com/kedro-org/kedro-plugins/pull/881 to fix lint complaints. However, on looking at it again now I realised the `session` property wasn't actually used, so updated the code to use that instead of having the None check. 

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Updated `jsonschema/kedro-catalog-X.XX.json` if necessary
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
- [ ] Received approvals from at least half of the TSC (required for adding a new, non-experimental dataset)
