### PR TITLE
test(datasets): restore doctests for every dataset

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -133,7 +133,7 @@
         "filename": "kedro-datasets/kedro_datasets/dask/parquet_dataset.py",
         "hashed_secret": "6e1d66a1596528c308e601c10aa0b92d53606ab9",
         "is_verified": false,
-        "line_number": 70
+        "line_number": 64
       }
     ],
     "kedro-datasets/kedro_datasets/pandas/sql_dataset.py": [
@@ -149,7 +149,7 @@
         "filename": "kedro-datasets/kedro_datasets/pandas/sql_dataset.py",
         "hashed_secret": "e026e197bb77b12d16ab6986e068751f016d0ea5",
         "is_verified": false,
-        "line_number": 378
+        "line_number": 369
       }
     ],
     "kedro-datasets/kedro_datasets/snowflake/snowpark_dataset.py": [
@@ -494,5 +494,5 @@
       }
     ]
   },
-  "generated_at": "2025-06-23T07:34:35Z"
+  "generated_at": "2025-06-27T02:56:04Z"
 }

--- a/Makefile
+++ b/Makefile
@@ -43,14 +43,14 @@ sign-off:
 ## kedro-datasets specific
 
 # kedro-datasets related only
-test-no-spark:
+test-no-spark: dataset-doctests-no-spark
 	cd kedro-datasets && pytest tests --no-cov --ignore tests/spark --ignore tests/databricks --numprocesses 4 --dist loadfile
 
 
 # kedro-datasets/snowflake tests skipped from default scope
 test-snowflake-only:
 	cd kedro-datasets && pytest --no-cov --numprocesses 1 --dist loadfile -m snowflake
-	cd kedro-datasets && pytest kedro_datasets/snowflake --no-cov
+	cd kedro-datasets && pytest kedro_datasets/snowflake --doctest-modules --doctest-continue-on-failure --no-cov
 
 build-datasets-docs:
 	# this checks: mkdocs.yml is valid, all listed pages exist, plugins are correctly configured, no broken references in nav or Markdown links (internal), broken links and images (internal, not external)
@@ -62,7 +62,26 @@ fix-markdownlint:
 	markdownlint-cli2 --config kedro-datasets/.markdownlint.yaml --fix "kedro-datasets/docs/**/*.md"
 
 # Run test_tensorflow_model_dataset separately, because these tests are flaky when run as part of the full test-suite
-dataset-tests:
+dataset-tests: dataset-doctests
 	cd kedro-datasets && pytest tests --cov-config pyproject.toml --numprocesses 4 --dist loadfile --ignore tests/tensorflow --ignore tests/databricks
 	cd kedro-datasets && pytest tests/tensorflow/test_tensorflow_model_dataset.py --no-cov
 	cd kedro-datasets && pytest tests/databricks --no-cov
+
+extra_pytest_args-no-spark=--ignore kedro_datasets/databricks --ignore kedro_datasets/spark
+extra_pytest_args=
+dataset-doctest%:
+	if [ "${*}" != 's-no-spark' ] && [ "${*}" != 's' ]; then \
+	  echo "make: *** No rule to make target \`${@}\`.  Stop."; \
+	  exit 2; \
+	fi; \
+    \
+	# The ignored datasets below require complicated setup with cloud/database clients which is overkill for the doctest examples.
+	cd kedro-datasets && pytest kedro_datasets --doctest-modules --doctest-continue-on-failure --no-cov \
+	  --ignore kedro_datasets/pandas/gbq_dataset.py \
+	  --ignore kedro_datasets/partitions/partitioned_dataset.py \
+	  --ignore kedro_datasets/redis/redis_dataset.py \
+	  --ignore kedro_datasets/snowflake/snowpark_dataset.py \
+	  --ignore kedro_datasets/spark/gbq_dataset.py \
+	  --ignore kedro_datasets/spark/spark_hive_dataset.py \
+	  --ignore kedro_datasets/spark/spark_jdbc_dataset.py \
+	  $(extra_pytest_arg${*})

--- a/kedro-datasets/CONTRIBUTING.md
+++ b/kedro-datasets/CONTRIBUTING.md
@@ -1,6 +1,5 @@
 # Introduction
 
