### PR TITLE
chore(datasets): Make `kedro-datasets` compatible with 1.0.0

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -344,35 +344,35 @@
         "filename": "kedro-datasets/tests/partitions/test_partitioned_dataset.py",
         "hashed_secret": "76f747de912e8682e29a23cb506dd5bf0de080d2",
         "is_verified": false,
-        "line_number": 468
+        "line_number": 471
       },
       {
         "type": "Secret Keyword",
         "filename": "kedro-datasets/tests/partitions/test_partitioned_dataset.py",
         "hashed_secret": "9027cc5a2c1321de60a2d71ccde6229d1152d6d3",
         "is_verified": false,
-        "line_number": 469
+        "line_number": 472
       },
       {
         "type": "Secret Keyword",
         "filename": "kedro-datasets/tests/partitions/test_partitioned_dataset.py",
         "hashed_secret": "5dcbdf371f181b9b7a41a4be7be70f8cbee67da7",
         "is_verified": false,
-        "line_number": 505
+        "line_number": 508
       },
       {
         "type": "Secret Keyword",
         "filename": "kedro-datasets/tests/partitions/test_partitioned_dataset.py",
         "hashed_secret": "727d8ff68b6b550f2cf6e737b3cad5149c65fe5b",
         "is_verified": false,
-        "line_number": 556
+        "line_number": 559
       },
       {
         "type": "Secret Keyword",
         "filename": "kedro-datasets/tests/partitions/test_partitioned_dataset.py",
         "hashed_secret": "adb5fabe51f5b45e83fdd91b71c92156fec4a63e",
         "is_verified": false,
-        "line_number": 576
+        "line_number": 579
       }
     ],
     "kedro-datasets/tests/plotly/test_html_dataset.py": [
@@ -494,5 +494,5 @@
       }
     ]
   },
-  "generated_at": "2025-05-23T11:17:12Z"
+  "generated_at": "2025-06-23T07:34:35Z"
 }

--- a/kedro-datasets/RELEASE.md
+++ b/kedro-datasets/RELEASE.md
@@ -1,8 +1,9 @@
-# Upcoming Release
+# Upcoming Release 8.0.0
 
 ## Major features and improvements
 
 - Migrated docs to mkdocs
+- Make `kedro-datasets` compatible with Kedro 1.0.0.
 
 ## Bug fixes and other changes
 
@@ -11,7 +12,7 @@
 
 ## Breaking changes
 
-- ...
+- `kedro-datasets` now requires Kedro 1.0.0 or higher.
 
 ## Community contributions
 

--- a/kedro-datasets/kedro_datasets/partitions/incremental_dataset.py
+++ b/kedro-datasets/kedro_datasets/partitions/incremental_dataset.py
@@ -14,6 +14,7 @@ from copy import deepcopy
 from typing import Any
 
 from cachetools import cachedmethod
