### PR TITLE
fix(telemetry): Replace DataCatalog with KedroDataCatalog

### DIFF
--- a/kedro-telemetry/kedro_telemetry/plugin.py
+++ b/kedro-telemetry/kedro_telemetry/plugin.py
@@ -22,7 +22,7 @@ from kedro.framework.cli.hooks import cli_hook_impl
 from kedro.framework.hooks import hook_impl
 from kedro.framework.project import PACKAGE_NAME, pipelines
 from kedro.framework.startup import ProjectMetadata
-from kedro.io.data_catalog import DataCatalog
+from kedro.io.kedro_data_catalog import KedroDataCatalog
 from kedro.pipeline import Pipeline
 
 from kedro_telemetry import __version__ as TELEMETRY_VERSION
@@ -289,7 +289,7 @@ def _get_project_properties(user_uuid: str, project_path: Path | None) -> dict:
 
 
 def _format_project_statistics_data(
-    catalog: DataCatalog,
+    catalog: KedroDataCatalog,
     default_pipeline: Pipeline,
     project_pipelines: dict,
 ):
@@ -297,7 +297,7 @@ def _format_project_statistics_data(
     project_statistics_properties = {}
     project_statistics_properties["number_of_datasets"] = sum(
         1
-        for c in catalog.list()
+        for c in catalog
         if not c.startswith("parameters") and not c.startswith("params:")
     )
     project_statistics_properties["number_of_nodes"] = (

--- a/kedro-telemetry/tests/integration/dummy-project/src/dummy_project/settings.py
+++ b/kedro-telemetry/tests/integration/dummy-project/src/dummy_project/settings.py
@@ -42,5 +42,5 @@ CONFIG_LOADER_ARGS = {
 # CONTEXT_CLASS = KedroContext
 
 # Class that manages the Data Catalog.
-# from kedro.io import DataCatalog
-# DATA_CATALOG_CLASS = DataCatalog
+# from kedro.io import KedroDataCatalog
+# DATA_CATALOG_CLASS = KedroDataCatalog

--- a/kedro-telemetry/tests/test_plugin.py
+++ b/kedro-telemetry/tests/test_plugin.py
@@ -7,7 +7,7 @@ import yaml
 from kedro import __version__ as kedro_version
 from kedro.framework.project import pipelines
 from kedro.framework.startup import ProjectMetadata
-from kedro.io import DataCatalog, MemoryDataset
+from kedro.io import KedroDataCatalog, MemoryDataset
 from kedro.pipeline import node
 from kedro.pipeline.modular_pipeline import pipeline as modular_pipeline
 from pytest import fixture, mark
@@ -76,7 +76,7 @@ def fake_metadata(tmp_path):
 
 @fixture
 def fake_catalog():
-    catalog = DataCatalog(
+    catalog = KedroDataCatalog(
         {
             "dummy_1": MemoryDataset(),
             "dummy_2": MemoryDataset(),


### PR DESCRIPTION
## Description

* As we move to Kedro 1.0.0 and remove DataCatalog, we need to make changes to the plugins referring to old catalog

## Development notes

* Replaced DataCatalog instances with KedroDataCatalog
* Updated tests
* Local testing with kedro - https://github.com/kedro-org/kedro/pull/4646 installation runs successfully

**NOTE:** 
1. This is not a backward compatible change. Need to discuss on this. 
2. This should go in only after DataCatalog clean up is done - https://github.com/kedro-org/kedro/issues/4584

## Checklist

- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Updated `jsonschema/kedro-catalog-X.XX.json` if necessary
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [x] Added tests to cover my changes
- [ ] Received approvals from at least half of the TSC (required for adding a new, non-experimental dataset)