-
 Thank you for considering contributing to Kedro-Datasets! Kedro-Datasets is a collection of [Kedro's](https://github.com/kedro-org/kedro) data connectors. We welcome contributions in the form of pull requests, issues or code reviews. You can contribute new datasets, fix bugs in existing datasets, or simply send us spelling and grammar fixes or extra tests. Contribute anything that you think improves the community for us all!
 
 The following sections describe our vision and the contribution process.
@@ -28,6 +27,7 @@ If you have new ideas for Kedro-Datasets then please open a [GitHub issue](https
 If you're unsure where to begin contributing to Kedro-Datasets, please start by looking through the `good first issue` and `help wanted` on [GitHub](https://github.com/kedro-org/kedro-plugins/issues).
 If you want to contribute a new dataset, read the [tutorial to create and contribute a custom dataset](https://docs.kedro.org/en/stable/data/how_to_create_a_custom_dataset.html) in the Kedro documentation.
 Make sure to add the necessary files for the new dataset so that it shows up in the API documentation:
+
 1. Ensure the dataset's docstring is markdown-parseable.
 2. Add an entry for your dataset to the table in `index.md` in either `docs/pages/api/kedro_datasets` or `docs/pages/api/kedro_datasets_experimental`, depending on the type.
 3. Create a markdown file for your dataset in the appropriate `pages/api` directory.
@@ -38,6 +38,7 @@ Below is a guide to help you understand the process of contributing a new datase
 ### Difference between core and experimental datasets
 
 #### Core datasets
+
 Core datasets are maintained by the [Kedro Technical Steering Committee (TSC)](https://docs.kedro.org/en/stable/contribution/technical_steering_committee.html) and adhere to specific standards. These datasets adhere to the following requirements:
 
 1. Must be something that the Kedro TSC is willing to maintain.
@@ -49,14 +50,15 @@ Core datasets are maintained by the [Kedro Technical Steering Committee (TSC)](h
 7. Should work on Linux, macOS, and Windows.
 
 #### Experimental datasets
+
 The requirements for experimental datasets are more flexible and these datasets are not maintained by the Kedro TSC. Experimental datasets:
 
 1. Do not need to be fully documented but must have docstrings explaining their use.
 2. Do not need to run as part of regular CI/CD jobs.
 3. Can be in the early stages of development or do not have to meet the criteria for core Kedro datasets.
 
-
 ### Graduation of datasets
+
 If your dataset is initially considered experimental but matures over time, it may qualify for graduation to a core dataset.
 
 1. Anyone, including TSC members and users, can trigger the graduation process.
@@ -64,37 +66,38 @@ If your dataset is initially considered experimental but matures over time, it m
 3. Your dataset can graduate when it meets all requirements of a core dataset.
 
 ### Demotion of datasets
+
 A dataset initially considered core might be demoted if it no longer meets the required standards.
 
 1. The demotion process will be initiated by someone from the TSC.
 2. A core dataset requires 1/2 approval from the TSC to be demoted to the experimental datasets space.
 
-
 ## Your first contribution
 
 Working on your first pull request? You can learn how from these resources:
-* [First timers only](https://www.firsttimersonly.com/)
-* [How to contribute to an open source project on GitHub](https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github)
+
+- [First timers only](https://www.firsttimersonly.com/)
+- [How to contribute to an open source project on GitHub](https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github)
 
 ### Guidelines
 
- - Aim for cross-platform compatibility on Windows, macOS and Linux
- - We use [Anaconda](https://www.anaconda.com/distribution/) as a preferred virtual environment
- - We use [SemVer](https://semver.org/) for versioning
- - We use [mkdocs](https://www.mkdocs.org/) for our documentation
+- Aim for cross-platform compatibility on Windows, macOS and Linux
+- We use [Anaconda](https://www.anaconda.com/distribution/) as a preferred virtual environment
+- We use [SemVer](https://semver.org/) for versioning
+- We use [mkdocs](https://www.mkdocs.org/) for our documentation
 
 Our code is designed to be compatible with Python 3.6 onwards and our style guidelines are (in cascading order):
 
-* [PEP 8 conventions](https://www.python.org/dev/peps/pep-0008/) for all Python code
-* [Google docstrings](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings) for code comments
-* [PEP 484 type hints](https://www.python.org/dev/peps/pep-0484/) for all user-facing functions / class methods e.g.
+- [PEP 8 conventions](https://www.python.org/dev/peps/pep-0008/) for all Python code
+- [Google docstrings](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings) for code comments
+- [PEP 484 type hints](https://www.python.org/dev/peps/pep-0484/) for all user-facing functions / class methods e.g.
 
 ```
 def count_truthy(elements: List[Any]) -> int:
     return sum(1 for elem in elements if elem)
 ```
 
-> *Note:* We only accept contributions under the [Apache 2.0](https://github.com/kedro-org/kedro-plugins/blob/main/LICENSE.md) license, and you should have permission to share the submitted code.
+> _Note:_ We only accept contributions under the [Apache 2.0](https://github.com/kedro-org/kedro-plugins/blob/main/LICENSE.md) license, and you should have permission to share the submitted code.
 
 ### Branching conventions
 
@@ -118,15 +121,14 @@ We use a branching model that helps us keep track of branches in a logical, cons
 7. Make sure the CI builds are green (have a look at the section [Running checks locally](#running-checks-locally) below).
 8. Update the PR according to the reviewer's comments.
 
-
 ## CI / CD and running checks locally
+
 To run tests you need to install the test requirements, do this using the following command:
 
 ```bash
 make plugin=kedro-datasets install-test-requirements
 make install-pre-commit
 ```
-
 
 ### Running checks locally
 
@@ -145,6 +147,7 @@ make plugin=kedro-datasets test
 ```
 
 If the tests in `kedro-datasets/kedro_datasets/spark` are failing, and you are not planning to work on Spark related features, then you can run the reduced test suite that excludes them with this command:
+
 ```bash
 make test-no-spark
 ```

--- a/kedro-datasets/CONTRIBUTING.md
+++ b/kedro-datasets/CONTRIBUTING.md
@@ -42,10 +42,11 @@ Core datasets are maintained by the [Kedro Technical Steering Committee (TSC)](h
 
 1. Must be something that the Kedro TSC is willing to maintain.
 2. Must be fully documented.
-3. Must run as part of the regular CI/CD jobs.
-4. Must have 100% test coverage.
-5. Should support all Python versions under NEP 29 (3.10+ currently).
-6. Should work on Linux, macOS, and Windows.
+3. Must have working doctests (unless complex cloud/DB setup required, which can be discussed in the review).
+4. Must run as part of the regular CI/CD jobs.
+5. Must have 100% test coverage.
+6. Should support all Python versions under NEP 29 (3.10+ currently).
+7. Should work on Linux, macOS, and Windows.
 
 #### Experimental datasets
 The requirements for experimental datasets are more flexible and these datasets are not maintained by the Kedro TSC. Experimental datasets:
@@ -108,14 +109,14 @@ We use a branching model that helps us keep track of branches in a logical, cons
 
 ## Dataset contribution process
 
- 1. Fork the project
- 2. Develop your contribution in a new branch.
- 3. Add your dataset to `kedro_datasets_experimental`.
- 4. Make sure all your commits are signed off by using `-s` flag with `git commit`.
- 5. Open a PR against the `main` branch and make sure that the PR title follows the [Conventional Commits specs](https://www.conventionalcommits.org/en/v1.0.0/) with the scope `(datasets)`.
- 6. The TSC will review your contribution and decide whether they want to maintain the dataset, and thus, whether it is contributed as a core or experimental dataset.
- 7. Make sure the CI builds are green (have a look at the section [Running checks locally](#running-checks-locally) below).
- 8. Update the PR according to the reviewer's comments.
+1. Fork the project
+2. Develop your contribution in a new branch.
+3. Add your dataset to `kedro_datasets_experimental`.
+4. Make sure all your commits are signed off by using `-s` flag with `git commit`.
+5. Open a PR against the `main` branch and make sure that the PR title follows the [Conventional Commits specs](https://www.conventionalcommits.org/en/v1.0.0/) with the scope `(datasets)`.
+6. The TSC will review your contribution and decide whether they want to maintain the dataset, and thus, whether it is contributed as a core or experimental dataset.
+7. Make sure the CI builds are green (have a look at the section [Running checks locally](#running-checks-locally) below).
+8. Update the PR according to the reviewer's comments.
 
 
 ## CI / CD and running checks locally

--- a/kedro-datasets/docs/javascript/code-select.js
+++ b/kedro-datasets/docs/javascript/code-select.js
@@ -1,0 +1,54 @@
+// Copied from https://github.com/astral-sh/uv/blob/78df14e7a8ff3345af3f58dfae53b07cacd8decb/docs/js/extra.js#L1-L45
+function cleanupClipboardText(targetSelector) {
+  const targetElement = document.querySelector(targetSelector);
+
+  // exclude "Generic Prompt" and "Generic Output" spans from copy
+  const excludedClasses = ["gp", "go"];
+
+  const clipboardText = Array.from(targetElement.childNodes)
+    .filter(
+      (node) =>
+        !excludedClasses.some((className) =>
+          node?.classList?.contains(className)
+        )
+    )
+    .map((node) => node.textContent)
+    .filter((s) => s != "");
+  return clipboardText.join("").trim();
+}
+
+// Sets copy text to attributes lazily using an Intersection Observer.
+function setCopyText() {
+  // The `data-clipboard-text` attribute allows for customized content in the copy
+  // See: https://www.npmjs.com/package/clipboard#copy-text-from-attribute
+  const attr = "clipboardText";
+  // all "copy" buttons whose target selector is a <code> element
+  const elements = document.querySelectorAll(
+    'button[data-clipboard-target$="code"]'
+  );
+  const observer = new IntersectionObserver((entries) => {
+    entries.forEach((entry) => {
+      // target in the viewport that have not been patched
+      if (
+        entry.intersectionRatio > 0 &&
+        entry.target.dataset[attr] === undefined
+      ) {
+        entry.target.dataset[attr] = cleanupClipboardText(
+          entry.target.dataset.clipboardTarget
+        );
+      }
+    });
+  });
+
+  elements.forEach((elt) => {
+    observer.observe(elt);
+  });
+}
+
+// Using the document$ observable is particularly important if you are using instant loading since
+// it will not result in a page refresh in the browser
+// See `How to integrate with third-party JavaScript libraries` guideline:
+// https://squidfunk.github.io/mkdocs-material/customization/?h=javascript#additional-javascript
+document$.subscribe(function () {
+  setCopyText();
+});

--- a/kedro-datasets/docs/stylesheets/code-select.css
+++ b/kedro-datasets/docs/stylesheets/code-select.css
@@ -1,0 +1,4 @@
+/* Copied from https://mkdocstrings.github.io/recipes/#prevent-selection-of-prompts-and-output-in-python-code-blocks */
+.highlight .gp, .highlight .go { /* Generic.Prompt, Generic.Output */
+    user-select: none;
+}

--- a/kedro-datasets/kedro_datasets/api/api_dataset.py
+++ b/kedro-datasets/kedro_datasets/api/api_dataset.py
@@ -17,10 +17,10 @@ class APIDataset(AbstractDataset[None, requests.Response]):
     """``APIDataset`` loads/saves data from/to HTTP(S) APIs.
     It uses the python requests library: https://requests.readthedocs.io/en/latest/
 
-    ### Example usage for the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
+    Examples:
+        Using the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
 
-    ```yaml
-
+        ```yaml
         usda:
           type: api.APIDataset
           url: https://quickstats.nass.usda.gov
@@ -31,39 +31,36 @@ class APIDataset(AbstractDataset[None, requests.Response]):
             statisticcat_des: YIELD,
             agg_level_desc: STATE,
             year: 2000
-    ```
-    ### Example usage for the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
+        ```
 
-    ```python
+        Using the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
 
-        from kedro_datasets.api import APIDataset
+        >>> from kedro_datasets.api import APIDataset
+        >>>
+        >>>
+        >>> dataset = APIDataset(
+        ...     url="https://api.spaceflightnewsapi.net/v4/articles",
+        ...     load_args={
+        ...         "params": {
+        ...             "news_site": "NASA",
+        ...             "launch": "65896761-b6ca-4df3-9699-e077a360c52a",  # Artemis I
+        ...         }
+        ...     },
+        ... )
+        >>> data = dataset.load()
 
+        ``APIDataset`` can also be used to save output on a remote server using HTTP(S)
+        methods:
 
-        dataset = APIDataset(
-            url="https://api.spaceflightnewsapi.net/v4/articles",
-            load_args={
-                "params": {
-                    "news_site": "NASA",
-                    "launch": "65896761-b6ca-4df3-9699-e077a360c52a",  # Artemis I
-                }
-            },
-        )
-        data = dataset.load()
-    ```
-    ``APIDataset`` can also be used to save output on a remote server using HTTP(S)
-    methods.
+        >>> example_table = '{"col1":["val1", "val2"], "col2":["val3", "val4"]}'
+        >>>
+        >>> dataset = APIDataset(
+        ...     method="POST",
+        ...     url="https://dummyjson.com/products/add",
+        ...     save_args={"chunk_size": 1},
+        ... )
+        >>> dataset.save(example_table)
 
-    ```python
-
-        example_table = '{"col1":["val1", "val2"], "col2":["val3", "val4"]}'
-
-        dataset = APIDataset(
-            method="POST",
-            url="https://dummyjson.com/products/add",
-            save_args={"chunk_size": 1},
-        )
-        dataset.save(example_table)
-    ```
     On initialisation, we can specify all the necessary parameters in the save args
     dictionary. The default HTTP(S) method is POST but PUT is also supported. Two
     important parameters to keep in mind are timeout and chunk_size. `timeout` defines
@@ -71,6 +68,7 @@ class APIDataset(AbstractDataset[None, requests.Response]):
     used if the input of save method is a list. It will divide the request into chunks
     of size `chunk_size`. For example, here we will send two requests each containing
     one row of our example DataFrame.
+
     If the data passed to the save method is not a list, ``APIDataset`` will check if it
     can be loaded as JSON. If true, it will send the data unchanged in a single request.
     Otherwise, the ``_save`` method will try to dump the data in JSON format and execute

--- a/kedro-datasets/kedro_datasets/biosequence/biosequence_dataset.py
+++ b/kedro-datasets/kedro_datasets/biosequence/biosequence_dataset.py
@@ -17,29 +17,25 @@ class BioSequenceDataset(AbstractDataset[list, list]):
 
     Example:
 
-    ```python
-
-        from kedro_datasets.biosequence import BioSequenceDataset
-        from io import StringIO
-        from Bio import SeqIO
-
-        data = ">Alpha\nACCGGATGTA\n>Beta\nAGGCTCGGTTA\n"
-        raw_data = []
-        for record in SeqIO.parse(StringIO(data), "fasta"):
-            raw_data.append(record)
-
-
-        dataset = BioSequenceDataset(
-            filepath=tmp_path / "ls_orchid.fasta",
-            load_args={"format": "fasta"},
-            save_args={"format": "fasta"},
-        )
-        dataset.save(raw_data)
-        sequence_list = dataset.load()
-
-        assert raw_data[0].id == sequence_list[0].id
-        assert raw_data[0].seq == sequence_list[0].seq
-    ```
+        >>> from Bio import SeqIO
+        >>> from io import StringIO
+        >>> from kedro_datasets.biosequence import BioSequenceDataset
+        >>>
+        >>> data = ">Alpha\nACCGGATGTA\n>Beta\nAGGCTCGGTTA\n"
+        >>> raw_data = []
+        >>> for record in SeqIO.parse(StringIO(data), "fasta"):
+        ...     raw_data.append(record)
+        ...
+        >>>
+        >>> dataset = BioSequenceDataset(
+        ...     filepath=tmp_path / "ls_orchid.fasta",
+        ...     load_args={"format": "fasta"},
+        ...     save_args={"format": "fasta"},
+        ... )
+        >>> dataset.save(raw_data)
+        >>> sequence_list = dataset.load()
+        >>> assert raw_data[0].id == sequence_list[0].id
+        >>> assert raw_data[0].seq == sequence_list[0].seq
     """
 
     DEFAULT_LOAD_ARGS: dict[str, Any] = {}

--- a/kedro-datasets/kedro_datasets/biosequence/biosequence_dataset.py
+++ b/kedro-datasets/kedro_datasets/biosequence/biosequence_dataset.py
@@ -15,7 +15,8 @@ from kedro.io.core import AbstractDataset, get_filepath_str, get_protocol_and_pa
 class BioSequenceDataset(AbstractDataset[list, list]):
     r"""``BioSequenceDataset`` loads and saves data to a sequence file.
 
-    Example:
+    Examples:
+        Using the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
 
         >>> from Bio import SeqIO
         >>> from io import StringIO
@@ -36,6 +37,7 @@ class BioSequenceDataset(AbstractDataset[list, list]):
         >>> sequence_list = dataset.load()
         >>> assert raw_data[0].id == sequence_list[0].id
         >>> assert raw_data[0].seq == sequence_list[0].seq
+
     """
 
     DEFAULT_LOAD_ARGS: dict[str, Any] = {}

--- a/kedro-datasets/kedro_datasets/conftest.py
+++ b/kedro-datasets/kedro_datasets/conftest.py
@@ -1,0 +1,6 @@
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def add_tmp_path(doctest_namespace, tmp_path):
+    doctest_namespace["tmp_path"] = tmp_path

--- a/kedro-datasets/kedro_datasets/dask/csv_dataset.py
+++ b/kedro-datasets/kedro_datasets/dask/csv_dataset.py
@@ -16,38 +16,36 @@ class CSVDataset(AbstractDataset[dd.DataFrame, dd.DataFrame]):
     remote data services to handle the corresponding load and save operations:
     https://docs.dask.org/en/stable/how-to/connect-to-remote-data.html
 
-    ### Example usage for the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
+    Examples:
+        Using the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
 
-    ```yaml
+        ```yaml
+        cars:
+          type: dask.CSVDataset
+          filepath: s3://bucket_name/path/to/folder
+          save_args:
+            compression: GZIP
+          credentials:
+            client_kwargs:
+              aws_access_key_id: YOUR_KEY
+              aws_secret_access_key: YOUR_SECRET
+        ```
 
-    cars:
-        type: dask.CSVDataset
-        filepath: s3://bucket_name/path/to/folder
-        save_args:
-        compression: GZIP
-        credentials:
-        client_kwargs:
-            aws_access_key_id: YOUR_KEY
-            aws_secret_access_key: YOUR_SECRET
-    ```
+        Using the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
 
-    ### Example usage for the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
+        >>> import dask.dataframe as dd
+        >>> import numpy as np
+        >>> import pandas as pd
+        >>> from kedro_datasets.dask import CSVDataset
+        >>>
+        >>> data = pd.DataFrame({"col1": [1, 2], "col2": [4, 5], "col3": [[5, 6], [7, 8]]})
+        >>> ddf = dd.from_pandas(data, npartitions=1)
+        >>>
+        >>> dataset = CSVDataset(filepath="path/to/folder/*.csv")
+        >>> dataset.save(ddf)
+        >>> reloaded = dataset.load()
+        >>> assert np.array_equal(ddf.compute(), reloaded.compute())
 
-    ```python
-
-    from kedro_datasets.dask import CSVDataset
-    import pandas as pd
-    import numpy as np
-    import dask.dataframe as dd
-
-    data = pd.DataFrame({"col1": [1, 2], "col2": [4, 5], "col3": [[5, 6], [7, 8]]})
-    ddf = dd.from_pandas(data, npartitions=1)
-    dataset = CSVDataset(filepath="path/to/folder/*.csv")
-
-    dataset.save(ddf)
-    reloaded = dataset.load()
-    assert np.array_equal(ddf.compute(), reloaded.compute())
-    ```
     """
 
     DEFAULT_LOAD_ARGS: dict[str, Any] = {}

--- a/kedro-datasets/kedro_datasets/dask/parquet_dataset.py
+++ b/kedro-datasets/kedro_datasets/dask/parquet_dataset.py
@@ -17,50 +17,44 @@ class ParquetDataset(AbstractDataset[dd.DataFrame, dd.DataFrame]):
     remote data services to handle the corresponding load and save operations:
     https://docs.dask.org/en/stable/how-to/connect-to-remote-data.html
 
-    ### Example usage for the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
+    Examples:
+        Using the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
 
-    ```yaml
+        ```yaml
+        cars:
+          type: dask.ParquetDataset
+          filepath: s3://bucket_name/path/to/folder
+          save_args:
+            compression: GZIP
+          credentials:
+            client_kwargs:
+              aws_access_key_id: YOUR_KEY
+              aws_secret_access_key: YOUR_SECRET
+        ```
 
-    cars:
-        type: dask.ParquetDataset
-        filepath: s3://bucket_name/path/to/folder
-        save_args:
-        compression: GZIP
-        credentials:
-        client_kwargs:
-            aws_access_key_id: YOUR_KEY
-            aws_secret_access_key: YOUR_SECRET
-    ```
-    ### Example usage for the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
+        Using the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
 
-    ```python
+        >>> import dask.dataframe as dd
+        >>> import pandas as pd
+        >>> import numpy as np
+        >>> from kedro_datasets.dask import ParquetDataset
+        >>>
+        >>> data = pd.DataFrame({"col1": [1, 2], "col2": [4, 5], "col3": [6, 7]})
+        >>> ddf = dd.from_pandas(data, npartitions=2)
+        >>>
+        >>> dataset = ParquetDataset(
+        ...     filepath=tmp_path / "path/to/folder", save_args={"compression": "GZIP"}
+        ... )
+        >>> dataset.save(ddf)
+        >>> reloaded = dataset.load()
+        >>> assert np.array_equal(ddf.compute(), reloaded.compute())
 
-    import dask.dataframe as dd
-    import pandas as pd
-    from kedro_datasets.dask import ParquetDataset
-    import numpy as np
+        The output schema can also be explicitly specified using
+        [Triad](https://triad.readthedocs.io/en/latest/api/triad.collections.html#module-triad.collections.schema).
+        This is processed to map specific columns to
+        [PyArrow field types](https://arrow.apache.org/docs/python/api/datatypes.html) or schema. For instance:
 
-    data = pd.DataFrame({"col1": [1, 2], "col2": [4, 5], "col3": [6, 7]})
-    ddf = dd.from_pandas(data, npartitions=2)
-
-    dataset = ParquetDataset(
-        filepath=tmp_path / "path/to/folder", save_args={"compression": "GZIP"}
-    )
-    dataset.save(ddf)
-    reloaded = dataset.load()
-
-    assert np.array_equal(ddf.compute(), reloaded.compute())
-    ```
-
-    The output schema can also be explicitly specified using
-    `Triad <https://triad.readthedocs.io/en/latest/api/\
-    triad.collections.html#module-triad.collections.schema>`_.
-    This is processed to map specific columns to
-    `PyArrow field types <https://arrow.apache.org/docs/python/api/\
-    datatypes.html>`_ or schema. For instance:
-
-    ```yaml
-
+        ```yaml
         parquet_dataset:
           type: dask.ParquetDataset
           filepath: "s3://bucket_name/path/to/folder"
@@ -74,7 +68,8 @@ class ParquetDataset(AbstractDataset[dd.DataFrame, dd.DataFrame]):
               col1: [int32]
               col2: [int32]
               col3: [[int32]]
-    ```
+        ```
+
     """
 
     DEFAULT_LOAD_ARGS: dict[str, Any] = {}

--- a/kedro-datasets/kedro_datasets/databricks/managed_table_dataset.py
+++ b/kedro-datasets/kedro_datasets/databricks/managed_table_dataset.py
@@ -33,50 +33,50 @@ class ManagedTableDataset(BaseTableDataset):
     dataset to function properly. Follow the instructions in that starter to
     setup your project for this dataset.
 
-    ### Example usage for the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
+    Examples:
+        Using the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
 
-    ```yaml
+        ```yaml
+        names_and_ages@spark:
+          type: databricks.ManagedTableDataset
+          table: names_and_ages
 
-    names_and_ages@spark:
-        type: databricks.ManagedTableDataset
-        table: names_and_ages
+        names_and_ages@pandas:
+          type: databricks.ManagedTableDataset
+          table: names_and_ages
+          dataframe_type: pandas
+        ```
 
-    names_and_ages@pandas:
-        type: databricks.ManagedTableDataset
-        table: names_and_ages
-        dataframe_type: pandas
-    ```
-    ### Example usage for the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
+        Using the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
 
-    ```python
+        >>> import importlib.metadata
+        >>>
+        >>> from kedro_datasets.databricks import ManagedTableDataset
+        >>> from pyspark.sql import SparkSession
+        >>> from pyspark.sql.types import IntegerType, Row, StringType, StructField, StructType
+        >>>
+        >>> DELTA_VERSION = importlib.metadata.version("delta-spark")
+        >>> schema = StructType(
+        ...     [StructField("name", StringType(), True), StructField("age", IntegerType(), True)]
+        ... )
+        >>> data = [("Alex", 31), ("Bob", 12), ("Clarke", 65), ("Dave", 29)]
+        >>> spark_df = (
+        ...     SparkSession.builder.config(
+        ...         "spark.jars.packages", f"io.delta:delta-core_2.12:{DELTA_VERSION}"
+        ...     )
+        ...     .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
+        ...     .config(
+        ...         "spark.sql.catalog.spark_catalog",
+        ...         "org.apache.spark.sql.delta.catalog.DeltaCatalog",
+        ...     )
+        ...     .getOrCreate()
+        ...     .createDataFrame(data, schema)
+        ... )
+        >>>
+        >>> dataset = ManagedTableDataset(table="names_and_ages", write_mode="overwrite")
+        >>> dataset.save(spark_df)
+        >>> reloaded = dataset.load()
 
-    from kedro_datasets.databricks import ManagedTableDataset
-    from pyspark.sql import SparkSession
-    from pyspark.sql.types import IntegerType, Row, StringType, StructField, StructType
-    import importlib_metadata
-
-    DELTA_VERSION = importlib_metadata.version("delta-spark")
-    schema = StructType(
-        [StructField("name", StringType(), True), StructField("age", IntegerType(), True)]
-    )
-    data = [("Alex", 31), ("Bob", 12), ("Clarke", 65), ("Dave", 29)]
-    spark_df = (
-        SparkSession.builder.config(
-            "spark.jars.packages", f"io.delta:delta-core_2.12:{DELTA_VERSION}"
-        )
-        .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
-        .config(
-            "spark.sql.catalog.spark_catalog",
-            "org.apache.spark.sql.delta.catalog.DeltaCatalog",
-        )
-        .getOrCreate()
-        .createDataFrame(data, schema)
-    )
-    dataset = ManagedTableDataset(table="names_and_ages", write_mode="overwrite")
-    dataset.save(spark_df)
-    reloaded = dataset.load()
-    assert Row(name="Bob", age=12) in reloaded.take(4)
-    ```
     """
 
     def __init__(  # noqa: PLR0913

--- a/kedro-datasets/kedro_datasets/email/message_dataset.py
+++ b/kedro-datasets/kedro_datasets/email/message_dataset.py
@@ -31,26 +31,23 @@ class EmailMessageDataset(AbstractVersionedDataset[Message, Message]):
 
     Example:
 
-    ```python
-
-        from email.message import EmailMessage
-
-        from kedro_datasets.email import EmailMessageDataset
-
-        string_to_write = "what would you do if you were invisable for one day????"
-
-        # Create a text/plain message
-        msg = EmailMessage()
-        msg.set_content(string_to_write)
-        msg["Subject"] = "invisibility"
-        msg["From"] = '"sin studly17"'
-        msg["To"] = '"strong bad"'
-
-        dataset = EmailMessageDataset(filepath=tmp_path / "test")
-        dataset.save(msg)
-        reloaded = dataset.load()
-        assert msg.__dict__ == reloaded.__dict__
-    ```
+        >>> from email.message import EmailMessage
+        >>>
+        >>> from kedro_datasets.email import EmailMessageDataset
+        >>>
+        >>> string_to_write = "what would you do if you were invisable for one day????"
+        >>>
+        >>> # Create a text/plain message
+        >>> msg = EmailMessage()
+        >>> msg.set_content(string_to_write)
+        >>> msg["Subject"] = "invisibility"
+        >>> msg["From"] = '"sin studly17"'
+        >>> msg["To"] = '"strong bad"'
+        >>>
+        >>> dataset = EmailMessageDataset(filepath=tmp_path / "test")
+        >>> dataset.save(msg)
+        >>> reloaded = dataset.load()
+        >>> assert msg.__dict__ == reloaded.__dict__
 
     """
 

--- a/kedro-datasets/kedro_datasets/email/message_dataset.py
+++ b/kedro-datasets/kedro_datasets/email/message_dataset.py
@@ -29,7 +29,8 @@ class EmailMessageDataset(AbstractVersionedDataset[Message, Message]):
 
     Note that ``EmailMessageDataset`` doesn't handle sending email messages.
 
-    Example:
+    Examples:
+        Using the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
 
         >>> from email.message import EmailMessage
         >>>

--- a/kedro-datasets/kedro_datasets/geopandas/generic_dataset.py
+++ b/kedro-datasets/kedro_datasets/geopandas/generic_dataset.py
@@ -37,22 +37,19 @@ class GenericDataset(
 
     Example:
 
-    ```python
-
-    import geopandas as gpd
-    from kedro_datasets.geopandas import GenericDataset
-    from shapely.geometry import Point
-
-    data = gpd.GeoDataFrame(
-        {"col1": [1, 2], "col2": [4, 5], "col3": [5, 6]},
-        geometry=[Point(1, 1), Point(2, 4)],
-    )
-    dataset = GenericDataset(filepath=tmp_path / "test.geojson")
-    dataset.save(data)
-    reloaded = dataset.load()
-
-    assert data.equals(reloaded)
-    ```
+        >>> import geopandas as gpd
+        >>> from kedro_datasets.geopandas import GenericDataset
+        >>> from shapely.geometry import Point
+        >>>
+        >>> data = gpd.GeoDataFrame(
+        ...     {"col1": [1, 2], "col2": [4, 5], "col3": [5, 6]},
+        ...     geometry=[Point(1, 1), Point(2, 4)],
+        ... )
+        >>>
+        >>> dataset = GenericDataset(filepath=tmp_path / "test.geojson")
+        >>> dataset.save(data)
+        >>> reloaded = dataset.load()
+        >>> assert data.equals(reloaded)
 
     """
 

--- a/kedro-datasets/kedro_datasets/geopandas/generic_dataset.py
+++ b/kedro-datasets/kedro_datasets/geopandas/generic_dataset.py
@@ -35,7 +35,8 @@ class GenericDataset(
     The underlying functionality is supported by geopandas, so it supports all
     allowed geopandas (pandas) options for loading and saving files.
 
-    Example:
+    Examples:
+        Using the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
 
         >>> import geopandas as gpd
         >>> from kedro_datasets.geopandas import GenericDataset

--- a/kedro-datasets/kedro_datasets/holoviews/holoviews_writer.py
+++ b/kedro-datasets/kedro_datasets/holoviews/holoviews_writer.py
@@ -25,12 +25,14 @@ class HoloviewsWriter(AbstractVersionedDataset[HoloViews, NoReturn]):
     """``HoloviewsWriter`` saves Holoviews objects to image file(s) in an underlying
     filesystem (e.g. local, S3, GCS).
 
-    Example:
+    Examples:
+        Using the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
 
         >>> import holoviews as hv
         >>> from kedro_datasets.holoviews import HoloviewsWriter
         >>>
         >>> curve = hv.Curve(range(10))
+        >>>
         >>> holoviews_writer = HoloviewsWriter(filepath=tmp_path / "holoviews")
         >>> holoviews_writer.save(curve)
 

--- a/kedro-datasets/kedro_datasets/holoviews/holoviews_writer.py
+++ b/kedro-datasets/kedro_datasets/holoviews/holoviews_writer.py
@@ -27,16 +27,12 @@ class HoloviewsWriter(AbstractVersionedDataset[HoloViews, NoReturn]):
 
     Example:
 
-    ```python
-
-        import holoviews as hv
-        from kedro_datasets.holoviews import HoloviewsWriter
-
-        curve = hv.Curve(range(10))
-        holoviews_writer = HoloviewsWriter(filepath=tmp_path / "holoviews")
-
-        holoviews_writer.save(curve)
-    ```
+        >>> import holoviews as hv
+        >>> from kedro_datasets.holoviews import HoloviewsWriter
+        >>>
+        >>> curve = hv.Curve(range(10))
+        >>> holoviews_writer = HoloviewsWriter(filepath=tmp_path / "holoviews")
+        >>> holoviews_writer.save(curve)
 
     """
 

--- a/kedro-datasets/kedro_datasets/huggingface/hugging_face_dataset.py
+++ b/kedro-datasets/kedro_datasets/huggingface/hugging_face_dataset.py
@@ -11,32 +11,29 @@ class HFDataset(AbstractDataset):
     """``HFDataset`` loads Hugging Face datasets
     using the `datasets <https://pypi.org/project/datasets>`_ library.
 
-    ### Example usage for the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
+    Examples:
+        Using the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
 
-    ```yaml
-    yelp_reviews:
-        type: kedro_hf_datasets.HFDataset
-        dataset_name: yelp_review_full
-    ```
+        ```yaml
+        yelp_reviews:
+          type: kedro_hf_datasets.HFDataset
+          dataset_name: yelp_review_full
+        ```
 
-    ### Example usage for the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
+        Using the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
 
-    ```python
-    from datasets.utils.logging import disable_progress_bar, set_verbosity, ERROR
-    disable_progress_bar()
-    set_verbosity(ERROR)
-
-    from kedro_datasets.huggingface import HFDataset
-    dataset = HFDataset(dataset_name="openai_humaneval")
-    ds = dataset.load()
-
-    # Output:
-    # Downloading and preparing dataset ...
-    # Dataset ...
-
-    assert "test" in ds
-    assert len(ds["test"]) == 164
-    ```
+        >>> from datasets.utils.logging import ERROR, disable_progress_bar, set_verbosity
+        >>> from kedro_datasets.huggingface import HFDataset
+        >>>
+        >>> disable_progress_bar()  # for doctest to pass
+        >>> set_verbosity(ERROR)  # for doctest to pass
+        >>>
+        >>> dataset = HFDataset(dataset_name="openai_humaneval")
+        >>> ds = dataset.load()  # doctest: +ELLIPSIS
+        Downloading and preparing dataset ...
+        Dataset ...
+        >>> assert "test" in ds
+        >>> assert len(ds["test"]) == 164
 
     """
 

--- a/kedro-datasets/kedro_datasets/huggingface/transformer_pipeline_dataset.py
+++ b/kedro-datasets/kedro_datasets/huggingface/transformer_pipeline_dataset.py
@@ -11,31 +11,29 @@ class HFTransformerPipelineDataset(AbstractDataset):
     """``HFTransformerPipelineDataset`` loads pretrained Hugging Face transformers
     using the `transformers <https://pypi.org/project/transformers>`_ library.
 
-    ### Example usage for the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
+    Examples:
+        Using the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
 
-    ```yaml
+        ```yaml
+        summarizer_model:
+          type: huggingface.HFTransformerPipelineDataset
+          task: summarization
 
-       summarizer_model:
-         type: huggingface.HFTransformerPipelineDataset
-         task: summarization
+        fill_mask_model:
+          type: huggingface.HFTransformerPipelineDataset
+          task: fill-mask
+          model_name: Twitter/twhin-bert-base
+        ```
 
-       fill_mask_model:
-         type: huggingface.HFTransformerPipelineDataset
-         task: fill-mask
-         model_name: Twitter/twhin-bert-base
-    ```
+        Using the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
 
-    ### Example usage for the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
-
-    ```python
-
-       from kedro_datasets.huggingface import HFTransformerPipelineDataset
-       dataset = HFTransformerPipelineDataset(
-           task="text-classification", model_name="prajjwal1/bert-tiny"
-       )
-       model = dataset.load()
-       assert model("Hello world")[0]["label"].startswith("LABEL_")
-    ```
+        >>> from kedro_datasets.huggingface import HFTransformerPipelineDataset
+        >>>
+        >>> dataset = HFTransformerPipelineDataset(
+        ...     task="text-classification", model_name="prajjwal1/bert-tiny"
+        ... )
+        >>> model = dataset.load()
+        >>> assert model("Hello world")[0]["label"].startswith("LABEL_")
 
     """
 

--- a/kedro-datasets/kedro_datasets/ibis/file_dataset.py
+++ b/kedro-datasets/kedro_datasets/ibis/file_dataset.py
@@ -17,9 +17,10 @@ if TYPE_CHECKING:
 class FileDataset(ConnectionMixin, AbstractVersionedDataset[ir.Table, ir.Table]):
     """``FileDataset`` loads/saves data from/to a specified file format.
 
-    ### Example usage for the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
+    Examples:
+        Using the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
 
-    ```yaml
+        ```yaml
         cars:
           type: ibis.FileDataset
           filepath: data/01_raw/company/cars.csv
@@ -42,28 +43,25 @@ class FileDataset(ConnectionMixin, AbstractVersionedDataset[ir.Table, ir.Table])
           table_name: motorbikes
           connection:
             backend: polars
-    ```
+        ```
 
-    ### Example usage for the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
+        Using the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
 
-    ```python
+        >>> import ibis
+        >>> from kedro_datasets.ibis import FileDataset
+        >>>
+        >>> data = ibis.memtable({"col1": [1, 2], "col2": [4, 5], "col3": [5, 6]})
+        >>>
+        >>> dataset = FileDataset(
+        ...     filepath=tmp_path / "test.csv",
+        ...     file_format="csv",
+        ...     table_name="test",
+        ...     connection={"backend": "duckdb", "database": tmp_path / "file.db"},
+        ... )
+        >>> dataset.save(data)
+        >>> reloaded = dataset.load()
+        >>> assert data.execute().equals(reloaded.execute())
 
-        import ibis
-        from kedro_datasets.ibis import FileDataset
-
-        data = ibis.memtable({"col1": [1, 2], "col2": [4, 5], "col3": [5, 6]})
-
-        dataset = FileDataset(
-            filepath=tmp_path / "test.csv",
-            file_format="csv",
-            table_name="test",
-            connection={"backend": "duckdb", "database": tmp_path / "file.db"},
-        )
-        dataset.save(data)
-        reloaded = dataset.load()
-        assert data.execute().equals(reloaded.execute())
-
-    ```
     """
 
     DEFAULT_CONNECTION_CONFIG: ClassVar[dict[str, Any]] = {

--- a/kedro-datasets/kedro_datasets/ibis/table_dataset.py
+++ b/kedro-datasets/kedro_datasets/ibis/table_dataset.py
@@ -16,41 +16,43 @@ if TYPE_CHECKING:
 class TableDataset(ConnectionMixin, AbstractDataset[ir.Table, ir.Table]):
     """`TableDataset` loads/saves data from/to Ibis table expressions.
 
-    ### Example usage for the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
-    ```yaml
-    cars:
-      type: ibis.TableDataset
-      table_name: cars
-      connection:
-        backend: duckdb
-        database: company.db
-      save_args:
-        materialized: table
+    Examples:
+        Using the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
 
-    motorbikes:
-      type: ibis.TableDataset
-      table_name: motorbikes
-      connection:
-        backend: duckdb
-        database: company.db
-    ```
+        ```yaml
+        cars:
+          type: ibis.TableDataset
+          table_name: cars
+          connection:
+            backend: duckdb
+            database: company.db
+          save_args:
+            materialized: table
 
-    ### Example usage for the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
-    ```python
-    import ibis
-    from kedro_datasets.ibis import TableDataset
+        motorbikes:
+          type: ibis.TableDataset
+          table_name: motorbikes
+          connection:
+            backend: duckdb
+            database: company.db
+        ```
 
-    data = ibis.memtable({"col1": [1, 2], "col2": [4, 5], "col3": [5, 6]})
+        Using the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
 
-    dataset = TableDataset(
-        table_name="test",
-        connection={"backend": "duckdb", "database": tmp_path / "file.db"},
-        save_args={"materialized": "table"},
-    )
-    dataset.save(data)
-    reloaded = dataset.load()
-    assert data.execute().equals(reloaded.execute())
-    ```
+        >>> import ibis
+        >>> from kedro_datasets.ibis import TableDataset
+        >>>
+        >>> data = ibis.memtable({"col1": [1, 2], "col2": [4, 5], "col3": [5, 6]})
+        >>>
+        >>> dataset = TableDataset(
+        ...     table_name="test",
+        ...     connection={"backend": "duckdb", "database": tmp_path / "file.db"},
+        ...     save_args={"materialized": "table"},
+        ... )
+        >>> dataset.save(data)
+        >>> reloaded = dataset.load()
+        >>> assert data.execute().equals(reloaded.execute())
+
     """
 
     DEFAULT_CONNECTION_CONFIG: ClassVar[dict[str, Any]] = {

--- a/kedro-datasets/kedro_datasets/json/json_dataset.py
+++ b/kedro-datasets/kedro_datasets/json/json_dataset.py
@@ -24,30 +24,29 @@ class JSONDataset(AbstractVersionedDataset[Any, Any]):
     """``JSONDataset`` loads/saves data from/to a JSON file using an underlying
     filesystem (e.g.: local, S3, GCS). It uses native json to handle the JSON file.
 
-    ### Example usage for the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
+    Examples:
+        Using the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
 
-    ```yaml
+        ```yaml
+        cars:
+          type: json.JSONDataset
+          filepath: gcs://your_bucket/cars.json
+          fs_args:
+            project: my-project
+          credentials: my_gcp_credentials
+        ```
 
-    cars:
-        type: json.JSONDataset
-        filepath: gcs://your_bucket/cars.json
-        fs_args:
-        project: my-project
-        credentials: my_gcp_credentials
-    ```
-    ### Example usage for the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
+        Using the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
 
-    ```python
+        >>> from kedro_datasets.json import JSONDataset
+        >>>
+        >>> data = {"col1": [1, 2], "col2": [4, 5], "col3": [5, 6]}
+        >>>
+        >>> dataset = JSONDataset(filepath=tmp_path / "test.json")
+        >>> dataset.save(data)
+        >>> reloaded = dataset.load()
+        >>> assert data == reloaded
 
-    from kedro_datasets.json import JSONDataset
-
-    data = {"col1": [1, 2], "col2": [4, 5], "col3": [5, 6]}
-
-    dataset = JSONDataset(filepath=tmp_path / "test.json")
-    dataset.save(data)
-    reloaded = dataset.load()
-    assert data == reloaded
-    ```
     """
 
     DEFAULT_SAVE_ARGS: dict[str, Any] = {"indent": 2}

--- a/kedro-datasets/kedro_datasets/matlab/matlab_dataset.py
+++ b/kedro-datasets/kedro_datasets/matlab/matlab_dataset.py
@@ -24,31 +24,30 @@ from scipy import io
 class MatlabDataset(AbstractVersionedDataset[np.ndarray, np.ndarray]):
     """`MatlabDataSet` loads and saves data from/to a MATLAB file using scipy.io.
 
-    ### Example usage for the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
+    Examples:
+        Using the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
 
-    ```yaml
+        ```yaml
+        cars:
+          type: matlab.MatlabDataset
+          filepath: gcs://your_bucket/cars.mat
+          fs_args:
+          project: my-project
+          credentials: my_gcp_credentials
+        ```
 
-    cars:
-        type: matlab.MatlabDataset
-        filepath: gcs://your_bucket/cars.mat
-        fs_args:
-        project: my-project
-        credentials: my_gcp_credentials
-    ```
-    ### Example usage for the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
+        Using the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
 
-    ```python
+        >>> import numpy as np
+        >>> from kedro_datasets.matlab import MatlabDataset
+        >>>
+        >>> data = np.array([1, 2, 3])
+        >>>
+        >>> dataset = MatlabDataset(filepath=tmp_path / "test.mat")
+        >>> dataset.save(data)
+        >>> reloaded = dataset.load()
+        >>> assert (data == reloaded["data"]).all()
 
-    from kedro_datasets.matlab import MatlabDataset
-    import numpy as np
-
-    data = np.array([1, 2, 3])
-    dataset = MatlabDataset(filepath=tmp_path / "test.mat")
-
-    dataset.save(data)
-    reloaded = dataset.load()
-    assert (data == reloaded["data"]).all()
-    ```
     """
 
     DEFAULT_SAVE_ARGS: dict[str, Any] = {"indent": 2}

--- a/kedro-datasets/kedro_datasets/matplotlib/matplotlib_dataset.py
+++ b/kedro-datasets/kedro_datasets/matplotlib/matplotlib_dataset.py
@@ -29,86 +29,60 @@ class MatplotlibDataset(
     """``MatplotlibDataset`` saves one or more Matplotlib objects as
     image files to an underlying filesystem (e.g. local, S3, GCS).
 
-    ### Example usage for the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
+    Examples:
+        Using the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
 
-    ```yaml
+        ```yaml
+        output_plot:
+          type: matplotlib.MatplotlibDataset
+          filepath: data/08_reporting/output_plot.png
+          save_args:
+            format: png
+        ```
 
-    output_plot:
-        type: matplotlib.MatplotlibDataset
-        filepath: data/08_reporting/output_plot.png
-        save_args:
-        format: png
-    ```
-    ### Example usage for the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
+        Using the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
 
-    ```python
+        >>> import matplotlib.pyplot as plt
+        >>> from kedro_datasets.matplotlib import MatplotlibDataset
+        >>>
+        >>> fig = plt.figure()
+        >>> plt.plot([1, 2, 3])  # doctest: +ELLIPSIS
+        [<matplotlib.lines.Line2D object at 0x...>]
+        >>> plot_dataset = MatplotlibDataset(filepath=tmp_path / "data/08_reporting/output_plot.png")
+        >>> plt.close()
+        >>> plot_dataset.save(fig)
 
-    import matplotlib.pyplot as plt
-    from kedro_datasets.matplotlib import MatplotlibDataset
+        Saving a plot as a PDF file:
 
-    fig = plt.figure()
-    plt.plot([1, 2, 3])
-    [<matplotlib.lines.Line2D object at 0x...>]
-    plot_dataset = MatplotlibDataset(filepath=tmp_path / "data/08_reporting/output_plot.png")
-    plt.close()
-    plot_dataset.save(fig)
-    ```
-    Example saving a plot as a PDF file:
+        >>> import matplotlib.pyplot as plt
+        >>> from kedro_datasets.matplotlib import MatplotlibDataset
+        >>>
+        >>> fig = plt.figure()
+        >>> plt.plot([1, 2, 3])  # doctest: +ELLIPSIS
+        [<matplotlib.lines.Line2D object at 0x...>]
+        >>> pdf_plot_dataset = MatplotlibDataset(
+        ...     filepath=tmp_path / "data/08_reporting/output_plot.pdf", save_args={"format": "pdf"}
+        ... )
+        >>> plt.close()
+        >>> pdf_plot_dataset.save(fig)
 
-    ```python
+        Saving multiple plots in a folder, using a dictionary:
 
-    import matplotlib.pyplot as plt
-    from kedro_datasets.matplotlib import MatplotlibDataset
+        >>> import matplotlib.pyplot as plt
+        >>> from kedro_datasets.matplotlib import MatplotlibDataset
+        >>>
+        >>> plots_dict = {}
+        >>> for colour in ["blue", "green", "red"]:
+        ...     plots_dict[f"{colour}.png"] = plt.figure()
+        ...     plt.plot([1, 2, 3], color=colour)
+        ...
+        [<matplotlib.lines.Line2D object at 0x...>]
+        [<matplotlib.lines.Line2D object at 0x...>]
+        [<matplotlib.lines.Line2D object at 0x...>]
+        >>> plt.close("all")
+        >>> dict_plot_dataset = MatplotlibDataset(filepath=tmp_path / "data/08_reporting/plots")
+        >>> dict_plot_dataset.save(plots_dict)
 
-    fig = plt.figure()
-    plt.plot([1, 2, 3])
-    [<matplotlib.lines.Line2D object at 0x...>]
-    pdf_plot_dataset = MatplotlibDataset(
-        filepath=tmp_path / "data/08_reporting/output_plot.pdf", save_args={"format": "pdf"}
-    )
-    plt.close()
-    pdf_plot_dataset.save(fig)
-    ```
-    Example saving multiple plots in a folder, using a dictionary:
-
-    ```python
-
-    import matplotlib.pyplot as plt
-    from kedro_datasets.matplotlib import MatplotlibDataset
-
-    plots_dict = {}
-    for colour in ["blue", "green", "red"]:
-        plots_dict[f"{colour}.png"] = plt.figure()
-        plt.plot([1, 2, 3], color=colour)
-
-    [<matplotlib.lines.Line2D object at 0x...>]
-    [<matplotlib.lines.Line2D object at 0x...>]
-    [<matplotlib.lines.Line2D object at 0x...>]
-    plt.close("all")
-    dict_plot_dataset = MatplotlibDataset(filepath=tmp_path / "data/08_reporting/plots")
-    dict_plot_dataset.save(plots_dict)
-    ```
-    Example saving multiple plots in a folder, using a list:
-
-    ```python
-
-    import matplotlib.pyplot as plt
-    from kedro_datasets.matplotlib import MatplotlibDataset
-
-    plots_list = []
-    for i in range(5):
-        plots_list.append(plt.figure())
-        plt.plot([i, i + 1, i + 2])
-
-    [<matplotlib.lines.Line2D object at 0x...>]
-    [<matplotlib.lines.Line2D object at 0x...>]
-    [<matplotlib.lines.Line2D object at 0x...>]
-    [<matplotlib.lines.Line2D object at 0x...>]
-    [<matplotlib.lines.Line2D object at 0x...>]
-    plt.close("all")
-    list_plot_dataset = MatplotlibDataset(filepath=tmp_path / "data/08_reporting/plots")
-    list_plot_dataset.save(plots_list)
-    ```
     """
 
     DEFAULT_SAVE_ARGS: dict[str, Any] = {}

--- a/kedro-datasets/kedro_datasets/networkx/gml_dataset.py
+++ b/kedro-datasets/kedro_datasets/networkx/gml_dataset.py
@@ -22,20 +22,21 @@ class GMLDataset(AbstractVersionedDataset[networkx.Graph, networkx.Graph]):
     """``GMLDataset`` loads and saves graphs to a GML file using an
     underlying filesystem (e.g.: local, S3, GCS). NetworkX is used to
     create GML data.
+
     See https://networkx.org/documentation/stable/tutorial.html for details.
 
     Example:
 
-    ```python
+        >>> import networkx as nx
+        >>> from kedro_datasets.networkx import GMLDataset
+        >>>
+        >>> graph = nx.complete_graph(100)
+        >>>
+        >>> graph_dataset = GMLDataset(filepath=tmp_path / "test.gml")
+        >>> graph_dataset.save(graph)
+        >>> reloaded = graph_dataset.load()
+        >>> assert nx.is_isomorphic(graph, reloaded)
 
-        from kedro_datasets.networkx import GMLDataset
-        import networkx as nx
-        graph = nx.complete_graph(100)
-        graph_dataset = GMLDataset(filepath=tmp_path / "test.gml")
-        graph_dataset.save(graph)
-        reloaded = graph_dataset.load()
-        assert nx.is_isomorphic(graph, reloaded)
-    ```
     """
 
     DEFAULT_LOAD_ARGS: dict[str, Any] = {}

--- a/kedro-datasets/kedro_datasets/networkx/gml_dataset.py
+++ b/kedro-datasets/kedro_datasets/networkx/gml_dataset.py
@@ -25,7 +25,8 @@ class GMLDataset(AbstractVersionedDataset[networkx.Graph, networkx.Graph]):
 
     See https://networkx.org/documentation/stable/tutorial.html for details.
 
-    Example:
+    Examples:
+        Using the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
 
         >>> import networkx as nx
         >>> from kedro_datasets.networkx import GMLDataset

--- a/kedro-datasets/kedro_datasets/networkx/graphml_dataset.py
+++ b/kedro-datasets/kedro_datasets/networkx/graphml_dataset.py
@@ -21,20 +21,21 @@ class GraphMLDataset(AbstractVersionedDataset[networkx.Graph, networkx.Graph]):
     """``GraphMLDataset`` loads and saves graphs to a GraphML file using an
     underlying filesystem (e.g.: local, S3, GCS). NetworkX is used to
     create GraphML data.
+
     See https://networkx.org/documentation/stable/tutorial.html for details.
 
     Example:
 
-    ```python
+        >>> import networkx as nx
+        >>> from kedro_datasets.networkx import GraphMLDataset
+        >>>
+        >>> graph = nx.complete_graph(100)
+        >>>
+        >>> graph_dataset = GraphMLDataset(filepath=tmp_path / "test.graphml")
+        >>> graph_dataset.save(graph)
+        >>> reloaded = graph_dataset.load()
+        >>> assert nx.is_isomorphic(graph, reloaded)
 
-        from kedro_datasets.networkx import GraphMLDataset
-        import networkx as nx
-        graph = nx.complete_graph(100)
-        graph_dataset = GraphMLDataset(filepath=tmp_path / "test.graphml")
-        graph_dataset.save(graph)
-        reloaded = graph_dataset.load()
-        assert nx.is_isomorphic(graph, reloaded)
-    ```
     """
 
     DEFAULT_LOAD_ARGS: dict[str, Any] = {}

--- a/kedro-datasets/kedro_datasets/networkx/graphml_dataset.py
+++ b/kedro-datasets/kedro_datasets/networkx/graphml_dataset.py
@@ -24,7 +24,8 @@ class GraphMLDataset(AbstractVersionedDataset[networkx.Graph, networkx.Graph]):
 
     See https://networkx.org/documentation/stable/tutorial.html for details.
 
-    Example:
+    Examples:
+        Using the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
 
         >>> import networkx as nx
         >>> from kedro_datasets.networkx import GraphMLDataset

--- a/kedro-datasets/kedro_datasets/networkx/json_dataset.py
+++ b/kedro-datasets/kedro_datasets/networkx/json_dataset.py
@@ -24,18 +24,19 @@ class JSONDataset(AbstractVersionedDataset[networkx.Graph, networkx.Graph]):
     create JSON data.
     See https://networkx.org/documentation/stable/tutorial.html for details.
 
-    Example:
+    Examples:
+        Using the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
 
-    ```python
+        >>> import networkx as nx
+        >>> from kedro_datasets.networkx import JSONDataset
+        >>>
+        >>> graph = nx.complete_graph(100)
+        >>>
+        >>> graph_dataset = JSONDataset(filepath=tmp_path / "test.json")
+        >>> graph_dataset.save(graph)
+        >>> reloaded = graph_dataset.load()
+        >>> assert nx.is_isomorphic(graph, reloaded)
 
-        from kedro_datasets.networkx import JSONDataset
-        import networkx as nx
-        graph = nx.complete_graph(100)
-        graph_dataset = JSONDataset(filepath=tmp_path / "test.json")
-        graph_dataset.save(graph)
-        reloaded = graph_dataset.load()
-        assert nx.is_isomorphic(graph, reloaded)
-    ```
     """
 
     DEFAULT_LOAD_ARGS: dict[str, Any] = {}

--- a/kedro-datasets/kedro_datasets/pandas/csv_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/csv_dataset.py
@@ -28,40 +28,42 @@ class CSVDataset(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
     """``CSVDataset`` loads/saves data from/to a CSV file using an underlying
     filesystem (e.g.: local, S3, GCS). It uses pandas to handle the CSV file.
 
-    ### Example usage for the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
+    Examples:
+        Using the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
 
-    ```yaml
+        ```yaml
+        cars:
+          type: pandas.CSVDataset
+          filepath: data/01_raw/company/cars.csv
+          load_args:
+            sep: ","
+            na_values: ["#NA", NA]
+          save_args:
+            index: False
+            date_format: "%Y-%m-%d %H:%M"
+            decimal: .
+          fs_args:
+            open_args_save:
+                mode: a
 
-    cars:
-        type: pandas.CSVDataset
-        filepath: data/01_raw/company/cars.csv
-        load_args:
-        sep: ","
-        na_values: ["#NA", NA]
-        save_args:
-        index: False
-        date_format: "%Y-%m-%d %H:%M"
-        decimal: .
+        motorbikes:
+          type: pandas.CSVDataset
+          filepath: s3://your_bucket/data/02_intermediate/company/motorbikes.csv
+          credentials: dev_s3
+        ```
 
-    motorbikes:
-        type: pandas.CSVDataset
-        filepath: s3://your_bucket/data/02_intermediate/company/motorbikes.csv
-        credentials: dev_s3
-    ```
-    ### Example usage for the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
+        Using the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
 
-    ```python
+        >>> from kedro_datasets.pandas import CSVDataset
+        >>> import pandas as pd
+        >>>
+        >>> data = pd.DataFrame({"col1": [1, 2], "col2": [4, 5], "col3": [5, 6]})
+        >>>
+        >>> dataset = CSVDataset(filepath=tmp_path / "test.csv")
+        >>> dataset.save(data)
+        >>> reloaded = dataset.load()
+        >>> assert data.equals(reloaded)
 
-    from kedro_datasets.pandas import CSVDataset
-    import pandas as pd
-
-    data = pd.DataFrame({"col1": [1, 2], "col2": [4, 5], "col3": [5, 6]})
-
-    dataset = CSVDataset(filepath=tmp_path / "test.csv")
-    dataset.save(data)
-    reloaded = dataset.load()
-    assert data.equals(reloaded)
-    ```
     """
 
     DEFAULT_LOAD_ARGS: dict[str, Any] = {}

--- a/kedro-datasets/kedro_datasets/pandas/deltatable_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/deltatable_dataset.py
@@ -23,10 +23,10 @@ class DeltaTableDataset(AbstractDataset):
     mode=overwrite together with partition_filters. This will remove all files within the
     matching partition and insert your data as new files.
 
-    ### Example usage for the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
+    Examples:
+        Using the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
 
-    ```yaml
-
+        ```yaml
         boats_filesystem:
           type: pandas.DeltaTableDataset
           filepath: data/01_raw/boats
@@ -54,25 +54,24 @@ class DeltaTableDataset(AbstractDataset):
           table: db_table
           save_args:
             mode: overwrite
-    ```
-    ### Example usage for the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
+        ```
 
-    ```python
+        Using the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
 
-        from kedro_datasets.pandas import DeltaTableDataset
-        import pandas as pd
+        >>> from kedro_datasets.pandas import DeltaTableDataset
+        >>> import pandas as pd
+        >>>
+        >>> data = pd.DataFrame({"col1": [1, 2], "col2": [4, 5], "col3": [5, 6]})
+        >>>
+        >>> dataset = DeltaTableDataset(filepath=tmp_path / "test")
+        >>> dataset.save(data)
+        >>> reloaded = dataset.load()
+        >>> assert data.equals(reloaded)
+        >>>
+        >>> new_data = pd.DataFrame({"col1": [7, 8], "col2": [9, 10], "col3": [11, 12]})
+        >>> dataset.save(new_data)
+        >>> assert isinstance(dataset.get_loaded_version(), int)
 
-        data = pd.DataFrame({"col1": [1, 2], "col2": [4, 5], "col3": [5, 6]})
-        dataset = DeltaTableDataset(filepath=tmp_path / "test")
-
-        dataset.save(data)
-        reloaded = dataset.load()
-        assert data.equals(reloaded)
-
-        new_data = pd.DataFrame({"col1": [7, 8], "col2": [9, 10], "col3": [11, 12]})
-        dataset.save(new_data)
-        assert isinstance(dataset.get_loaded_version(), int)
-    ```
     """
 
     DEFAULT_WRITE_MODE = "overwrite"

--- a/kedro-datasets/kedro_datasets/pandas/excel_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/excel_dataset.py
@@ -33,71 +33,66 @@ class ExcelDataset(
     """``ExcelDataset`` loads/saves data from/to a Excel file using an underlying
     filesystem (e.g.: local, S3, GCS). It uses pandas to handle the Excel file.
 
-    ### Example usage for the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
-
-    ```yaml
-
-    rockets:
-        type: pandas.ExcelDataset
-        filepath: gcs://your_bucket/rockets.xlsx
-        fs_args:
-        project: my-project
-        credentials: my_gcp_credentials
-        save_args:
-        sheet_name: Sheet1
-        load_args:
-        sheet_name: Sheet1
-
-    shuttles:
-        type: pandas.ExcelDataset
-        filepath: data/01_raw/shuttles.xlsx
-    ```
-    ### Example usage for the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
-
-    ```python
-
-    from kedro_datasets.pandas import ExcelDataset
-    import pandas as pd
-
-    data = pd.DataFrame({"col1": [1, 2], "col2": [4, 5], "col3": [5, 6]})
-
-    dataset = ExcelDataset(filepath=tmp_path / "test.xlsx")
-    dataset.save(data)
-    reloaded = dataset.load()
-    assert data.equals(reloaded)
-    ```
-
     To save a multi-sheet Excel file, no special ``save_args`` are required.
     Instead, return a dictionary of ``Dict[str, pd.DataFrame]`` where the string
     keys are your sheet names.
 
-    ### Example usage for the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html) for a multi-sheet Excel file:
+    Examples:
+        Using the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
 
-    ```yaml
+        ```yaml
+        rockets:
+          type: pandas.ExcelDataset
+          filepath: gcs://your_bucket/rockets.xlsx
+          fs_args:
+            project: my-project
+          credentials: my_gcp_credentials
+          save_args:
+            sheet_name: Sheet1
+          load_args:
+            sheet_name: Sheet1
 
-    trains:
-        type: pandas.ExcelDataset
-        filepath: data/02_intermediate/company/trains.xlsx
-        load_args:
-        sheet_name: [Sheet1, Sheet2, Sheet3]
-    ```
+        shuttles:
+          type: pandas.ExcelDataset
+          filepath: data/01_raw/shuttles.xlsx
+        ```
 
-    ### Example usage for the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html) for a multi-sheet Excel file:
+        Using the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
 
-    ```python
+        >>> import pandas as pd
+        >>> from kedro_datasets.pandas import ExcelDataset
+        >>>
+        >>> data = pd.DataFrame({"col1": [1, 2], "col2": [4, 5], "col3": [5, 6]})
+        >>>
+        >>> dataset = ExcelDataset(filepath=tmp_path / "test.xlsx")
+        >>> dataset.save(data)
+        >>> reloaded = dataset.load()
+        >>> assert data.equals(reloaded)
 
-    from kedro_datasets.pandas import ExcelDataset
-    import pandas as pd
+        For a multi-sheet Excel file, using the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
 
-    dataframe = pd.DataFrame({"col1": [1, 2], "col2": [4, 5], "col3": [5, 6]})
-    another_dataframe = pd.DataFrame({"x": [10, 20], "y": ["hello", "world"]})
-    multiframe = {"Sheet1": dataframe, "Sheet2": another_dataframe}
-    dataset = ExcelDataset(filepath="test.xlsx", load_args={"sheet_name": None})
-    dataset.save(multiframe)
-    reloaded = dataset.load()
-    assert multiframe["Sheet1"].equals(reloaded["Sheet1"])
-    assert multiframe["Sheet2"].equals(reloaded["Sheet2"])
-    ```
+        ```yaml
+        trains:
+          type: pandas.ExcelDataset
+          filepath: data/02_intermediate/company/trains.xlsx
+          load_args:
+            sheet_name: [Sheet1, Sheet2, Sheet3]
+        ```
+
+        For a multi-sheet Excel file, using the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
+
+        >>> import pandas as pd
+        >>> from kedro_datasets.pandas import ExcelDataset
+        >>>
+        >>> dataframe = pd.DataFrame({"col1": [1, 2], "col2": [4, 5], "col3": [5, 6]})
+        >>> another_dataframe = pd.DataFrame({"x": [10, 20], "y": ["hello", "world"]})
+        >>> multiframe = {"Sheet1": dataframe, "Sheet2": another_dataframe}
+        >>>
+        >>> dataset = ExcelDataset(filepath="test.xlsx", load_args={"sheet_name": None})
+        >>> dataset.save(multiframe)
+        >>> reloaded = dataset.load()
+        >>> assert multiframe["Sheet1"].equals(reloaded["Sheet1"])
+        >>> assert multiframe["Sheet2"].equals(reloaded["Sheet2"])
     """
 
     DEFAULT_LOAD_ARGS = {"engine": "openpyxl"}

--- a/kedro-datasets/kedro_datasets/pandas/feather_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/feather_dataset.py
@@ -28,38 +28,35 @@ class FeatherDataset(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
     is supported by pandas, so it supports all allowed pandas options
     for loading and saving csv files.
 
-    ### Example usage for the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
+    Examples:
+        Using the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
 
-    ```yaml
+        ```yaml
+        cars:
+          type: pandas.FeatherDataset
+          filepath: data/01_raw/company/cars.feather
+          load_args:
+            columns: ['col1', 'col2', 'col3']
+            use_threads: True
 
-    cars:
-        type: pandas.FeatherDataset
-        filepath: data/01_raw/company/cars.feather
-        load_args:
-        columns: ['col1', 'col2', 'col3']
-        use_threads: True
+        motorbikes:
+          type: pandas.FeatherDataset
+          filepath: s3://your_bucket/data/02_intermediate/company/motorbikes.feather
+          credentials: dev_s3
+        ```
 
-    motorbikes:
-        type: pandas.FeatherDataset
-        filepath: s3://your_bucket/data/02_intermediate/company/motorbikes.feather
-        credentials: dev_s3
-    ```
-    ### Example usage for the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
+        Using the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
 
-    ```python
+        >>> import pandas as pd
+        >>> from kedro_datasets.pandas import FeatherDataset
+        >>>
+        >>> data = pd.DataFrame({"col1": [1, 2], "col2": [4, 5], "col3": [5, 6]})
+        >>>
+        >>> dataset = FeatherDataset(filepath=tmp_path / "test.feather")
+        >>> dataset.save(data)
+        >>> reloaded = dataset.load()
+        >>> assert data.equals(reloaded)
 
-    from kedro_datasets.pandas import FeatherDataset
-    import pandas as pd
-
-    data = pd.DataFrame({"col1": [1, 2], "col2": [4, 5], "col3": [5, 6]})
-
-    dataset = FeatherDataset(filepath=tmp_path / "test.feather")
-
-    dataset.save(data)
-    reloaded = dataset.load()
-
-    assert data.equals(reloaded)
-    ```
     """
 
     DEFAULT_LOAD_ARGS: dict[str, Any] = {}

--- a/kedro-datasets/kedro_datasets/pandas/gbq_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/gbq_dataset.py
@@ -39,38 +39,36 @@ class GBQTableDataset(ConnectionMixin, AbstractDataset[None, pd.DataFrame]):
     """``GBQTableDataset`` loads and saves data from/to Google BigQuery.
     It uses pandas-gbq to read and write from/to BigQuery table.
 
-    ### Example usage for the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
+    Examples:
+        Using the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
 
-    ```yaml
+        ```yaml
+        vehicles:
+          type: pandas.GBQTableDataset
+          dataset: big_query_dataset
+          table_name: big_query_table
+          project: my-project
+          credentials: gbq-creds
+          load_args:
+            reauth: True
+          save_args:
+            chunk_size: 100
+        ```
 
-    vehicles:
-        type: pandas.GBQTableDataset
-        dataset: big_query_dataset
-        table_name: big_query_table
-        project: my-project
-        credentials: gbq-creds
-        load_args:
-        reauth: True
-        save_args:
-        chunk_size: 100
-    ```
-    ### Example usage for the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
+        Using the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
 
-    ```python
+        >>> import pandas as pd
+        >>> from kedro_datasets.pandas import GBQTableDataset
+        >>>
+        >>> data = pd.DataFrame({"col1": [1, 2], "col2": [4, 5], "col3": [5, 6]})
+        >>>
+        >>> dataset = GBQTableDataset(
+        ...     dataset="dataset", table_name="table_name", project="my-project"
+        >>> )
+        >>> dataset.save(data)
+        >>> reloaded = dataset.load()
+        >>> assert data.equals(reloaded)
 
-    from kedro_datasets.pandas import GBQTableDataset
-    import pandas as pd
-
-    data = pd.DataFrame({"col1": [1, 2], "col2": [4, 5], "col3": [5, 6]})
-
-    dataset = GBQTableDataset(
-        dataset="dataset", table_name="table_name", project="my-project"
-    )
-    dataset.save(data)
-    reloaded = dataset.load()
-
-    assert data.equals(reloaded)
-    ```
     """
 
     DEFAULT_LOAD_ARGS: dict[str, Any] = {}
@@ -215,7 +213,6 @@ class GBQQueryDataset(AbstractDataset[None, pd.DataFrame]):
     ### Example usage for the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
 
     ```python
-
     from kedro_datasets.pandas import GBQQueryDataset
 
     sql = "SELECT * FROM dataset_1.table_a"

--- a/kedro-datasets/kedro_datasets/pandas/generic_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/generic_dataset.py
@@ -35,50 +35,49 @@ class GenericDataset(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
     filesystem (e.g.: local, S3, GCS). It uses pandas to dynamically select the
     appropriate type of read/write target on a best effort basis.
 
-    ### Example usage for the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
+    Examples:
+        Using the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
 
-    ```yaml
+        ```yaml
+        cars:
+          type: pandas.GenericDataset
+          file_format: csv
+          filepath: s3://data/01_raw/company/cars.csv
+          load_args:
+            sep: ","
+            na_values: ["#NA", NA]
+          save_args:
+            index: False
+            date_format: "%Y-%m-%d"
+        ```
 
-    cars:
-        type: pandas.GenericDataset
-        file_format: csv
-        filepath: s3://data/01_raw/company/cars.csv
-        load_args:
-        sep: ","
-        na_values: ["#NA", NA]
-        save_args:
-        index: False
-        date_format: "%Y-%m-%d"
-    ```
-    This second example is able to load a SAS7BDAT file via the ``pd.read_sas`` method.
-    Trying to save this dataset will raise a ``DatasetError`` since pandas does not provide an
-    equivalent ``pd.DataFrame.to_sas`` write method.
+        This second example is able to load a SAS7BDAT file via the ``pd.read_sas`` method.
+        Trying to save this dataset will raise a ``DatasetError`` since pandas does not provide an
+        equivalent ``pd.DataFrame.to_sas`` write method.
 
-    ```yaml
-
-    flights:
-        type: pandas.GenericDataset
-        file_format: sas
-        filepath: data/01_raw/airplanes.sas7bdat
-        load_args:
+        ```yaml
+        flights:
+          type: pandas.GenericDataset
+          file_format: sas
+          filepath: data/01_raw/airplanes.sas7bdat
+          load_args:
             format: sas7bdat
-    ```
-    ### Example usage for the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
+        ```
 
-    ```python
+        Using the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
 
-    from kedro_datasets.pandas import GenericDataset
-    import pandas as pd
+        >>> import pandas as pd
+        >>> from kedro_datasets.pandas import GenericDataset
+        >>>
+        >>> data = pd.DataFrame({"col1": [1, 2], "col2": [4, 5], "col3": [5, 6]})
+        >>>
+        >>> dataset = GenericDataset(
+        ...     filepath=tmp_path / "test.csv", file_format="csv", save_args={"index": False}
+        ... )
+        >>> dataset.save(data)
+        >>> reloaded = dataset.load()
+        >>> assert data.equals(reloaded)
 
-    data = pd.DataFrame({"col1": [1, 2], "col2": [4, 5], "col3": [5, 6]})
-
-    dataset = GenericDataset(
-        filepath=tmp_path / "test.csv", file_format="csv", save_args={"index": False}
-    )
-    dataset.save(data)
-    reloaded = dataset.load()
-    assert data.equals(reloaded)
-    ```
     """
 
     DEFAULT_LOAD_ARGS: dict[str, Any] = {}

--- a/kedro-datasets/kedro_datasets/pandas/hdf_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/hdf_dataset.py
@@ -25,30 +25,29 @@ class HDFDataset(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
     """``HDFDataset`` loads/saves data from/to a hdf file using an underlying
     filesystem (e.g. local, S3, GCS). It uses pandas.HDFStore to handle the hdf file.
 
-    ### Example usage for the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
+    Examples:
+        Using the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
 
-    ```yaml
+        ```yaml
+        hdf_dataset:
+          type: pandas.HDFDataset
+          filepath: s3://my_bucket/raw/sensor_reading.h5
+          credentials: aws_s3_creds
+          key: data
+        ```
 
-    hdf_dataset:
-        type: pandas.HDFDataset
-        filepath: s3://my_bucket/raw/sensor_reading.h5
-        credentials: aws_s3_creds
-        key: data
-    ```
-    ### Example usage for the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
+        Using the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
 
-    ```python
+        >>> import pandas as pd
+        >>> from kedro_datasets.pandas import HDFDataset
+        >>>
+        >>> data = pd.DataFrame({"col1": [1, 2], "col2": [4, 5], "col3": [5, 6]})
+        >>>
+        >>> dataset = HDFDataset(filepath=tmp_path / "test.h5", key="data")
+        >>> dataset.save(data)
+        >>> reloaded = dataset.load()
+        >>> assert data.equals(reloaded)
 
-    from kedro_datasets.pandas import HDFDataset
-    import pandas as pd
-
-    data = pd.DataFrame({"col1": [1, 2], "col2": [4, 5], "col3": [5, 6]})
-
-    dataset = HDFDataset(filepath=tmp_path / "test.h5", key="data")
-    dataset.save(data)
-    reloaded = dataset.load()
-    assert data.equals(reloaded)
-    ```
     """
 
     # _lock is a class attribute that will be shared across all the instances.

--- a/kedro-datasets/kedro_datasets/pandas/json_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/json_dataset.py
@@ -28,35 +28,34 @@ class JSONDataset(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
     """``JSONDataset`` loads/saves data from/to a JSON file using an underlying
     filesystem (e.g.: local, S3, GCS). It uses pandas to handle the json file.
 
-    ### Example usage for the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
+    Examples:
+        Using the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
 
-    ```yaml
+        ```yaml
+        clickstream_dataset:
+          type: pandas.JSONDataset
+          filepath: abfs://landing_area/primary/click_stream.json
+          credentials: abfs_creds
 
-    clickstream_dataset:
-        type: pandas.JSONDataset
-        filepath: abfs://landing_area/primary/click_stream.json
-        credentials: abfs_creds
+        json_dataset:
+          type: pandas.JSONDataset
+          filepath: data/01_raw/Video_Games.json
+          load_args:
+            lines: True
+        ```
 
-    json_dataset:
-        type: pandas.JSONDataset
-        filepath: data/01_raw/Video_Games.json
-        load_args:
-        lines: True
-    ```
-    ### Example usage for the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
+        Using the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
 
-    ```python
+        >>> import pandas as pd
+        >>> from kedro_datasets.pandas import JSONDataset
+        >>>
+        >>> data = pd.DataFrame({"col1": [1, 2], "col2": [4, 5], "col3": [5, 6]})
+        >>>
+        >>> dataset = JSONDataset(filepath=tmp_path / "test.json")
+        >>> dataset.save(data)
+        >>> reloaded = dataset.load()
+        >>> assert data.equals(reloaded)
 
-    from kedro_datasets.pandas import JSONDataset
-    import pandas as pd
-
-    data = pd.DataFrame({"col1": [1, 2], "col2": [4, 5], "col3": [5, 6]})
-
-    dataset = JSONDataset(filepath=tmp_path / "test.json")
-    dataset.save(data)
-    reloaded = dataset.load()
-    assert data.equals(reloaded)
-    ```
     """
 
     DEFAULT_LOAD_ARGS: dict[str, Any] = {}

--- a/kedro-datasets/kedro_datasets/pandas/parquet_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/parquet_dataset.py
@@ -28,46 +28,44 @@ class ParquetDataset(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
     """``ParquetDataset`` loads/saves data from/to a Parquet file using an underlying
     filesystem (e.g.: local, S3, GCS). It uses pandas to handle the Parquet file.
 
-    ### Example usage for the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
+    Examples:
+        Using the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
 
-    ```yaml
+        ```yaml
+        boats:
+          type: pandas.ParquetDataset
+          filepath: data/01_raw/boats.parquet
+          load_args:
+            engine: pyarrow
+            use_nullable_dtypes: True
+          save_args:
+            file_scheme: hive
+            has_nulls: False
+            engine: pyarrow
 
-    boats:
-        type: pandas.ParquetDataset
-        filepath: data/01_raw/boats.parquet
-        load_args:
-        engine: pyarrow
-        use_nullable_dtypes: True
-        save_args:
-        file_scheme: hive
-        has_nulls: False
-        engine: pyarrow
+        trucks:
+          type: pandas.ParquetDataset
+          filepath: abfs://container/02_intermediate/trucks.parquet
+          credentials: dev_abs
+          load_args:
+            columns: [name, gear, disp, wt]
+            index: name
+          save_args:
+            compression: GZIP
+            partition_on: [name]
+        ```
 
-    trucks:
-        type: pandas.ParquetDataset
-        filepath: abfs://container/02_intermediate/trucks.parquet
-        credentials: dev_abs
-        load_args:
-        columns: [name, gear, disp, wt]
-        index: name
-        save_args:
-        compression: GZIP
-        partition_on: [name]
-    ```
-    ### Example usage for the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
+        Using the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
 
-    ```python
-
-    from kedro_datasets.pandas import ParquetDataset
-    import pandas as pd
-
-    data = pd.DataFrame({"col1": [1, 2], "col2": [4, 5], "col3": [5, 6]})
-
-    dataset = ParquetDataset(filepath=tmp_path / "test.parquet")
-    dataset.save(data)
-    reloaded = dataset.load()
-    assert data.equals(reloaded)
-    ```
+        >>> import pandas as pd
+        >>> from kedro_datasets.pandas import ParquetDataset
+        >>>
+        >>> data = pd.DataFrame({"col1": [1, 2], "col2": [4, 5], "col3": [5, 6]})
+        >>>
+        >>> dataset = ParquetDataset(filepath=tmp_path / "test.parquet")
+        >>> dataset.save(data)
+        >>> reloaded = dataset.load()
+        >>> assert data.equals(reloaded)
     """
 
     DEFAULT_LOAD_ARGS: dict[str, Any] = {}

--- a/kedro-datasets/kedro_datasets/pandas/sql_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/sql_dataset.py
@@ -106,10 +106,10 @@ class SQLTableDataset(AbstractDataset[pd.DataFrame, pd.DataFrame]):
     the data with no index. This is designed to make load and save methods
     symmetric.
 
-    ### Example usage for the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
+    Examples:
+        Using the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
 
-    ```yaml
-
+        ```yaml
         shuttles_table_dataset:
           type: pandas.SQLTableDataset
           credentials: db_credentials
@@ -119,32 +119,30 @@ class SQLTableDataset(AbstractDataset[pd.DataFrame, pd.DataFrame]):
           save_args:
             schema: dwschema
             if_exists: replace
-    ```
-    Sample database credentials entry in ``credentials.yml``:
+        ```
 
-    ```yaml
+        Sample database credentials entry in ``credentials.yml``:
 
+        ```yaml
         db_credentials:
           con: postgresql://scott:tiger@localhost/test
           pool_size: 10 # additional parameters
-    ```
-    ### Example usage for the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
+        ```
 
-    ```python
+        Using the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
 
-        from kedro_datasets.pandas import SQLTableDataset
-        import pandas as pd
+        >>> import pandas as pd
+        >>> from kedro_datasets.pandas import SQLTableDataset
+        >>>
+        >>> data = pd.DataFrame({"col1": [1, 2], "col2": [4, 5], "col3": [5, 6]})
+        >>>
+        >>> table_name = "table_a"
+        >>> credentials = {"con": f"sqlite:///{tmp_path / 'test.db'}"}
+        >>> dataset = SQLTableDataset(table_name=table_name, credentials=credentials)
+        >>> dataset.save(data)
+        >>> reloaded = dataset.load()
+        >>> assert data.equals(reloaded)
 
-        data = pd.DataFrame({"col1": [1, 2], "col2": [4, 5], "col3": [5, 6]})
-        table_name = "table_a"
-        credentials = {"con": f"sqlite:///{tmp_path / 'test.db'}"}
-        dataset = SQLTableDataset(table_name=table_name, credentials=credentials)
-
-        dataset.save(data)
-        reloaded = dataset.load()
-
-        assert data.equals(reloaded)
-    ```
     """
 
     DEFAULT_LOAD_ARGS: dict[str, Any] = {}
@@ -307,116 +305,109 @@ class SQLQueryDataset(AbstractDataset[None, pd.DataFrame]):
     It does not support save method so it is a read only dataset.
     To save data to a SQL server use ``SQLTableDataset``.
 
-    ### Example usage for the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
+    Examples:
+        Using the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
 
-    ```yaml
+        ```yaml
+        shuttle_id_dataset:
+          type: pandas.SQLQueryDataset
+          sql: "select shuttle, shuttle_id from spaceflights.shuttles;"
+          credentials: db_credentials
+        ```
 
-    shuttle_id_dataset:
-        type: pandas.SQLQueryDataset
-        sql: "select shuttle, shuttle_id from spaceflights.shuttles;"
-        credentials: db_credentials
-    ```
+        Advanced example using the ``stream_results`` and ``chunksize`` options to reduce memory usage:
 
-    Advanced example using the ``stream_results`` and ``chunksize`` options to reduce memory usage:
+        ```yaml
+        shuttle_id_dataset:
+          type: pandas.SQLQueryDataset
+          sql: "select shuttle, shuttle_id from spaceflights.shuttles;"
+          credentials: db_credentials
+          execution_options:
+            stream_results: true
+          load_args:
+            chunksize: 1000
+        ```
 
-    ```yaml
+        Sample database credentials entry in ``credentials.yml``:
 
-    shuttle_id_dataset:
-        type: pandas.SQLQueryDataset
-        sql: "select shuttle, shuttle_id from spaceflights.shuttles;"
-        credentials: db_credentials
-        execution_options:
-        stream_results: true
-        load_args:
-        chunksize: 1000
-    ```
+        ```yaml
+        db_credentials:
+          con: postgresql://scott:tiger@localhost/test
+          pool_size: 10 # additional parameters
+        ```
 
-    Sample database credentials entry in ``credentials.yml``:
+        Using the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
 
-    ```yaml
+        >>> import sqlite3
+        >>>
+        >>> import pandas as pd
+        >>> from kedro_datasets.pandas import SQLQueryDataset
+        >>>
+        >>> data = pd.DataFrame({"col1": [1, 2], "col2": [4, 5], "col3": [5, 6]})
+        >>>
+        >>> sql = "SELECT * FROM table_a"
+        >>> credentials = {"con": f"sqlite:///{tmp_path / 'test.db'}"}
+        >>> dataset = SQLQueryDataset(sql=sql, credentials=credentials)
+        >>>
+        >>> con = sqlite3.connect(tmp_path / "test.db")
+        >>> cur = con.cursor()
+        >>> cur.execute("CREATE TABLE table_a(col1, col2, col3)")
+        <sqlite3.Cursor object at 0x...>
+        >>> cur.execute("INSERT INTO table_a VALUES (1, 4, 5), (2, 5, 6)")
+        <sqlite3.Cursor object at 0x...>
+        >>> con.commit()
+        >>> reloaded = dataset.load()
+        >>> assert data.equals(reloaded)
 
-    db_credentials:
-        con: postgresql://scott:tiger@localhost/test
-        pool_size: 10 # additional parameters
-    ```
+        Using MSSQL:
 
-    ### Example usage for the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
+        >>> credentials = {
+        ...     "server": "localhost",
+        ...     "port": "1433",
+        ...     "database": "TestDB",
+        ...     "user": "SA",
+        ...     "password": "StrongPassword",
+        ... }
+        >>>
+        >>> def _make_mssql_connection_str(
+        ...     server: str, port: str, database: str, user: str, password: str
+        ... ) -> str:
+        ...     import pyodbc
+        ...     from sqlalchemy.engine import URL
+        ...     driver = pyodbc.drivers()[-1]
+        ...     connection_str = (
+        ...         f"DRIVER={driver};SERVER={server},{port};DATABASE={database};"
+        ...         f"ENCRYPT=yes;UID={user};PWD={password};"
+        ...         f"TrustServerCertificate=yes;"
+        ...     )
+        ...     return URL.create("mssql+pyodbc", query={"odbc_connect": connection_str})
+        ...
+        >>> connection_str = _make_mssql_connection_str(**credentials)  # doctest: +SKIP
+        >>> dataset = SQLQueryDataset(  # doctest: +SKIP
+        ...     credentials={"con": connection_str}, sql="SELECT TOP 5 * FROM TestTable;"
+        ... )
+        >>> df = dataset.load()
 
-    ```python
+        In addition, here is an example of a catalog with dates parsing:
 
-    import sqlite3
+        ```yaml
+        mssql_dataset:
+          type: kedro_datasets.pandas.SQLQueryDataset
+          credentials: mssql_credentials
+          sql: >
+            SELECT *
+            FROM  DateTable
+            WHERE date >= ? AND date <= ?
+            ORDER BY date
+          load_args:
+            params:
+              - ${begin}
+              - ${end}
+            index_col: date
+            parse_dates:
+              date: "%Y-%m-%d %H:%M:%S.%f0 %z"
+        ```
 
-    from kedro_datasets.pandas import SQLQueryDataset
-    import pandas as pd
-
-    data = pd.DataFrame({"col1": [1, 2], "col2": [4, 5], "col3": [5, 6]})
-    sql = "SELECT * FROM table_a"
-    credentials = {"con": f"sqlite:///{tmp_path / 'test.db'}"}
-    dataset = SQLQueryDataset(sql=sql, credentials=credentials)
-
-    con = sqlite3.connect(tmp_path / "test.db")
-    cur = con.cursor()
-    cur.execute("CREATE TABLE table_a(col1, col2, col3)")
-    <sqlite3.Cursor object at 0x...>
-    cur.execute("INSERT INTO table_a VALUES (1, 4, 5), (2, 5, 6)")
-    <sqlite3.Cursor object at 0x...>
-    con.commit()
-    reloaded = dataset.load()
-
-    assert data.equals(reloaded)
-    ```
-
-    Example of usage for MSSQL:
-
-    ```python
-
-    credentials = {
-        "server": "localhost",
-        "port": "1433",
-        "database": "TestDB",
-        "user": "SA",
-        "password": "StrongPassword",
-    }
-    def _make_mssql_connection_str(
-        server: str, port: str, database: str, user: str, password: str
-    ) -> str:
-        import pyodbc
-        from sqlalchemy.engine import URL
-        driver = pyodbc.drivers()[-1]
-        connection_str = (
-            f"DRIVER={driver};SERVER={server},{port};DATABASE={database};"
-            f"ENCRYPT=yes;UID={user};PWD={password};"
-            f"TrustServerCertificate=yes;"
-        )
-        return URL.create("mssql+pyodbc", query={"odbc_connect": connection_str})
-
-    connection_str = _make_mssql_connection_str(**credentials)
-    dataset = SQLQueryDataset(
-        credentials={"con": connection_str}, sql="SELECT TOP 5 * FROM TestTable;"
-    )
-    df = dataset.load()
-    ```
-
-    In addition, here is an example of a catalog with dates parsing:
-
-    ```yaml
-
-    mssql_dataset:
-        type: kedro_datasets.pandas.SQLQueryDataset
-        credentials: mssql_credentials
-        sql: >
-        SELECT *
-        FROM  DateTable
-        WHERE date >= ? AND date <= ?
-        ORDER BY date
-        load_args:
-        params:
-            - ${begin}
-            - ${end}
-        index_col: date
-        parse_dates:
-            date: "%Y-%m-%d %H:%M:%S.%f0 %z"
-    ```
     """
 
     # using Any because of Sphinx but it should be

--- a/kedro-datasets/kedro_datasets/pandas/xml_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/xml_dataset.py
@@ -26,7 +26,8 @@ class XMLDataset(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
     """``XMLDataset`` loads/saves data from/to a XML file using an underlying
     filesystem (e.g.: local, S3, GCS). It uses pandas to handle the XML file.
 
-    Example:
+    Examples:
+        Using the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
 
         >>> import pandas as pd
         >>> from kedro_datasets.pandas import XMLDataset

--- a/kedro-datasets/kedro_datasets/pandas/xml_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/xml_dataset.py
@@ -26,20 +26,18 @@ class XMLDataset(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
     """``XMLDataset`` loads/saves data from/to a XML file using an underlying
     filesystem (e.g.: local, S3, GCS). It uses pandas to handle the XML file.
 
-    ### Example usage for the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
+    Example:
 
-    ```python
+        >>> import pandas as pd
+        >>> from kedro_datasets.pandas import XMLDataset
+        >>>
+        >>> data = pd.DataFrame({"col1": [1, 2], "col2": [4, 5], "col3": [5, 6]})
+        >>>
+        >>> dataset = XMLDataset(filepath=tmp_path / "test.xml")
+        >>> dataset.save(data)
+        >>> reloaded = dataset.load()
+        >>> assert data.equals(reloaded)
 
-    from kedro_datasets.pandas import XMLDataset
-    import pandas as pd
-
-    data = pd.DataFrame({"col1": [1, 2], "col2": [4, 5], "col3": [5, 6]})
-
-    dataset = XMLDataset(filepath=tmp_path / "test.xml")
-    dataset.save(data)
-    reloaded = dataset.load()
-    assert data.equals(reloaded)
-    ```
     """
 
     DEFAULT_LOAD_ARGS: dict[str, Any] = {}

--- a/kedro-datasets/kedro_datasets/partitions/incremental_dataset.py
+++ b/kedro-datasets/kedro_datasets/partitions/incremental_dataset.py
@@ -42,23 +42,21 @@ class IncrementalDataset(PartitionedDataset):
 
     Example:
 
-    ```python
+        >>> from kedro_datasets.partitions import IncrementalDataset
+        >>>
+        >>> dataset = IncrementalDataset(
+        ...     path=str(tmp_path / "test_data"), dataset="pandas.CSVDataset"
+        ... )
+        >>> loaded = dataset.load()  # loads all available partitions
+        >>> # assert isinstance(loaded, dict)
+        >>>
+        >>> dataset.confirm()  # update checkpoint value to the last processed partition ID
+        >>> reloaded = dataset.load()  # still loads all available partitions
+        >>>
+        >>> dataset.release()  # clears load cache
+        >>> # returns an empty dictionary as no new partitions were added
+        >>> assert dataset.load() == {}
 
-    from kedro_datasets.partitions import IncrementalDataset
-
-    dataset = IncrementalDataset(
-        path=str(tmp_path / "test_data"), dataset="pandas.CSVDataset"
-    )
-    loaded = dataset.load()  # loads all available partitions
-    # assert isinstance(loaded, dict)
-
-    dataset.confirm()  # update checkpoint value to the last processed partition ID
-    reloaded = dataset.load()  # still loads all available partitions
-
-    dataset.release()  # clears load cache
-    # returns an empty dictionary as no new partitions were added
-    assert dataset.load() == {}
-    ```
     """
 
     DEFAULT_CHECKPOINT_TYPE = "kedro_datasets.text.TextDataset"

--- a/kedro-datasets/kedro_datasets/partitions/incremental_dataset.py
+++ b/kedro-datasets/kedro_datasets/partitions/incremental_dataset.py
@@ -40,7 +40,8 @@ class IncrementalDataset(PartitionedDataset):
     that is persisted to the location of the data partitions by default, so that
     subsequent pipeline run loads only new partitions past the checkpoint.
 
-    Example:
+    Examples:
+        Using the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
 
         >>> from kedro_datasets.partitions import IncrementalDataset
         >>>

--- a/kedro-datasets/kedro_datasets/partitions/partitioned_dataset.py
+++ b/kedro-datasets/kedro_datasets/partitions/partitioned_dataset.py
@@ -50,92 +50,89 @@ class PartitionedDataset(AbstractDataset[dict[str, Any], dict[str, Callable[[], 
 
     It also supports advanced features like [lazy saving](https://docs.kedro.org/en/stable/data/kedro_io.html#partitioned-dataset-lazy-saving).
 
-    ### Example usage for the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
+    Examples:
+        Using the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
 
-    ```yaml
+        ```yaml
 
-    station_data:
-        type: partitions.PartitionedDataset
-        path: data/03_primary/station_data
-        dataset:
-        type: pandas.CSVDataset
-        load_args:
+        station_data:
+          type: partitions.PartitionedDataset
+          path: data/03_primary/station_data
+          dataset:
+          type: pandas.CSVDataset
+          load_args:
             sep: '\\t'
-        save_args:
+          save_args:
             sep: '\\t'
             index: true
-        filename_suffix: '.dat'
-        save_lazily: True
-    ```
-    ### Example usage for the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
+          filename_suffix: '.dat'
+          save_lazily: True
+        ```
 
-    ```python
+        Using the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
 
-    import pandas as pd
-    from kedro_datasets.partitions import PartitionedDataset
+        >>> import pandas as pd
+        >>> from kedro_datasets.partitions import PartitionedDataset
+        >>>
+        >>> # Create a fake pandas dataframe with 10 rows of data
+        >>> df = pd.DataFrame([{"DAY_OF_MONTH": str(i), "VALUE": i} for i in range(1, 11)])
+        >>>
+        >>> # Convert it to a dict of pd.DataFrame with DAY_OF_MONTH as the dict key
+        >>> dict_df = {
+        ...     day_of_month: df[df["DAY_OF_MONTH"] == day_of_month]
+        ...     for day_of_month in df["DAY_OF_MONTH"]
+        ... }
+        >>>
+        >>> # Save it as small partitions with DAY_OF_MONTH as the partition key
+        >>> dataset = PartitionedDataset(
+        ...     path=str(tmp_path / "df_with_partition"),
+        ...     dataset="pandas.CSVDataset",
+        ...     filename_suffix=".csv",
+        ...     save_lazily=False
+        ... )
+        >>> # This will create a folder `df_with_partition` and save multiple files
+        >>> # with the dict key + filename_suffix as filename, i.e. 1.csv, 2.csv etc.
+        >>> dataset.save(dict_df)
+        >>>
+        >>> # This will create lazy load functions instead of loading data into memory immediately.
+        >>> loaded = dataset.load()
+        >>>
+        >>> # Load all the partitions
+        >>> for partition_id, partition_load_func in loaded.items():
+        ...     # The actual function that loads the data
+        ...     partition_data = partition_load_func()
+        ...
+        >>> # Add the processing logic for individual partition HERE
+        >>> # print(partition_data)
 
-    # Create a fake pandas dataframe with 10 rows of data
-    df = pd.DataFrame([{"DAY_OF_MONTH": str(i), "VALUE": i} for i in range(1, 11)])
+        You can also load multiple partitions from a remote storage and combine them
+        like this:
 
-    # Convert it to a dict of pd.DataFrame with DAY_OF_MONTH as the dict key
-    dict_df = {
-            day_of_month: df[df["DAY_OF_MONTH"] == day_of_month]
-            for day_of_month in df["DAY_OF_MONTH"]
-        }
+        >>> import pandas as pd
+        >>> from kedro_datasets.partitions import PartitionedDataset
+        >>>
+        >>> # these credentials will be passed to both 'fsspec.filesystem()' call
+        >>> # and the dataset initializer
+        >>> credentials = {"key1": "secret1", "key2": "secret2"}
+        >>>
+        >>> dataset = PartitionedDataset(
+        ...     path="s3://bucket-name/path/to/folder",
+        ...     dataset="pandas.CSVDataset",
+        ...     credentials=credentials,
+        ... )
+        >>> loaded = dataset.load()
+        >>> # assert isinstance(loaded, dict)
+        >>>
+        >>> combine_all = pd.DataFrame()
+        >>>
+        >>> for partition_id, partition_load_func in loaded.items():
+        ...     partition_data = partition_load_func()
+        ...     combine_all = pd.concat([combine_all, partition_data], ignore_index=True, sort=True)
+        ...
+        >>> new_data = pd.DataFrame({"new": [1, 2]})
+        >>> # creates "s3://bucket-name/path/to/folder/new/partition.csv"
+        >>> dataset.save({"new/partition.csv": new_data})
 
-    # Save it as small partitions with DAY_OF_MONTH as the partition key
-    dataset = PartitionedDataset(
-            path=str(tmp_path / "df_with_partition"),
-            dataset="pandas.CSVDataset",
-            filename_suffix=".csv",
-            save_lazily=False
-        )
-    # This will create a folder `df_with_partition` and save multiple files
-    # with the dict key + filename_suffix as filename, i.e. 1.csv, 2.csv etc.
-    dataset.save(dict_df)
-
-    # This will create lazy load functions instead of loading data into memory immediately.
-    loaded = dataset.load()
-
-    # Load all the partitions
-    for partition_id, partition_load_func in loaded.items():
-            # The actual function that loads the data
-            partition_data = partition_load_func()
-
-    # Add the processing logic for individual partition HERE
-    # print(partition_data)
-    ```
-
-    You can also load multiple partitions from a remote storage and combine them
-    like this:
-
-    ```python
-
-    import pandas as pd
-    from kedro_datasets.partitions import PartitionedDataset
-
-    # these credentials will be passed to both 'fsspec.filesystem()' call
-    # and the dataset initializer
-    credentials = {"key1": "secret1", "key2": "secret2"}
-
-    dataset = PartitionedDataset(
-            path="s3://bucket-name/path/to/folder",
-            dataset="pandas.CSVDataset",
-            credentials=credentials,
-        )
-    loaded = dataset.load()
-    # assert isinstance(loaded, dict)
-
-    combine_all = pd.DataFrame()
-
-    for partition_id, partition_load_func in loaded.items():
-            partition_data = partition_load_func()
-            combine_all = pd.concat([combine_all, partition_data], ignore_index=True, sort=True)
-
-    new_data = pd.DataFrame({"new": [1, 2]})
-    # creates "s3://bucket-name/path/to/folder/new/partition.csv"
-    dataset.save({"new/partition.csv": new_data})
-    ```
     """
 
     def __init__(  # noqa: PLR0913

--- a/kedro-datasets/kedro_datasets/pickle/pickle_dataset.py
+++ b/kedro-datasets/kedro_datasets/pickle/pickle_dataset.py
@@ -26,10 +26,10 @@ class PickleDataset(AbstractVersionedDataset[Any, Any]):
     the specified backend library passed in (defaults to the ``pickle`` library), so it
     supports all allowed options for loading and saving pickle files.
 
-    ### Example usage for the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
+    Examples:
+        Using the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
 
-    ```yaml
-
+        ```yaml
         test_model: # simple example without compression
           type: pickle.PickleDataset
           filepath: data/07_model_output/test_model.pkl
@@ -42,31 +42,29 @@ class PickleDataset(AbstractVersionedDataset[Any, Any]):
           credentials: s3_credentials
           save_args:
             compress: lz4
-    ```
-    ### Example usage for the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
+        ```
 
-    ```python
+        Using the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
 
-        from kedro_datasets.pickle import PickleDataset
-        import pandas as pd
-
-        data = pd.DataFrame({"col1": [1, 2], "col2": [4, 5], "col3": [5, 6]})
-
-        dataset = PickleDataset(filepath="test.pkl", backend="pickle")
-        dataset.save(data)
-        reloaded = dataset.load()
-        assert data.equals(reloaded)
-
-        dataset = PickleDataset(
-            filepath=tmp_path / "test.pickle.lz4",
-            backend="compress_pickle",
-            load_args={"compression": "lz4"},
-            save_args={"compression": "lz4"},
-        )
-        dataset.save(data)
-        reloaded = dataset.load()
-        assert data.equals(reloaded)
-    ```
+        >>> import pandas as pd
+        >>> from kedro_datasets.pickle import PickleDataset
+        >>>
+        >>> data = pd.DataFrame({"col1": [1, 2], "col2": [4, 5], "col3": [5, 6]})
+        >>>
+        >>> dataset = PickleDataset(filepath="test.pkl", backend="pickle")
+        >>> dataset.save(data)
+        >>> reloaded = dataset.load()
+        >>> assert data.equals(reloaded)
+        >>>
+        >>> dataset = PickleDataset(
+        ...     filepath=tmp_path / "test.pickle.lz4",
+        ...     backend="compress_pickle",
+        ...     load_args={"compression": "lz4"},
+        ...     save_args={"compression": "lz4"},
+        ... )
+        >>> dataset.save(data)
+        >>> reloaded = dataset.load()
+        >>> assert data.equals(reloaded)
     """
 
     DEFAULT_LOAD_ARGS: dict[str, Any] = {}

--- a/kedro-datasets/kedro_datasets/pillow/image_dataset.py
+++ b/kedro-datasets/kedro_datasets/pillow/image_dataset.py
@@ -22,21 +22,23 @@ class ImageDataset(AbstractVersionedDataset[Image.Image, Image.Image]):
     """``ImageDataset`` loads/saves image data as `numpy` from an underlying
     filesystem (e.g.: local, S3, GCS). It uses Pillow to handle image file.
 
-    ### Example usage for the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
+    Examples:
+        Using the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
 
-    ```python
+        >>> import sys
+        >>>
+        >>> import pytest
+        >>> from kedro_datasets.pillow import ImageDataset
+        >>>
+        >>> if sys.platform.startswith("win"):
+        ...     pytest.skip("this doctest hangs on Windows CI runner")
+        ...
+        >>> dataset = ImageDataset(
+        ...     filepath="https://storage.googleapis.com/gtv-videos-bucket/sample/images/ForBiggerBlazes.jpg"
+        ... )
+        >>> image = dataset.load()
+        >>> image.show()
 
-        import sys
-
-        import pytest
-        from kedro_datasets.pillow import ImageDataset
-
-        dataset = ImageDataset(
-            filepath="https://storage.googleapis.com/gtv-videos-bucket/sample/images/ForBiggerBlazes.jpg"
-        )
-        image = dataset.load()
-        image.show()
-    ```
     """
 
     DEFAULT_SAVE_ARGS: dict[str, Any] = {}

--- a/kedro-datasets/kedro_datasets/plotly/html_dataset.py
+++ b/kedro-datasets/kedro_datasets/plotly/html_dataset.py
@@ -22,28 +22,27 @@ class HTMLDataset(AbstractVersionedDataset[go.Figure, go.Figure | go.FigureWidge
     """``HTMLDataset`` saves a plotly figure to an HTML file using an
     underlying filesystem (e.g.: local, S3, GCS).
 
-    ### Example usage for the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
+    Examples:
+        Using the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
 
-    ```yaml
-
+        ```yaml
         scatter_plot:
           type: plotly.HTMLDataset
           filepath: data/08_reporting/scatter_plot.html
           save_args:
             auto_open: False
-    ```
+        ```
 
-    ### Example usage for the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
+        Using the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
 
-    ```python
+        >>> import plotly.express as px
+        >>> from kedro_datasets.plotly import HTMLDataset
+        >>>
+        >>> fig = px.bar(x=["a", "b", "c"], y=[1, 3, 2])
+        >>>
+        >>> dataset = HTMLDataset(filepath=tmp_path / "test.html")
+        >>> dataset.save(fig)
 
-        from kedro_datasets.plotly import HTMLDataset
-        import plotly.express as px
-
-        fig = px.bar(x=["a", "b", "c"], y=[1, 3, 2])
-        dataset = HTMLDataset(filepath=tmp_path / "test.html")
-        dataset.save(fig)
-    ```
     """
 
     DEFAULT_SAVE_ARGS: dict[str, Any] = {}

--- a/kedro-datasets/kedro_datasets/plotly/json_dataset.py
+++ b/kedro-datasets/kedro_datasets/plotly/json_dataset.py
@@ -25,29 +25,29 @@ class JSONDataset(AbstractVersionedDataset[go.Figure, go.Figure | go.FigureWidge
     """``JSONDataset`` loads/saves a plotly figure from/to a JSON file using an
     underlying filesystem (e.g.: local, S3, GCS).
 
-    ### Example usage for the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
+    Examples:
+        Using the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
 
-    ```yaml
+        ```yaml
+        scatter_plot:
+          type: plotly.JSONDataset
+          filepath: data/08_reporting/scatter_plot.json
+          save_args:
+            engine: auto
+        ```
 
-    scatter_plot:
-        type: plotly.JSONDataset
-        filepath: data/08_reporting/scatter_plot.json
-        save_args:
-        engine: auto
-    ```
-    ### Example usage for the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
+        Using the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
 
-    ```python
+        >>> import plotly.express as px
+        >>> from kedro_datasets.plotly import JSONDataset
+        >>>
+        >>> fig = px.bar(x=["a", "b", "c"], y=[1, 3, 2])
+        >>>
+        >>> dataset = JSONDataset(filepath=tmp_path / "test.json")
+        >>> dataset.save(fig)
+        >>> reloaded = dataset.load()
+        >>> assert fig == reloaded
 
-    from kedro_datasets.plotly import JSONDataset
-    import plotly.express as px
-
-    fig = px.bar(x=["a", "b", "c"], y=[1, 3, 2])
-    dataset = JSONDataset(filepath=tmp_path / "test.json")
-    dataset.save(fig)
-    reloaded = dataset.load()
-    assert fig == reloaded
-    ```
     """
 
     DEFAULT_LOAD_ARGS: dict[str, Any] = {}

--- a/kedro-datasets/kedro_datasets/plotly/plotly_dataset.py
+++ b/kedro-datasets/kedro_datasets/plotly/plotly_dataset.py
@@ -25,45 +25,44 @@ class PlotlyDataset(JSONDataset):
     ``PlotlyDataset`` is a convenience wrapper for ``plotly.JSONDataset``. It generates
     the JSON file directly from a pandas DataFrame through ``plotly_args``.
 
-    ### Example usage for the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
+    Examples:
+        Using the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
 
-    ```yaml
+        ```yaml
+        bar_plot:
+          type: plotly.PlotlyDataset
+          filepath: data/08_reporting/bar_plot.json
+          plotly_args:
+            type: bar
+            fig:
+              x: features
+              y: importance
+              orientation: h
+            layout:
+              xaxis_title: x
+              yaxis_title: y
+              title: Title
+        ```
 
-    bar_plot:
-        type: plotly.PlotlyDataset
-        filepath: data/08_reporting/bar_plot.json
-        plotly_args:
-        type: bar
-        fig:
-            x: features
-            y: importance
-            orientation: h
-        layout:
-            xaxis_title: x
-            yaxis_title: y
-            title: Title
-    ```
-    ### Example usage for the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
+        Using the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
 
-    ```python
+        >>> import pandas as pd
+        >>> import plotly.express as px
+        >>> from kedro_datasets.plotly import PlotlyDataset
+        >>>
+        >>> df_data = pd.DataFrame([[0, 1], [1, 0]], columns=("x1", "x2"))
+        >>>
+        >>> dataset = PlotlyDataset(
+        ...     filepath=tmp_path / "scatter_plot.json",
+        ...     plotly_args={
+        ...         "type": "scatter",
+        ...         "fig": {"x": "x1", "y": "x2"},
+        ...     },
+        ... )
+        >>> dataset.save(df_data)
+        >>> reloaded = dataset.load()
+        >>> assert px.scatter(df_data, x="x1", y="x2") == reloaded
 
-    from kedro_datasets.plotly import PlotlyDataset
-    import plotly.express as px
-    import pandas as pd
-
-    df_data = pd.DataFrame([[0, 1], [1, 0]], columns=("x1", "x2"))
-
-    dataset = PlotlyDataset(
-        filepath=tmp_path / "scatter_plot.json",
-        plotly_args={
-            "type": "scatter",
-            "fig": {"x": "x1", "y": "x2"},
-        },
-    )
-    dataset.save(df_data)
-    reloaded = dataset.load()
-    assert px.scatter(df_data, x="x1", y="x2") == reloaded
-    ```
     """
 
     DEFAULT_FS_ARGS: dict[str, Any] = {"open_args_save": {"mode": "w"}}

--- a/kedro-datasets/kedro_datasets/polars/csv_dataset.py
+++ b/kedro-datasets/kedro_datasets/polars/csv_dataset.py
@@ -26,10 +26,10 @@ class CSVDataset(AbstractVersionedDataset[pl.DataFrame, pl.DataFrame]):
     """``CSVDataset`` loads/saves data from/to a CSV file using an underlying
     filesystem (e.g.: local, S3, GCS). It uses polars to handle the CSV file.
 
-    ### Example usage for the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
+    Examples:
+        Using the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
 
-    ```yaml
-
+        ```yaml
         cars:
           type: polars.CSVDataset
           filepath: data/01_raw/company/cars.csv
@@ -44,24 +44,26 @@ class CSVDataset(AbstractVersionedDataset[pl.DataFrame, pl.DataFrame]):
           type: polars.CSVDataset
           filepath: s3://your_bucket/data/02_intermediate/company/motorbikes.csv
           credentials: dev_s3
-    ```
-    ### Example usage for the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
+        ```
 
-    ```python
+        Using the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
 
-        import sys
+        >>> import sys
+        >>>
+        >>> import polars as pl
+        >>> import pytest
+        >>> from kedro_datasets.polars import CSVDataset
+        >>>
+        >>> if sys.platform.startswith("win"):
+        ...     pytest.skip("this doctest fails on Windows CI runner")
+        ...
+        >>> data = pl.DataFrame({"col1": [1, 2], "col2": [4, 5], "col3": [5, 6]})
+        >>>
+        >>> dataset = CSVDataset(filepath=tmp_path / "test.csv")
+        >>> dataset.save(data)
+        >>> reloaded = dataset.load()
+        >>> assert data.equals(reloaded)
 
-        import polars as pl
-        import pytest
-        from kedro_datasets.polars import CSVDataset
-
-        data = pl.DataFrame({"col1": [1, 2], "col2": [4, 5], "col3": [5, 6]})
-
-        dataset = CSVDataset(filepath=tmp_path / "test.csv")
-        dataset.save(data)
-        reloaded = dataset.load()
-        assert data.equals(reloaded)
-    ```
     """
 
     DEFAULT_LOAD_ARGS: dict[str, Any] = {"rechunk": True}

--- a/kedro-datasets/kedro_datasets/polars/eager_polars_dataset.py
+++ b/kedro-datasets/kedro_datasets/polars/eager_polars_dataset.py
@@ -25,34 +25,32 @@ class EagerPolarsDataset(AbstractVersionedDataset[pl.DataFrame, pl.DataFrame]):
     filesystem (e.g.: local, S3, GCS). It uses polars to handle the dynamically select the
     appropriate type of read/write on a best effort basis.
 
-    ### Example usage for the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
+    Examples:
+        Using the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
 
-    ```yaml
+        ```yaml
+        cars:
+          type: polars.EagerPolarsDataset
+          file_format: parquet
+          filepath: s3://data/01_raw/company/cars.parquet
+          load_args:
+            low_memory: True
+          save_args:
+            compression: "snappy"
+        ```
 
-    cars:
-        type: polars.EagerPolarsDataset
-        file_format: parquet
-        filepath: s3://data/01_raw/company/cars.parquet
-        load_args:
-        low_memory: True
-        save_args:
-        compression: "snappy"
-    ```
+        Using the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
 
-    ### Example usage for the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
+        >>> import polars as pl
+        >>> from kedro_datasets.polars import EagerPolarsDataset
+        >>>
+        >>> data = pl.DataFrame({"col1": [1, 2], "col2": [4, 5], "col3": [5, 6]})
+        >>>
+        >>> dataset = EagerPolarsDataset(filepath=tmp_path / "test.parquet", file_format="parquet")
+        >>> dataset.save(data)
+        >>> reloaded = dataset.load()
+        >>> assert data.equals(reloaded)
 
-    ```python
-
-    from kedro_datasets.polars import EagerPolarsDataset
-    import polars as pl
-
-    data = pl.DataFrame({"col1": [1, 2], "col2": [4, 5], "col3": [5, 6]})
-
-    dataset = EagerPolarsDataset(filepath=tmp_path / "test.parquet", file_format="parquet")
-    dataset.save(data)
-    reloaded = dataset.load()
-    assert data.equals(reloaded)
-    ```
     """
 
     DEFAULT_LOAD_ARGS = {}  # type: dict[str, Any]

--- a/kedro-datasets/kedro_datasets/polars/lazy_polars_dataset.py
+++ b/kedro-datasets/kedro_datasets/polars/lazy_polars_dataset.py
@@ -37,39 +37,38 @@ class LazyPolarsDataset(
     the type of read/write target. It uses lazy loading with Polars Lazy API, but it can
     save both Lazy and Eager Polars DataFrames.
 
-    ### Example usage for the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
+    Examples:
+        Using the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
 
-    ```yaml
+        ```yaml
+        cars:
+          type: polars.LazyPolarsDataset
+          filepath: data/01_raw/company/cars.csv
+          load_args:
+            sep: ","
+            parse_dates: False
+          save_args:
+            has_header: False
+            null_value: "somenullstring"
 
-    cars:
-        type: polars.LazyPolarsDataset
-        filepath: data/01_raw/company/cars.csv
-        load_args:
-        sep: ","
-        parse_dates: False
-        save_args:
-        has_header: False
-        null_value: "somenullstring"
+        motorbikes:
+          type: polars.LazyPolarsDataset
+          filepath: s3://your_bucket/data/02_intermediate/company/motorbikes.csv
+          credentials: dev_s3
+        ```
 
-    motorbikes:
-        type: polars.LazyPolarsDataset
-        filepath: s3://your_bucket/data/02_intermediate/company/motorbikes.csv
-        credentials: dev_s3
-    ```
-    ### Example usage for the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
+        Using the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
 
-    ```python
+        >>> import polars as pl
+        >>> from kedro_datasets.polars import LazyPolarsDataset
+        >>>
+        >>> data = pl.DataFrame({"col1": [1, 2], "col2": [4, 5], "col3": [5, 6]})
+        >>>
+        >>> dataset = LazyPolarsDataset(filepath=tmp_path / "test.csv", file_format="csv")
+        >>> dataset.save(data)
+        >>> reloaded = dataset.load()
+        >>> assert data.equals(reloaded.collect())
 
-    from kedro_datasets.polars import LazyPolarsDataset
-    import polars as pl
-
-    data = pl.DataFrame({"col1": [1, 2], "col2": [4, 5], "col3": [5, 6]})
-
-    dataset = LazyPolarsDataset(filepath=tmp_path / "test.csv", file_format="csv")
-    dataset.save(data)
-    reloaded = dataset.load()
-    assert data.equals(reloaded.collect())
-    ```
     """
 
     DEFAULT_LOAD_ARGS: ClassVar[dict[str, Any]] = {}

--- a/kedro-datasets/kedro_datasets/redis/redis_dataset.py
+++ b/kedro-datasets/kedro_datasets/redis/redis_dataset.py
@@ -18,39 +18,38 @@ class PickleDataset(AbstractDataset[Any, Any]):
     all allowed options for instantiating the redis app ``from_url`` and setting
     a value.
 
-    ### Example usage for the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
+    Examples:
+        Using the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
 
-    ```yaml
+        ```yaml
+        my_python_object: # simple example
+          type: redis.PickleDataset
+          key: my_object
+          from_url_args:
+            url: redis://127.0.0.1:6379
 
-    my_python_object: # simple example
-        type: redis.PickleDataset
-        key: my_object
-        from_url_args:
-        url: redis://127.0.0.1:6379
+        final_python_object: # example with save args
+          type: redis.PickleDataset
+          key: my_final_object
+          from_url_args:
+            url: redis://127.0.0.1:6379
+            db: 1
+          save_args:
+            ex: 10
+        ```
 
-    final_python_object: # example with save args
-        type: redis.PickleDataset
-        key: my_final_object
-        from_url_args:
-        url: redis://127.0.0.1:6379
-        db: 1
-        save_args:
-        ex: 10
-    ```
-    ### Example usage for the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
+        Using the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
 
-    ```python
+        >>> import pandas as pd
+        >>> from kedro_datasets.redis import PickleDataset
+        >>>
+        >>> data = pd.DataFrame({"col1": [1, 2], "col2": [4, 5], "col3": [5, 6]})
+        >>>
+        >>> my_data = PickleDataset(key="my_data")
+        >>> my_data.save(data)
+        >>> reloaded = my_data.load()
+        >>> assert data.equals(reloaded)
 
-    from kedro_datasets.redis import PickleDataset
-    import pandas as pd
-
-    data = pd.DataFrame({"col1": [1, 2], "col2": [4, 5], "col3": [5, 6]})
-
-    my_data = PickleDataset(key="my_data")
-    my_data.save(data)
-    reloaded = my_data.load()
-    assert data.equals(reloaded)
-    ```
     """
 
     DEFAULT_REDIS_URL = os.getenv("REDIS_URL", "redis://127.0.0.1:6379")

--- a/kedro-datasets/kedro_datasets/snowflake/snowpark_dataset.py
+++ b/kedro-datasets/kedro_datasets/snowflake/snowpark_dataset.py
@@ -17,13 +17,13 @@ logger = logging.getLogger(__name__)
 class SnowparkTableDataset(AbstractDataset):
     """``SnowparkTableDataset`` loads and saves Snowpark DataFrames.
 
-     As of October 2024, the Snowpark connector works with Python 3.9, 3.10, and 3.11.
-     Python 3.12 is not supported yet.
+    As of October 2024, the Snowpark connector works with Python 3.9, 3.10, and 3.11.
+    Python 3.12 is not supported yet.
 
-    ### Example usage for the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
+    Examples:
+        Using the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
 
-     ```yaml
-
+        ```yaml
        weather:
          type: kedro_datasets.snowflake.SnowparkTableDataset
          table_name: "weather_data"
@@ -34,65 +34,66 @@ class SnowparkTableDataset(AbstractDataset):
            mode: overwrite
            column_order: name
            table_type: ''
-     ```
-     You can skip everything but "table_name" if the database and schema are
-     provided via credentials. This allows catalog entries to be shorter when
-     all Snowflake tables are in the same database and schema. Values in the
-     dataset definition take priority over those defined in credentials.
+        ```
 
-     Example:
-     The credentials file provides all connection attributes. The catalog entry
-     for "weather" reuses the credentials parameters, while the "polygons" catalog
-     entry reuses all credentials parameters except for specifying a different
-     schema. The second example demonstrates the use of ``externalbrowser`` authentication.
+        You can skip everything but "table_name" if the database and schema are
+        provided via credentials. This allows catalog entries to be shorter when
+        all Snowflake tables are in the same database and schema. Values in the
+        dataset definition take priority over those defined in credentials.
 
-     catalog.yml:
+        The credentials file provides all connection attributes. The catalog entry
+        for "weather" reuses the credentials parameters, while the "polygons" catalog
+        entry reuses all credentials parameters except for specifying a different
+        schema. The second example demonstrates the use of ``externalbrowser`` authentication.
 
-     ```yaml
+        catalog.yml:
 
-       weather:
-         type: kedro_datasets.snowflake.SnowparkTableDataset
-         table_name: "weather_data"
-         database: "meteorology"
-         schema: "observations"
-         credentials: snowflake_client
-         save_args:
-           mode: overwrite
-           column_order: name
-           table_type: ''
+        ```yaml
+        weather:
+          type: kedro_datasets.snowflake.SnowparkTableDataset
+          table_name: "weather_data"
+          database: "meteorology"
+          schema: "observations"
+          credentials: snowflake_client
+          save_args:
+            mode: overwrite
+            column_order: name
+            table_type: ''
 
-       polygons:
-         type: kedro_datasets.snowflake.SnowparkTableDataset
-         table_name: "geopolygons"
-         credentials: snowflake_client
-         schema: "geodata"
-     ```
-     credentials.yml:
+        polygons:
+          type: kedro_datasets.snowflake.SnowparkTableDataset
+          table_name: "geopolygons"
+          credentials: snowflake_client
+          schema: "geodata"
+        ```
 
-     ```yaml
+        credentials.yml:
 
-       snowflake_client:
-         account: 'ab12345.eu-central-1'
-         port: 443
-         warehouse: "datascience_wh"
-         database: "detailed_data"
-         schema: "observations"
-         user: "service_account_abc"
-         password: "supersecret"
-     ```
-     credentials.yml (with externalbrowser authentication):
+        ```yaml
 
-     ```yaml
+        snowflake_client:
+          account: 'ab12345.eu-central-1'
+          port: 443
+          warehouse: "datascience_wh"
+          database: "detailed_data"
+          schema: "observations"
+          user: "service_account_abc"
+          password: "supersecret"
+        ```
 
-       snowflake_client:
-         account: 'ab12345.eu-central-1'
-         port: 443
-         warehouse: "datascience_wh"
-         database: "detailed_data"
-         schema: "observations"
-         user: "john_doe@wdomain.com"
-         authenticator: "externalbrowser"
-     ```
+        credentials.yml (with externalbrowser authentication):
+
+        ```yaml
+        snowflake_client:
+          account: 'ab12345.eu-central-1'
+          port: 443
+          warehouse: "datascience_wh"
+          database: "detailed_data"
+          schema: "observations"
+          user: "john_doe@wdomain.com"
+          authenticator: "externalbrowser"
+        ```
+
     """
 
     # this dataset cannot be used with ``ParallelRunner``,

--- a/kedro-datasets/kedro_datasets/snowflake/snowpark_dataset.py
+++ b/kedro-datasets/kedro_datasets/snowflake/snowpark_dataset.py
@@ -24,16 +24,16 @@ class SnowparkTableDataset(AbstractDataset):
         Using the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
 
         ```yaml
-       weather:
-         type: kedro_datasets.snowflake.SnowparkTableDataset
-         table_name: "weather_data"
-         database: "meteorology"
-         schema: "observations"
-         credentials: db_credentials
-         save_args:
-           mode: overwrite
-           column_order: name
-           table_type: ''
+        weather:
+          type: kedro_datasets.snowflake.SnowparkTableDataset
+          table_name: "weather_data"
+          database: "meteorology"
+          schema: "observations"
+          credentials: db_credentials
+          save_args:
+            mode: overwrite
+            column_order: name
+            table_type: ''
         ```
 
         You can skip everything but "table_name" if the database and schema are

--- a/kedro-datasets/kedro_datasets/spark/deltatable_dataset.py
+++ b/kedro-datasets/kedro_datasets/spark/deltatable_dataset.py
@@ -17,43 +17,40 @@ from kedro_datasets._utils.spark_utils import get_spark
 class DeltaTableDataset(AbstractDataset[None, DeltaTable]):
     """``DeltaTableDataset`` loads data into DeltaTable objects.
 
-    ### Example usage for the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
+    Examples:
+        Using the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
 
-    ```yaml
+        ```yaml
+        weather@spark:
+          type: spark.SparkDataset
+          filepath: data/02_intermediate/data.parquet
+          file_format: "delta"
 
-    weather@spark:
-        type: spark.SparkDataset
-        filepath: data/02_intermediate/data.parquet
-        file_format: "delta"
+        weather@delta:
+          type: spark.DeltaTableDataset
+          filepath: data/02_intermediate/data.parquet
+        ```
 
-    weather@delta:
-        type: spark.DeltaTableDataset
-        filepath: data/02_intermediate/data.parquet
-    ```
-    ### Example usage for the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
+        Using the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
 
-    ```python
+        >>> from delta import DeltaTable
+        >>> from kedro_datasets.spark import DeltaTableDataset, SparkDataset
+        >>> from pyspark.sql import SparkSession
+        >>> from pyspark.sql.types import StructField, StringType, IntegerType, StructType
+        >>>
+        >>> schema = StructType(
+        ...     [StructField("name", StringType(), True), StructField("age", IntegerType(), True)]
+        ... )
+        >>> data = [("Alex", 31), ("Bob", 12), ("Clarke", 65), ("Dave", 29)]
+        >>> spark_df = SparkSession.builder.getOrCreate().createDataFrame(data, schema)
+        >>>
+        >>> filepath = (tmp_path / "test_data").as_posix()
+        >>> dataset = SparkDataset(filepath=filepath, file_format="delta")
+        >>> dataset.save(spark_df)
+        >>> deltatable_dataset = DeltaTableDataset(filepath=filepath)
+        >>> delta_table = deltatable_dataset.load()
+        >>> assert isinstance(delta_table, DeltaTable)
 
-    from delta import DeltaTable
-    from kedro_datasets.spark import DeltaTableDataset, SparkDataset
-    from pyspark.sql import SparkSession
-    from pyspark.sql.types import StructField, StringType, IntegerType, StructType
-
-    schema = StructType(
-        [StructField("name", StringType(), True), StructField("age", IntegerType(), True)]
-    )
-
-    data = [("Alex", 31), ("Bob", 12), ("Clarke", 65), ("Dave", 29)]
-
-    spark_df = SparkSession.builder.getOrCreate().createDataFrame(data, schema)
-    filepath = (tmp_path / "test_data").as_posix()
-    dataset = SparkDataset(filepath=filepath, file_format="delta")
-    dataset.save(spark_df)
-    deltatable_dataset = DeltaTableDataset(filepath=filepath)
-    delta_table = deltatable_dataset.load()
-
-    assert isinstance(delta_table, DeltaTable)
-    ```
     """
 
     # this dataset cannot be used with ``ParallelRunner``,

--- a/kedro-datasets/kedro_datasets/spark/gbq_dataset.py
+++ b/kedro-datasets/kedro_datasets/spark/gbq_dataset.py
@@ -24,42 +24,44 @@ logger = logging.getLogger(__name__)
 class GBQQueryDataset(AbstractDataset[None, DataFrame]):
     """``GBQQueryDataset`` loads data from Google BigQuery with a SQL query using BigQuery Spark connector.
 
-    ### Example usage for the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
+    Examples:
+        Using the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
 
-    ```yaml
-    my_gbq_spark_data:
-        type: spark.GBQQueryDataset
-        sql: |
-        SELECT * FROM your_table
-        materialization_dataset: your_dataset
-        materialization_project: your_project
-        bq_credentials:
-        file: /path/to/your/credentials.json
-        fs_credentials:
-        key: value
-    ```
+        ```yaml
+        my_gbq_spark_data:
+          type: spark.GBQQueryDataset
+          sql: |
+            SELECT * FROM your_table
+          materialization_dataset: your_dataset
+          materialization_project: your_project
+          bq_credentials:
+            file: /path/to/your/credentials.json
+          fs_credentials:
+            key: value
+        ```
 
-    ### Example usage for the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
+        Using the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
 
-    ```python
-    # Define your SQL query
-    sql = "SELECT * FROM your_table"
+        >>> from kedro_datasets.spark import GBQQueryDataset
+        >>>
+        >>> # Define your SQL query
+        >>> sql = "SELECT * FROM your_table"
+        >>>
+        >>> # Initialize dataset
+        >>> dataset = GBQQueryDataset(
+        ...     sql=sql,
+        ...     materialization_dataset="your_dataset",
+        ...     materialization_project="your_project",  # optional
+        ...     bq_credentials=dict(file="/path/to/your/credentials.json"),  # optional
+        ...     fs_credentials=dict(key="value"),  # optional
+        ... )
+        >>>
+        >>> # Load data
+        >>> df = dataset.load()
+        >>>
+        >>> # Example output
+        >>> df.show()
 
-    # Initialize dataset
-    dataset = GBQQueryDataset(
-        sql=sql,
-        materialization_dataset="your_dataset",
-        materialization_project="your_project",  # optional
-        bq_credentials=dict(file="/path/to/your/credentials.json"),  # optional
-        fs_credentials=dict(key="value"),  # optional
-    )
-
-    # Load data
-    df = dataset.load()
-
-    # Example output
-    df.show()
-    ```
     """
 
     _VALID_CREDENTIALS_KEYS = {"base64", "file", "json"}

--- a/kedro-datasets/kedro_datasets/spark/spark_dataset.py
+++ b/kedro-datasets/kedro_datasets/spark/spark_dataset.py
@@ -87,61 +87,56 @@ class KedroHdfsInsecureClient(InsecureClient):
 class SparkDataset(AbstractVersionedDataset[DataFrame, DataFrame]):
     """``SparkDataset`` loads and saves Spark dataframes.
 
-    ### Example usage for the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
+    Examples:
+        Using the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
 
-    ```yaml
+        ```yaml
+        weather:
+          type: spark.SparkDataset
+          filepath: s3a://your_bucket/data/01_raw/weather/*
+          file_format: csv
+          load_args:
+            header: True
+            inferSchema: True
+          save_args:
+            sep: '|'
+            header: True
 
-    weather:
-        type: spark.SparkDataset
-        filepath: s3a://your_bucket/data/01_raw/weather/*
-        file_format: csv
-        load_args:
-        header: True
-        inferSchema: True
-        save_args:
-        sep: '|'
-        header: True
+        weather_with_schema:
+          type: spark.SparkDataset
+          filepath: s3a://your_bucket/data/01_raw/weather/*
+          file_format: csv
+          load_args:
+            header: True
+            schema:
+              filepath: path/to/schema.json
+          save_args:
+            sep: '|'
+            header: True
 
-    weather_with_schema:
-        type: spark.SparkDataset
-        filepath: s3a://your_bucket/data/01_raw/weather/*
-        file_format: csv
-        load_args:
-        header: True
-        schema:
-            filepath: path/to/schema.json
-        save_args:
-        sep: '|'
-        header: True
+        weather_cleaned:
+          type: spark.SparkDataset
+          filepath: data/02_intermediate/data.parquet
+          file_format: parquet
+        ```
 
-    weather_cleaned:
-        type: spark.SparkDataset
-        filepath: data/02_intermediate/data.parquet
-        file_format: parquet
-    ```
-    ### Example usage for the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
+        Using the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
 
-    ```python
+        >>> from kedro_datasets.spark import SparkDataset
+        >>> from pyspark.sql import SparkSession
+        >>> from pyspark.sql.types import IntegerType, Row, StringType, StructField, StructType
+        >>>
+        >>> schema = StructType(
+        ...     [StructField("name", StringType(), True), StructField("age", IntegerType(), True)]
+        ... )
+        >>> data = [("Alex", 31), ("Bob", 12), ("Clarke", 65), ("Dave", 29)]
+        >>> spark_df = SparkSession.builder.getOrCreate().createDataFrame(data, schema)
+        >>>
+        >>> dataset = SparkDataset(filepath=tmp_path / "test_data")
+        >>> dataset.save(spark_df)
+        >>> reloaded = dataset.load()
+        >>> assert Row(name="Bob", age=12) in reloaded.take(4)
 
-    from pyspark.sql import SparkSession
-    from pyspark.sql.types import IntegerType, Row, StringType, StructField, StructType
-
-    from kedro_datasets.spark import SparkDataset
-
-    schema = StructType(
-        [StructField("name", StringType(), True), StructField("age", IntegerType(), True)]
-    )
-
-    data = [("Alex", 31), ("Bob", 12), ("Clarke", 65), ("Dave", 29)]
-
-    spark_df = SparkSession.builder.getOrCreate().createDataFrame(data, schema)
-
-    dataset = SparkDataset(filepath=tmp_path / "test_data")
-    dataset.save(spark_df)
-    reloaded = dataset.load()
-
-    assert Row(name="Bob", age=12) in reloaded.take(4)
-    ```
     """
 
     # this dataset cannot be used with ``ParallelRunner``,

--- a/kedro-datasets/kedro_datasets/spark/spark_hive_dataset.py
+++ b/kedro-datasets/kedro_datasets/spark/spark_hive_dataset.py
@@ -28,41 +28,36 @@ class SparkHiveDataset(AbstractDataset[DataFrame, DataFrame]):
       to external changes to the target table while executing. Upsert methodology works by
       leveraging Spark DataFrame execution plan checkpointing.
 
-    ### Example usage for the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
+    Examples:
+        Using the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
 
-    ```yaml
+        ```yaml
+        hive_dataset:
+          type: spark.SparkHiveDataset
+          database: hive_database
+          table: table_name
+          write_mode: overwrite
+        ```
 
-    hive_dataset:
-        type: spark.SparkHiveDataset
-        database: hive_database
-        table: table_name
-        write_mode: overwrite
-    ```
-    ### Example usage for the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
+        Using the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
 
-    ```python
+        >>> from kedro_datasets.spark import SparkHiveDataset
+        >>> from pyspark.sql import SparkSession
+        >>> from pyspark.sql.types import StructField, StringType, IntegerType, StructType
+        >>>
+        >>> schema = StructType(
+        ...     [StructField("name", StringType(), True), StructField("age", IntegerType(), True)]
+        ... )
+        >>> data = [("Alex", 31), ("Bob", 12), ("Clarke", 65), ("Dave", 29)]
+        >>> spark_df = SparkSession.builder.getOrCreate().createDataFrame(data, schema)
+        >>>
+        >>> dataset = SparkHiveDataset(
+        ...     database="test_database", table="test_table", write_mode="overwrite"
+        ... )
+        >>> dataset.save(spark_df)
+        >>> reloaded = dataset.load()
+        >>> reloaded.take(4)
 
-    from pyspark.sql import SparkSession
-    from pyspark.sql.types import StructField, StringType, IntegerType, StructType
-
-    from kedro_datasets.spark import SparkHiveDataset
-
-    schema = StructType(
-        [StructField("name", StringType(), True), StructField("age", IntegerType(), True)]
-    )
-
-    data = [("Alex", 31), ("Bob", 12), ("Clarke", 65), ("Dave", 29)]
-
-    spark_df = SparkSession.builder.getOrCreate().createDataFrame(data, schema)
-
-    dataset = SparkHiveDataset(
-        database="test_database", table="test_table", write_mode="overwrite"
-    )
-    dataset.save(spark_df)
-    reloaded = dataset.load()
-
-    reloaded.take(4)
-    ```
     """
 
     DEFAULT_SAVE_ARGS: dict[str, Any] = {}

--- a/kedro-datasets/kedro_datasets/spark/spark_jdbc_dataset.py
+++ b/kedro-datasets/kedro_datasets/spark/spark_jdbc_dataset.py
@@ -16,50 +16,48 @@ class SparkJDBCDataset(AbstractDataset[DataFrame, DataFrame]):
     ``pyspark.sql.DataFrameReader`` and ``pyspark.sql.DataFrameWriter``
     internally, so it supports all allowed PySpark options on ``jdbc``.
 
-    ### Example usage for the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
+    Examples:
+        Using the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
 
-    ```yaml
+        ```yaml
+        weather:
+          type: spark.SparkJDBCDataset
+          table: weather_table
+          url: jdbc:postgresql://localhost/test
+          credentials: db_credentials
+          load_args:
+            properties:
+              driver: org.postgresql.Driver
+          save_args:
+            properties:
+              driver: org.postgresql.Driver
+        ```
 
-    weather:
-        type: spark.SparkJDBCDataset
-        table: weather_table
-        url: jdbc:postgresql://localhost/test
-        credentials: db_credentials
-        load_args:
-        properties:
-            driver: org.postgresql.Driver
-        save_args:
-        properties:
-            driver: org.postgresql.Driver
-    ```
-    ### Example usage for the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
+        Using the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
 
-    ```python
-
-    import pandas as pd
-    from kedro_datasets.spark import SparkJDBCDataset
-    from pyspark.sql import SparkSession
-
-    spark = SparkSession.builder.getOrCreate()
-    data = spark.createDataFrame(
-        pd.DataFrame({"col1": [1, 2], "col2": [4, 5], "col3": [5, 6]})
-    )
-    url = "jdbc:postgresql://localhost/test"
-    table = "table_a"
-    connection_properties = {"driver": "org.postgresql.Driver"}
-    dataset = SparkJDBCDataset(
-        url=url,
-        table=table,
-        credentials={"user": "scott", "password": "tiger"},
-        load_args={"properties": connection_properties},
-        save_args={"properties": connection_properties},
-    )
-
-    dataset.save(data)
-    reloaded = dataset.load()
-
-    assert data.toPandas().equals(reloaded.toPandas())
-    ```
+        >>> import pandas as pd
+        >>> from kedro_datasets.spark import SparkJDBCDataset
+        >>> from pyspark.sql import SparkSession
+        >>>
+        >>> spark = SparkSession.builder.getOrCreate()
+        >>> data = spark.createDataFrame(
+        ...     pd.DataFrame({"col1": [1, 2], "col2": [4, 5], "col3": [5, 6]})
+        ... )
+        >>>
+        >>> url = "jdbc:postgresql://localhost/test"
+        >>> table = "table_a"
+        >>> connection_properties = {"driver": "org.postgresql.Driver"}
+        >>> dataset = SparkJDBCDataset(
+        ...     url=url,
+        ...     table=table,
+        ...     credentials={"user": "scott", "password": "tiger"},
+        ...     load_args={"properties": connection_properties},
+        ...     save_args={"properties": connection_properties},
+        ... )
+        >>>
+        >>> dataset.save(data)
+        >>> reloaded = dataset.load()
+        >>> assert data.toPandas().equals(reloaded.toPandas())
 
     """
 

--- a/kedro-datasets/kedro_datasets/spark/spark_streaming_dataset.py
+++ b/kedro-datasets/kedro_datasets/spark/spark_streaming_dataset.py
@@ -16,22 +16,23 @@ from kedro_datasets.spark.spark_dataset import SparkDataset
 class SparkStreamingDataset(AbstractDataset):
     """``SparkStreamingDataset`` loads data to Spark Streaming Dataframe objects.
 
-    ### Example usage for the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
+    Examples:
+        Using the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
 
-     ```yaml
+        ```yaml
+        raw.new_inventory:
+          type: spark.SparkStreamingDataset
+          filepath: data/01_raw/stream/inventory/
+          file_format: json
+          save_args:
+            output_mode: append
+            checkpoint: data/04_checkpoint/raw_new_inventory
+            header: True
+          load_args:
+            schema:
+                filepath: data/01_raw/schema/inventory_schema.json
+        ```
 
-     raw.new_inventory:
-         type: spark.SparkStreamingDataset
-         filepath: data/01_raw/stream/inventory/
-         file_format: json
-         save_args:
-         output_mode: append
-         checkpoint: data/04_checkpoint/raw_new_inventory
-         header: True
-         load_args:
-         schema:
-             filepath: data/01_raw/schema/inventory_schema.json
-     ```
     """
 
     DEFAULT_LOAD_ARGS = {}  # type: dict[str, Any]

--- a/kedro-datasets/kedro_datasets/svmlight/svmlight_dataset.py
+++ b/kedro-datasets/kedro_datasets/svmlight/svmlight_dataset.py
@@ -44,45 +44,44 @@ class SVMLightDataset(AbstractVersionedDataset[_DI, _DO]):
     This format is used as the default format for both svmlight and the
     libsvm command line programs.
 
-    ### Example usage for the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
+    Examples:
+        Using the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
 
-    ```yaml
+        ```yaml
+        svm_dataset:
+          type: svmlight.SVMLightDataset
+          filepath: data/01_raw/location.svm
+          load_args:
+            zero_based: False
+          save_args:
+            zero_based: False
 
-    svm_dataset:
-        type: svmlight.SVMLightDataset
-        filepath: data/01_raw/location.svm
-        load_args:
-        zero_based: False
-        save_args:
-        zero_based: False
+        cars:
+          type: svmlight.SVMLightDataset
+          filepath: gcs://your_bucket/cars.svm
+          fs_args:
+            project: my-project
+          credentials: my_gcp_credentials
+          load_args:
+            zero_based: False
+          save_args:
+            zero_based: False
+        ```
 
-    cars:
-        type: svmlight.SVMLightDataset
-        filepath: gcs://your_bucket/cars.svm
-        fs_args:
-        project: my-project
-        credentials: my_gcp_credentials
-        load_args:
-        zero_based: False
-        save_args:
-        zero_based: False
-    ```
-    ### Example usage for the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
+        Using the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
 
-    ```python
+        >>> import numpy as np
+        >>> from kedro_datasets.svmlight import SVMLightDataset
+        >>>
+        >>> # Features and labels.
+        >>> data = (np.array([[0, 1], [2, 3.14159]]), np.array([7, 3]))
+        >>>
+        >>> dataset = SVMLightDataset(filepath=tmp_path / "test.svm")
+        >>> dataset.save(data)
+        >>> reloaded_features, reloaded_labels = dataset.load()
+        >>> assert (data[0] == reloaded_features).all()
+        >>> assert (data[1] == reloaded_labels).all()
 
-    from kedro_datasets.svmlight import SVMLightDataset
-    import numpy as np
-
-    # Features and labels.
-    data = (np.array([[0, 1], [2, 3.14159]]), np.array([7, 3]))
-
-    dataset = SVMLightDataset(filepath=tmp_path / "test.svm")
-    dataset.save(data)
-    reloaded_features, reloaded_labels = dataset.load()
-    assert (data[0] == reloaded_features).all()
-    assert (data[1] == reloaded_labels).all()
-    ```
     """
 
     DEFAULT_LOAD_ARGS: dict[str, Any] = {}

--- a/kedro-datasets/kedro_datasets/tensorflow/tensorflow_model_dataset.py
+++ b/kedro-datasets/kedro_datasets/tensorflow/tensorflow_model_dataset.py
@@ -27,41 +27,39 @@ class TensorFlowModelDataset(AbstractVersionedDataset[tf.keras.Model, tf.keras.M
     The underlying functionality is supported by, and passes input arguments through to,
     TensorFlow 2.X load_model and save_model methods.
 
-    ### Example usage for the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
+    Examples:
+        Using the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
 
-    ```yaml
+        ```yaml
+        tensorflow_model:
+          type: tensorflow.TensorFlowModelDataset
+          filepath: data/06_models/tensorflow_model.h5
+          load_args:
+            compile: False
+          save_args:
+            overwrite: True
+            include_optimizer: False
+          credentials: tf_creds
+        ```
 
-    tensorflow_model:
-        type: tensorflow.TensorFlowModelDataset
-        filepath: data/06_models/tensorflow_model.h5
-        load_args:
-        compile: False
-        save_args:
-        overwrite: True
-        include_optimizer: False
-        credentials: tf_creds
-    ```
-    ### Example usage for the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
+        Using the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
 
-    ```python
+        >>> import numpy as np
+        >>> import tensorflow as tf
+        >>> from kedro_datasets.tensorflow import TensorFlowModelDataset
+        >>>
+        >>> model = tf.keras.Sequential(
+        ...     [tf.keras.layers.Dense(5, input_shape=(3,)), tf.keras.layers.Softmax()]
+        ... )
+        >>> # x = tf.random.uniform((10, 3))
+        >>> # predictions = model.predict(x)
+        >>>
+        >>> dataset = TensorFlowModelDataset(
+        ...     filepath=tmp_path / "data/06_models/tensorflow_model.h5"
+        ... )
+        >>> dataset.save(model)
+        >>> loaded_model = dataset.load()
 
-    from kedro_datasets.tensorflow import TensorFlowModelDataset
-    import tensorflow as tf
-    import numpy as np
-
-    dataset = TensorFlowModelDataset(
-        filepath=tmp_path / "data/06_models/tensorflow_model.h5"
-    )
-    model = tf.keras.Sequential(
-        [tf.keras.layers.Dense(5, input_shape=(3,)), tf.keras.layers.Softmax()]
-    )
-
-    # x = tf.random.uniform((10, 3))
-    # predictions = model.predict(x)
-
-    dataset.save(model)
-    loaded_model = dataset.load()
-    ```
     """
 
     DEFAULT_LOAD_ARGS: dict[str, Any] = {}

--- a/kedro-datasets/kedro_datasets/text/text_dataset.py
+++ b/kedro-datasets/kedro_datasets/text/text_dataset.py
@@ -21,26 +21,26 @@ class TextDataset(AbstractVersionedDataset[str, str]):
     """``TextDataset`` loads/saves data from/to a text file using an underlying
     filesystem (e.g.: local, S3, GCS)
 
-    ### Example usage for the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
+    Examples:
+        Using the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
 
-    ```yaml
-    alice_book:
-        type: text.TextDataset
-        filepath: data/01_raw/alice.txt
-    ```
-    ### Example usage for the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
+        ```yaml
+        alice_book:
+          type: text.TextDataset
+          filepath: data/01_raw/alice.txt
+        ```
 
-    ```python
+        Using the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
 
-    from kedro_datasets.text import TextDataset
+        >>> from kedro_datasets.text import TextDataset
+        >>>
+        >>> string_to_write = "This will go in a file."
+        >>>
+        >>> dataset = TextDataset(filepath=tmp_path / "test.md")
+        >>> dataset.save(string_to_write)
+        >>> reloaded = dataset.load()
+        >>> assert string_to_write == reloaded
 
-    string_to_write = "This will go in a file."
-
-    dataset = TextDataset(filepath=tmp_path / "test.md")
-    dataset.save(string_to_write)
-    reloaded = dataset.load()
-    assert string_to_write == reloaded
-    ```
     """
 
     DEFAULT_FS_ARGS: dict[str, Any] = {

--- a/kedro-datasets/kedro_datasets/yaml/yaml_dataset.py
+++ b/kedro-datasets/kedro_datasets/yaml/yaml_dataset.py
@@ -26,26 +26,26 @@ class YAMLDataset(AbstractVersionedDataset[dict, dict]):
     """``YAMLDataset`` loads/saves data from/to a YAML file using an underlying
     filesystem (e.g.: local, S3, GCS). It uses PyYAML to handle the YAML file.
 
-    ### Example usage for the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
+    Examples:
+        Using the [YAML API](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html):
 
-    ```yaml
-    cars:
-        type: yaml.YAMLDataset
-        filepath: cars.yaml
-    ```
-    ### Example usage for the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
+        ```yaml
+        cars:
+          type: yaml.YAMLDataset
+          filepath: cars.yaml
+        ```
 
-    ```python
+        Using the [Python API](https://docs.kedro.org/en/stable/data/advanced_data_catalog_usage.html):
 
-    from kedro_datasets.yaml import YAMLDataset
+        >>> from kedro_datasets.yaml import YAMLDataset
+        >>>
+        >>> data = {"col1": [1, 2], "col2": [4, 5], "col3": [5, 6]}
+        >>>
+        >>> dataset = YAMLDataset(filepath=tmp_path / "test.yaml")
+        >>> dataset.save(data)
+        >>> reloaded = dataset.load()
+        >>> assert data == reloaded
 
-    data = {"col1": [1, 2], "col2": [4, 5], "col3": [5, 6]}
-
-    dataset = YAMLDataset(filepath=tmp_path / "test.yaml")
-    dataset.save(data)
-    reloaded = dataset.load()
-    assert data == reloaded
-    ```
     """
 
     DEFAULT_SAVE_ARGS: dict[str, Any] = {"default_flow_style": False}

--- a/kedro-datasets/mkdocs.yml
+++ b/kedro-datasets/mkdocs.yml
@@ -106,10 +106,12 @@ extra_css:
   - stylesheets/themes.css
   - stylesheets/footer.css
   - stylesheets/welcome.css
+  - stylesheets/code-select.css
 
 extra_javascript:
   - javascript/readthedocs.js
   - javascript/deindex-old-docs.js
+  - javascript/code-select.js
 
 nav:
   - Welcome: https://docs.kedro.org/en/develop/


### PR DESCRIPTION
## Description

Restore doctests removed in #1076 and #1078.

Fix a lot of YAML formatting errors along the way.

## Development notes

Tested in CI:

```
============================= test session starts ==============================
platform linux -- Python 3.12.11, pytest-7.4.4, pluggy-1.6.0
rootdir: /home/runner/work/kedro-plugins/kedro-plugins/kedro-datasets
configfile: pyproject.toml
plugins: forked-1.6.0, cov-3.0.0, requests-mock-1.12.1, xdist-2.2.1, anyio-4.9.0, mock-1.13.0
collected 43 items
kedro_datasets/api/api_dataset.py .                                      [  2%]
kedro_datasets/biosequence/biosequence_dataset.py .                      [  4%]
kedro_datasets/dask/csv_dataset.py .                                     [  6%]
kedro_datasets/dask/parquet_dataset.py .                                 [  9%]
kedro_datasets/databricks/managed_table_dataset.py .                     [ 11%]
kedro_datasets/email/message_dataset.py .                                [ 13%]
kedro_datasets/geopandas/generic_dataset.py .                            [ 16%]
kedro_datasets/holoviews/holoviews_writer.py .                           [ 18%]
kedro_datasets/huggingface/hugging_face_dataset.py .                     [ 20%]
kedro_datasets/huggingface/transformer_pipeline_dataset.py .             [ 23%]
kedro_datasets/ibis/file_dataset.py .                                    [ 25%]
kedro_datasets/ibis/table_dataset.py .                                   [ [27](https://github.com/kedro-org/kedro-plugins/actions/runs/15917153358/job/44896793783?pr=1116#step:11:28)%]
kedro_datasets/json/json_dataset.py .                                    [ 30%]
kedro_datasets/matlab/matlab_dataset.py .                                [ 32%]
kedro_datasets/matplotlib/matplotlib_dataset.py .                        [ 34%]
kedro_datasets/networkx/gml_dataset.py .                                 [ 37%]
kedro_datasets/networkx/graphml_dataset.py .                             [ 39%]
kedro_datasets/pandas/csv_dataset.py .                                   [ 41%]
kedro_datasets/pandas/deltatable_dataset.py .                            [ 44%]
kedro_datasets/pandas/excel_dataset.py .                                 [ 46%]
kedro_datasets/pandas/feather_dataset.py .                               [ 48%]
kedro_datasets/pandas/generic_dataset.py .                               [ 51%]
kedro_datasets/pandas/hdf_dataset.py .                                   [ 53%]
kedro_datasets/pandas/json_dataset.py .                                  [ 55%]
kedro_datasets/pandas/parquet_dataset.py .                               [ 58%]
kedro_datasets/pandas/sql_dataset.py ..                                  [ 62%]
kedro_datasets/pandas/xml_dataset.py .                                   [ 65%]
kedro_datasets/partitions/incremental_dataset.py .                       [ 67%]
kedro_datasets/pickle/pickle_dataset.py .                                [ 69%]
kedro_datasets/pillow/image_dataset.py .                                 [ 72%]
kedro_datasets/plotly/html_dataset.py .                                  [ 74%]
kedro_datasets/plotly/json_dataset.py .                                  [ 76%]
kedro_datasets/plotly/plotly_dataset.py .                                [ 79%]
kedro_datasets/polars/csv_dataset.py .                                   [ 81%]
kedro_datasets/polars/eager_polars_dataset.py .                          [ 83%]
kedro_datasets/polars/lazy_polars_dataset.py .                           [ 86%]
kedro_datasets/spark/deltatable_dataset.py .                             [ 88%]
kedro_datasets/spark/spark_dataset.py .                                  [ 90%]
kedro_datasets/svmlight/svmlight_dataset.py .                            [ 93%]
kedro_datasets/tensorflow/tensorflow_model_dataset.py .                  [ 95%]
kedro_datasets/text/text_dataset.py .                                    [ 97%]
kedro_datasets/yaml/yaml_dataset.py .                                    [100%]
======================== 43 passed in 60.[39](https://github.com/kedro-org/kedro-plugins/actions/runs/15917153358/job/44896793783?pr=1116#step:11:40)s (0:01:00) =========================
```

## Checklist

- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [ ] Updated `jsonschema/kedro-catalog-X.XX.json` if necessary
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
- [ ] Received approvals from at least half of the TSC (required for adding a new, non-experimental dataset)