+from kedro.io.catalog_config_resolver import CREDENTIALS_KEY
 from kedro.io.core import (
     VERSION_KEY,
     VERSIONED_FLAG_KEY,
@@ -21,7 +22,6 @@ from kedro.io.core import (
     DatasetError,
     parse_dataset_definition,
 )
-from kedro.io.data_catalog import CREDENTIALS_KEY
 from kedro.utils import load_obj
 
 from .partitioned_dataset import (

--- a/kedro-datasets/kedro_datasets/partitions/partitioned_dataset.py
+++ b/kedro-datasets/kedro_datasets/partitions/partitioned_dataset.py
@@ -14,13 +14,13 @@ from warnings import warn
 
 import fsspec
 from cachetools import Cache, cachedmethod
+from kedro.io.catalog_config_resolver import CREDENTIALS_KEY
 from kedro.io.core import (
     VERSION_KEY,
     AbstractDataset,
     DatasetError,
     parse_dataset_definition,
 )
-from kedro.io.data_catalog import CREDENTIALS_KEY
 
 KEY_PROPAGATION_WARNING = (
     "Top-level %(keys)s will not propagate into the %(target)s since "

--- a/kedro-datasets/tests/partitions/test_incremental_dataset.py
+++ b/kedro-datasets/tests/partitions/test_incremental_dataset.py
@@ -8,8 +8,8 @@ from typing import Any
 import boto3
 import pandas as pd
 import pytest
+from kedro.io.catalog_config_resolver import CREDENTIALS_KEY
 from kedro.io.core import AbstractDataset, DatasetError
-from kedro.io.data_catalog import CREDENTIALS_KEY
 from moto import mock_aws
 from pandas.testing import assert_frame_equal
 

--- a/kedro-datasets/tests/partitions/test_partitioned_dataset.py
+++ b/kedro-datasets/tests/partitions/test_partitioned_dataset.py
@@ -348,12 +348,15 @@ class TestPartitionedDatasetLocal:
                 r"Dataset type 'tests\.partitions\.test_partitioned_dataset\.FakeDataset' "
                 r"is invalid\: all dataset types must extend 'AbstractDataset'",
             ),
-            ({}, "'type' is missing from dataset catalog configuration"),
         ],
     )
     def test_invalid_dataset_config(self, dataset_config, error_pattern):
         with pytest.raises(DatasetError, match=error_pattern):
             PartitionedDataset(path=str(Path.cwd()), dataset=dataset_config)
+
+    def test_empty_dataset_config(self):
+        with pytest.raises(KeyError, match="type"):
+            PartitionedDataset(path=str(Path.cwd()), dataset={})
 
     @pytest.mark.parametrize(
         "dataset_config",

--- a/kedro-datasets/tests/partitions/test_partitioned_dataset.py
+++ b/kedro-datasets/tests/partitions/test_partitioned_dataset.py
@@ -8,7 +8,7 @@ import pandas as pd
 import pytest
 import s3fs
 from kedro.io import DatasetError
-from kedro.io.data_catalog import CREDENTIALS_KEY
+from kedro.io.catalog_config_resolver import CREDENTIALS_KEY
 from moto import mock_aws
 from pandas.testing import assert_frame_equal
 

--- a/kedro-datasets/tests/spark/test_deltatable_dataset.py
+++ b/kedro-datasets/tests/spark/test_deltatable_dataset.py
@@ -1,9 +1,8 @@
 import pytest
 from delta import DeltaTable
-from kedro.io import DataCatalog
 from kedro.io.core import DatasetError
-from kedro.pipeline import node
-from kedro.pipeline.modular_pipeline import pipeline as modular_pipeline
+from kedro.io.data_catalog import SharedMemoryDataCatalog
+from kedro.pipeline import node, pipeline
 from kedro.runner import ParallelRunner
 from packaging.version import Version
 from pyspark import __version__
@@ -91,11 +90,11 @@ class TestDeltaTableDataset:
             _ = x + 1  # pragma: no cover
 
         delta_ds = DeltaTableDataset(filepath="")
-        catalog = DataCatalog({"delta_in": delta_ds})
-        pipeline = modular_pipeline([node(no_output, "delta_in", None)])
+        catalog = SharedMemoryDataCatalog({"delta_in": delta_ds})
+        test_pipeline = pipeline([node(no_output, "delta_in", None)])
         pattern = (
             r"The following datasets cannot be used with "
             r"multiprocessing: \['delta_in'\]"
         )
         with pytest.raises(AttributeError, match=pattern):
-            ParallelRunner(is_async=is_async).run(pipeline, catalog)
+            ParallelRunner(is_async=is_async).run(test_pipeline, catalog)


### PR DESCRIPTION
## Description
Fix https://github.com/kedro-org/kedro-plugins/issues/1107 and address https://github.com/kedro-org/kedro-plugins/issues/1080

## Development notes
- Updated references to `modular_pipelines` 
- Updated import for `CREDENTIALS_KEYS`
- Use `SharedMemoryCatalog` for paralllel running

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Updated `jsonschema/kedro-catalog-X.XX.json` if necessary
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
- [ ] Received approvals from at least half of the TSC (required for adding a new, non-experimental dataset)
