### PR TITLE
Update kedro-airflow to support `grouped_nodes_by_namespace` returning a list of `GroupedNode`

### DIFF
--- a/kedro-airflow/.gitignore
+++ b/kedro-airflow/.gitignore
@@ -115,6 +115,7 @@ celerybeat-schedule
 .venv
 env/
 venv/
+.venv/
 ENV/
 env.bak/
 venv.bak/

--- a/kedro-airflow/kedro_airflow/airflow_dag_template.j2
+++ b/kedro-airflow/kedro_airflow/airflow_dag_template.j2
@@ -65,12 +65,12 @@ with DAG(
     )
 ) as dag:
     tasks = {
-    {%- for node_name, node_data in node_objs.items() %}
-        "{{ node_name | slugify }}": KedroOperator(
-            task_id="{{ node_name | slugify }}",
+    {%- for group in node_objs %}
+        "{{ group.name | slugify }}": KedroOperator(
+            task_id="{{ group.name | slugify }}",
             package_name=package_name,
             pipeline_name=pipeline_name,
-            node_name={% if node_data.nodes | length > 1 %}[{% endif %}{% for node in node_data.nodes %}"{{ node.name }}"{% if not loop.last %}, {% endif %}{% endfor %}{% if node_data.nodes | length > 1 %}]{% endif %},
+            node_name={% if group.nodes | length > 1 %}[{% endif %}{% for node in group.nodes %}"{{ node }}"{% if not loop.last %}, {% endif %}{% endfor %}{% if group.nodes | length > 1 %}]{% endif %},
             project_path=project_path,
             env=env,
             conf_source=conf_source,
@@ -78,8 +78,8 @@ with DAG(
     {%- endfor %}
     }
 
-    {%- for node_name, node_data in node_objs.items() %}
-    {%- for dep in node_data.dependencies %}
-    tasks["{{ dep | slugify }}"] >> tasks["{{ node_name | slugify }}"]
+    {%- for group in node_objs %}
+    {%- for dep in group.dependencies %}
+    tasks["{{ dep | slugify }}"] >> tasks["{{ group.name | slugify }}"]
     {%- endfor %}
     {%- endfor %}

--- a/kedro-airflow/kedro_airflow/grouping.py
+++ b/kedro-airflow/kedro_airflow/grouping.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 from kedro.io import DataCatalog, MemoryDataset
-from kedro.pipeline.pipeline import Pipeline
+from kedro.pipeline.pipeline import Pipeline, GroupedNode
 
 try:
     from kedro.io import CatalogProtocol
@@ -58,7 +58,7 @@ def create_adjacency_list(
 
 def group_memory_nodes(
     catalog: CatalogProtocol | DataCatalog, pipeline: Pipeline
-) -> dict[str, dict[str, Any]]:
+) -> list[GroupedNode]:
     """
     Nodes that are connected through MemoryDatasets cannot be distributed across
     multiple machines, e.g. be in different Kubernetes pods. This function
@@ -93,20 +93,20 @@ def group_memory_nodes(
         groups[component].append(node_name)
 
     old_name_to_group = {}
-    grouped_by_memory: dict[str, dict[str, Any]] = {}
+    grouped_by_memory: dict[str, GroupedNode] = {}
 
     for group in groups:
         group_name = "_".join(group)
-        group_nodes = [name_to_node[node_name] for node_name in group]
         for node_name in group:
             old_name_to_group[node_name] = group_name
 
-        grouped_by_memory[group_name] = {
-            "name": group_name,
-            "type": "node",
-            "nodes": group_nodes,
-            "dependencies": [],
-        }
+        grouped_by_memory[group_name] = GroupedNode(
+            name=group_name,
+            type="node",
+            nodes=group,
+            dependencies=[],
+        )
+
 
     # Compute dependencies between groups
     for parent, children in parent_to_children.items():
@@ -114,7 +114,7 @@ def group_memory_nodes(
         for child in children:
             child_group = old_name_to_group[child]
             if parent_group != child_group:
-                if parent_group not in grouped_by_memory[child_group]["dependencies"]:
-                    grouped_by_memory[child_group]["dependencies"].append(parent_group)
+                if parent_group not in grouped_by_memory[child_group].dependencies:
+                    grouped_by_memory[child_group].dependencies.append(parent_group)
 
-    return grouped_by_memory
+    return list(grouped_by_memory.values())

--- a/kedro-airflow/kedro_airflow/plugin.py
+++ b/kedro-airflow/kedro_airflow/plugin.py
@@ -20,6 +20,7 @@ from kedro.framework.context import KedroContext
 from kedro.framework.project import pipelines
 from kedro.framework.session import KedroSession
 from kedro.framework.startup import ProjectMetadata
+from kedro.pipeline.pipeline import GroupedNode
 from slugify import slugify
 
 from kedro_airflow.grouping import group_memory_nodes
@@ -225,19 +226,23 @@ def create(  # noqa: PLR0913, PLR0912
         else:
             # To keep the order of nodes and dependencies deterministic - nodes are
             # iterated in the topological sort order obtained from pipeline.nodes and
-            # appended to the corresponding dictionaries
-            node_objs = {}
+            # appended to the corresponding list
+            node_objs = []
             for node in pipeline.nodes:
-                node_objs[node.name] = {
-                    "name": node.name,
-                    "nodes": [],
-                    "dependencies": [],
-                }
-                node_objs[node.name]["nodes"].append(node)
+                dependencies = [
+                    parent.name
+                    for parent in pipeline.node_dependencies[node]
+                    if parent.name != node.name
+                ]
 
-                for parent in pipeline.node_dependencies[node]:
-                    if parent.name != node.name:
-                        node_objs[node.name]["dependencies"].append(parent.name)
+                node_objs.append(
+                    GroupedNode(
+                        name=node.name,
+                        type="node",
+                        nodes=[node.name],
+                        dependencies=dependencies,
+                    )
+                )
 
         template.stream(
             dag_name=package_name,

--- a/kedro-airflow/tests/test_node_grouping.py
+++ b/kedro-airflow/tests/test_node_grouping.py
@@ -153,16 +153,16 @@ def test_group_memory_nodes(
 
     # Extract node name groups (sorted inside and overall, to ensure deterministic comparison)
     actual_nodes = [
-        sorted([node.name for node in group_info["nodes"]])
-        for group_info in result.values()
+        sorted(group_info.nodes)
+        for group_info in result
     ]
     assert sorted(actual_nodes) == sorted(expected_nodes)
 
     # Extract dependencies
     actual_dependencies = {
-        group_name: set(group_info["dependencies"])
-        for group_name, group_info in result.items()
-        if group_info["dependencies"]
+        group_info.name: set(group_info.dependencies)
+        for group_info in result
+        if group_info.dependencies
     }
     assert actual_dependencies == expected_dependencies
 


### PR DESCRIPTION
## Description

Second part of [#4684](https://github.com/kedro-org/kedro/issues/4684) - this PR updates kedro-airflow to support the updated `Pipeline.grouped_nodes_by_namespace` API, which now returns a list of `GroupedNode` objects instead of a dictionary.

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Updated `jsonschema/kedro-catalog-X.XX.json` if necessary
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
- [ ] Received approvals from at least half of the TSC (required for adding a new, non-experimental dataset)
