### PR TITLE
feat(telemetry): Update telemetry to support both catalogs

### DIFF
--- a/kedro-telemetry/RELEASE.md
+++ b/kedro-telemetry/RELEASE.md
@@ -1,4 +1,5 @@
 # Upcoming release
+* Updated catalog API usage to comply with both new and old catalogs.
 
 # Release 0.6.2
 * Removed support for Python 3.8

--- a/kedro-telemetry/kedro_telemetry/plugin.py
+++ b/kedro-telemetry/kedro_telemetry/plugin.py
@@ -294,10 +294,16 @@ def _format_project_statistics_data(
     project_pipelines: dict,
 ):
     """Add project statistics to send to Heap."""
+    # Support both catalog.list() for `kedro < 1.0` and catalog.keys() for `kedro >= 1.0`
+    if hasattr(catalog, "keys") and callable(catalog.keys):
+        dataset_names = catalog.keys()
+    else:
+        dataset_names = catalog.list()
+
     project_statistics_properties = {}
     project_statistics_properties["number_of_datasets"] = sum(
         1
-        for c in catalog.list()
+        for c in dataset_names
         if not c.startswith("parameters") and not c.startswith("params:")
     )
     project_statistics_properties["number_of_nodes"] = (

--- a/kedro-telemetry/tests/test_plugin.py
+++ b/kedro-telemetry/tests/test_plugin.py
@@ -689,9 +689,11 @@ class TestKedroTelemetryHook:
             catalog, pipeline_fixture, project_pipelines
         )
 
-        assert result["number_of_datasets"] == 2
-        assert result["number_of_nodes"] == 2
-        assert result["number_of_pipelines"] == 2
+        ds_nodes_pipes_cnt = 2
+
+        assert result["number_of_datasets"] == ds_nodes_pipes_cnt
+        assert result["number_of_nodes"] == ds_nodes_pipes_cnt
+        assert result["number_of_pipelines"] == ds_nodes_pipes_cnt
 
     def test_new_catalog_with_keys_method(self, pipeline_fixture, project_pipelines):
         # catalog.list() was replaces with catalog.keys() in `kedro >= 1.0`
@@ -710,6 +712,8 @@ class TestKedroTelemetryHook:
             catalog, pipeline_fixture, project_pipelines
         )
 
-        assert result["number_of_datasets"] == 2
-        assert result["number_of_nodes"] == 2
-        assert result["number_of_pipelines"] == 2
+        ds_nodes_pipes_cnt = 2
+
+        assert result["number_of_datasets"] == ds_nodes_pipes_cnt
+        assert result["number_of_nodes"] == ds_nodes_pipes_cnt
+        assert result["number_of_pipelines"] == ds_nodes_pipes_cnt

--- a/kedro-telemetry/tests/test_plugin.py
+++ b/kedro-telemetry/tests/test_plugin.py
@@ -1,6 +1,7 @@
 import logging
 import sys
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import requests
 import yaml
@@ -10,6 +11,7 @@ from kedro.framework.startup import ProjectMetadata
 from kedro.io import DataCatalog, MemoryDataset
 from kedro.pipeline import node
 from kedro.pipeline.modular_pipeline import pipeline as modular_pipeline
+from kedro.pipeline import Pipeline
 from pytest import fixture, mark
 
 from kedro_telemetry import __version__ as TELEMETRY_VERSION
@@ -20,6 +22,7 @@ from kedro_telemetry.plugin import (
     KedroTelemetryHook,
     _check_for_telemetry_consent,
     _is_known_ci_env,
+    _format_project_statistics_data,
 )
 
 REPO_NAME = "dummy_project"
@@ -120,6 +123,21 @@ def fake_sub_pipeline():
         ],
     )
     return mock_sub_pipeline
+
+
+@fixture
+def pipeline_fixture() -> Pipeline:
+    mock_pipeline = MagicMock(spec=Pipeline)
+    mock_pipeline.nodes = ["node1", "node2"]
+    return mock_pipeline
+
+
+@fixture
+def project_pipelines() -> dict[str, Pipeline]:
+    return {
+        "pipeline1": MagicMock(spec=Pipeline),
+        "pipeline2": MagicMock(spec=Pipeline),
+    }
 
 
 class TestKedroTelemetryHook:
@@ -652,3 +670,46 @@ class TestKedroTelemetryHook:
         telemetry_hook.after_context_created(fake_context)
 
         mocked_heap_call.assert_not_called()
+
+    def test_old_catalog_with_list_method(self, pipeline_fixture, project_pipelines):
+        # catalog.list() was replaces with catalog.keys() in `kedro >= 1.0`
+        catalog = MagicMock()
+        catalog.list.return_value = [
+            "dataset1",
+            "params:my_param",
+            "dataset2",
+            "parameters",
+        ]
+
+        # Ensure .keys is not present
+        if hasattr(catalog, "keys"):
+            del catalog.keys
+
+        result = _format_project_statistics_data(
+            catalog, pipeline_fixture, project_pipelines
+        )
+
+        assert result["number_of_datasets"] == 2
+        assert result["number_of_nodes"] == 2
+        assert result["number_of_pipelines"] == 2
+
+    def test_new_catalog_with_keys_method(self, pipeline_fixture, project_pipelines):
+        # catalog.list() was replaces with catalog.keys() in `kedro >= 1.0`
+        catalog = MagicMock()
+        catalog.keys.return_value = [
+            "datasetA",
+            "params:global",
+            "datasetB",
+            "parameters",
+        ]
+        # Ensure .list is not present
+        if hasattr(catalog, "list"):
+            del catalog.list
+
+        result = _format_project_statistics_data(
+            catalog, pipeline_fixture, project_pipelines
+        )
+
+        assert result["number_of_datasets"] == 2
+        assert result["number_of_nodes"] == 2
+        assert result["number_of_pipelines"] == 2

--- a/kedro-telemetry/tests/test_plugin.py
+++ b/kedro-telemetry/tests/test_plugin.py
@@ -9,9 +9,8 @@ from kedro import __version__ as kedro_version
 from kedro.framework.project import pipelines
 from kedro.framework.startup import ProjectMetadata
 from kedro.io import DataCatalog, MemoryDataset
-from kedro.pipeline import node
+from kedro.pipeline import Pipeline, node
 from kedro.pipeline.modular_pipeline import pipeline as modular_pipeline
-from kedro.pipeline import Pipeline
 from pytest import fixture, mark
 
 from kedro_telemetry import __version__ as TELEMETRY_VERSION
@@ -21,8 +20,8 @@ from kedro_telemetry.plugin import (
     MISSING_USER_IDENTITY,
     KedroTelemetryHook,
     _check_for_telemetry_consent,
-    _is_known_ci_env,
     _format_project_statistics_data,
+    _is_known_ci_env,
 )
 
 REPO_NAME = "dummy_project"


### PR DESCRIPTION
## Description
Solves https://github.com/kedro-org/kedro/issues/4620

## Development notes
Since we decided to keep the old catalog name - `DataCatalog` (https://github.com/kedro-org/kedro/issues/4721) -importing it for both versions will not cause the issue. However, we use the old list API to list datasets, which was deprecated for the new catalog. In this PR, we replace the old API call (list) with the new one (keys) and fallback to the old one in case the new one is not found.

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Updated `jsonschema/kedro-catalog-X.XX.json` if necessary
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
- [ ] Received approvals from at least half of the TSC (required for adding a new, non-experimental dataset)
