### PR TITLE
Fix credentials handling in pandas GBQ datasets

### DIFF
--- a/kedro-datasets/kedro_datasets/pandas/gbq_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/gbq_dataset.py
@@ -11,9 +11,10 @@ from typing import Any, ClassVar, NoReturn
 import fsspec
 import pandas as pd
 import pandas_gbq as pd_gbq
+from google.auth.credentials import Credentials
 from google.cloud import bigquery
 from google.cloud.exceptions import NotFound
-from google.oauth2.credentials import Credentials
+from google.oauth2.service_account import Credentials as ServiceAccountCredentials
 from kedro.io.core import (
     AbstractDataset,
     DatasetError,
@@ -23,6 +24,15 @@ from kedro.io.core import (
 )
 
 from kedro_datasets._utils import ConnectionMixin
+
+
+def _get_credentials(credentials: dict[str, Any] | str) -> ServiceAccountCredentials:
+    # If dict: Assume it's a service account json
+    if isinstance(credentials, dict):
+        return ServiceAccountCredentials.from_service_account_info(credentials)
+
+    # If str: Assume it's a path to a service account key json file
+    return ServiceAccountCredentials.from_service_account_file(credentials)
 
 
 class GBQTableDataset(ConnectionMixin, AbstractDataset[None, pd.DataFrame]):
@@ -78,7 +88,7 @@ class GBQTableDataset(ConnectionMixin, AbstractDataset[None, pd.DataFrame]):
         dataset: str,
         table_name: str,
         project: str | None = None,
-        credentials: dict[str, Any] | Credentials | None = None,
+        credentials: dict[str, Any] | str | Credentials | None = None,
         load_args: dict[str, Any] | None = None,
         save_args: dict[str, Any] | None = None,
         metadata: dict[str, Any] | None = None,
@@ -92,10 +102,9 @@ class GBQTableDataset(ConnectionMixin, AbstractDataset[None, pd.DataFrame]):
                 Optional when available from the environment.
                 https://cloud.google.com/resource-manager/docs/creating-managing-projects
             credentials: Credentials for accessing Google APIs.
-                Either ``google.auth.credentials.Credentials`` object or dictionary with
-                parameters required to instantiate ``google.oauth2.credentials.Credentials``.
-                Here you can find all the arguments:
-                https://google-auth.readthedocs.io/en/latest/reference/google.oauth2.credentials.html
+                Either a credential that bases on ``google.auth.credentials.Credentials`` OR
+                a service account json as a dictionary OR
+                a path to a service account key json file.
             load_args: Pandas options for loading BigQuery table into DataFrame.
                 Here you can find all available arguments:
                 https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_gbq.html
@@ -121,6 +130,10 @@ class GBQTableDataset(ConnectionMixin, AbstractDataset[None, pd.DataFrame]):
         self._dataset = dataset
         self._table_name = table_name
         self._project_id = project
+
+        if (not isinstance(credentials, Credentials)) and (credentials is not None):
+            credentials = _get_credentials(credentials)
+
         self._connection_config = {
             "project": self._project_id,
             "credentials": credentials,
@@ -138,14 +151,9 @@ class GBQTableDataset(ConnectionMixin, AbstractDataset[None, pd.DataFrame]):
         }
 
     def _connect(self) -> bigquery.Client:
-        credentials = self._connection_config["credentials"]
-        if isinstance(credentials, dict):
-            # Only create `Credentials` object once for consistent hash.
-            credentials = Credentials(**credentials)
-
         return bigquery.Client(
             project=self._connection_config["project"],
-            credentials=credentials,
+            credentials=self._connection_config["credentials"],
             location=self._connection_config["location"],
         )
 
@@ -276,10 +284,10 @@ class GBQQueryDataset(AbstractDataset[None, pd.DataFrame]):
 
         self._project_id = project
 
-        if isinstance(credentials, dict):
-            credentials = Credentials(**credentials)
-
-        self._credentials = credentials
+        if (not isinstance(credentials, Credentials)) and (credentials is not None):
+            self._credentials = _get_credentials(credentials)
+        else:
+            self._credentials = credentials
 
         # load sql query from arg or from file
         if sql:


### PR DESCRIPTION
## Description
This PR fixes the credentials handling in pandas.GBQTableDataset and pandas.GBQQueryDataset.

Details are in #975 

## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Updated `jsonschema/kedro-catalog-X.XX.json` if necessary
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
- [ ] Received approvals from at least half of the TSC (required for adding a new, non-experimental dataset)
