### PR TITLE
chore: Bump `ruff` to latest in all plugins

### DIFF
--- a/kedro-airflow/pyproject.toml
+++ b/kedro-airflow/pyproject.toml
@@ -41,7 +41,7 @@ lint = [
     "detect-secrets~=1.5.0",
     "mypy~=1.0",
     "pre-commit>=2.9.2",
-    "ruff~=0.0.290",
+    "ruff~=0.12.1",
     # mypy requirements
     "types-PyYAML",
     "types-cachetools",
@@ -84,6 +84,8 @@ exclude_also = ["raise NotImplementedError"]
 [tool.ruff]
 line-length = 88
 show-fixes = true
+
+[tool.ruff.lint]
 select = [
     "F",   # Pyflakes
     "W",   # pycodestyle

--- a/kedro-datasets/kedro_datasets/_utils/databricks_utils.py
+++ b/kedro-datasets/kedro_datasets/_utils/databricks_utils.py
@@ -65,12 +65,12 @@ def get_dbutils(spark: Union[SparkSession, "DatabricksSession"]) -> "DBUtils":
         return dbutils
 
     try:
-        from pyspark.dbutils import DBUtils
+        from pyspark.dbutils import DBUtils  # noqa: PLC0415
 
         dbutils = DBUtils(spark)
     except ImportError:
         try:
-            import IPython
+            import IPython  # noqa: PLC0415
         except ImportError:
             pass
         else:

--- a/kedro-datasets/kedro_datasets/_utils/spark_utils.py
+++ b/kedro-datasets/kedro_datasets/_utils/spark_utils.py
@@ -16,7 +16,7 @@ def get_spark() -> Union[SparkSession, "DatabricksSession"]:
         # When using databricks-connect >= 13.0.0 (a.k.a databricks-connect-v2)
         # the remote session is instantiated using the databricks module
         # If the databricks-connect module is installed, we use a remote session
-        from databricks.connect import DatabricksSession
+        from databricks.connect import DatabricksSession  # noqa: PLC0415
 
         # We can't test this as there's no Databricks test env available
         spark = DatabricksSession.builder.getOrCreate()  # pragma: no cover

--- a/kedro-datasets/kedro_datasets/ibis/file_dataset.py
+++ b/kedro-datasets/kedro_datasets/ibis/file_dataset.py
@@ -144,7 +144,7 @@ class FileDataset(ConnectionMixin, AbstractVersionedDataset[ir.Table, ir.Table])
             self._save_args.update(save_args)
 
     def _connect(self) -> BaseBackend:
-        import ibis
+        import ibis  # noqa: PLC0415
 
         config = deepcopy(self._connection_config)
         backend = getattr(ibis, config.pop("backend"))

--- a/kedro-datasets/kedro_datasets/ibis/table_dataset.py
+++ b/kedro-datasets/kedro_datasets/ibis/table_dataset.py
@@ -133,7 +133,7 @@ class TableDataset(ConnectionMixin, AbstractDataset[ir.Table, ir.Table]):
         self._materialized = self._save_args.pop("materialized")
 
     def _connect(self) -> BaseBackend:
-        import ibis
+        import ibis  # noqa: PLC0415
 
         config = deepcopy(self._connection_config)
         backend = getattr(ibis, config.pop("backend"))

--- a/kedro-datasets/kedro_datasets/pandas/parquet_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/parquet_dataset.py
@@ -229,7 +229,7 @@ class ParquetDataset(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
         Returns:
             dict: A dictionary containing the data in a split format.
         """
-        import pyarrow.parquet as pq
+        import pyarrow.parquet as pq  # noqa: PLC0415
 
         load_path = str(self._get_load_path())
 

--- a/kedro-datasets/kedro_datasets/partitions/partitioned_dataset.py
+++ b/kedro-datasets/kedro_datasets/partitions/partitioned_dataset.py
@@ -199,7 +199,8 @@ class PartitionedDataset(AbstractDataset[dict[str, Any], dict[str, Callable[[], 
         Raises:
             DatasetError: If versioning is enabled for the underlying dataset.
         """
-        from fsspec.utils import infer_storage_options  # for performance reasons
+        # for performance reasons
+        from fsspec.utils import infer_storage_options  # noqa: PLC0415
 
         super().__init__()
 

--- a/kedro-datasets/pyproject.toml
+++ b/kedro-datasets/pyproject.toml
@@ -289,7 +289,7 @@ lint = [
     "import-linter[toml]==1.2.6",
     "mypy~=1.0",
     "pre-commit>=2.9.2",
-    "ruff~=0.0.290",
+    "ruff~=0.12.1",
     # mypy related dependencies
     "types-cachetools",
     "types-PyYAML",
@@ -355,6 +355,8 @@ addopts = [
 [tool.ruff]
 line-length = 88
 show-fixes = true
+
+[tool.ruff.lint]
 select = [
     "F",   # Pyflakes
     "W",   # pycodestyle

--- a/kedro-datasets/tests/spark/test_spark_hive_dataset.py
+++ b/kedro-datasets/tests/spark/test_spark_hive_dataset.py
@@ -135,7 +135,7 @@ def _generate_spark_df_upsert_expected():
 
 class TestSparkHiveDataset:
     def test_cant_pickle(self):
-        import pickle
+        import pickle  # noqa: PLC0415
 
         with pytest.raises(pickle.PicklingError):
             pickle.dumps(

--- a/kedro-datasets/tests/tensorflow/test_tensorflow_model_dataset.py
+++ b/kedro-datasets/tests/tensorflow/test_tensorflow_model_dataset.py
@@ -32,14 +32,14 @@ if sys.platform == "win32":
 # a subprocess spawned by the parallel runner, so we wrap the import inside fixtures.
 @pytest.fixture(scope="module")
 def tf():
-    import tensorflow as tf
+    import tensorflow as tf  # noqa: PLC0415
 
     return tf
 
 
 @pytest.fixture(scope="module")
 def tensorflow_model_dataset():
-    from kedro_datasets.tensorflow import TensorFlowModelDataset
+    from kedro_datasets.tensorflow import TensorFlowModelDataset  # noqa: PLC0415
 
     return TensorFlowModelDataset
 

--- a/kedro-docker/pyproject.toml
+++ b/kedro-docker/pyproject.toml
@@ -42,7 +42,7 @@ lint = [
     "detect-secrets~=1.5.0",
     "mypy~=1.0",
     "pre-commit>=2.9.2",
-    "ruff~=0.0.290",
+    "ruff~=0.12.1",
 ]
 
 [project.entry-points."kedro.project_commands"]
@@ -85,6 +85,8 @@ exclude_also = ["raise NotImplementedError"]
 [tool.ruff]
 line-length = 88
 show-fixes = true
+
+[tool.ruff.lint]
 select = [
     "F",   # Pyflakes
     "W",   # pycodestyle

--- a/kedro-telemetry/pyproject.toml
+++ b/kedro-telemetry/pyproject.toml
@@ -38,7 +38,7 @@ lint = [
     "detect-secrets~=1.5.0",
     "mypy~=1.0",
     "pre-commit>=2.9.2",
-    "ruff~=0.0.290",
+    "ruff~=0.12.1",
     # mypy requirements
     "types-requests",
     "types-PyYAML",
@@ -63,6 +63,8 @@ version = {attr = "kedro_telemetry.__version__"}
 [tool.ruff]
 line-length = 88
 show-fixes = true
+
+[tool.ruff.lint]
 select = [
     "F",   # Pyflakes
     "W",   # pycodestyle

--- a/kedro-telemetry/pyproject.toml
+++ b/kedro-telemetry/pyproject.toml
@@ -76,5 +76,5 @@ select = [
 ]
 ignore = ["E501"]  # Black takes care of line-too-long
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 known-first-party = ["kedro_telemetry"]

--- a/kedro-telemetry/tests/integration/dummy-project/src/dummy_project/__main__.py
+++ b/kedro-telemetry/tests/integration/dummy-project/src/dummy_project/__main__.py
@@ -22,7 +22,7 @@ def _find_run_command(package_name):
             # use run command from installed plugin if it exists
             return run
         # use run command from the framework project
-        from kedro.framework.cli.project import run
+        from kedro.framework.cli.project import run  # noqa: PLC0415
 
         return run
     # fail badly if cli.py exists, but has no `cli` in it

--- a/kedro-telemetry/tests/integration/test_telemetry.py
+++ b/kedro-telemetry/tests/integration/test_telemetry.py
@@ -25,7 +25,7 @@ class TestKedroTelemetryHookIntegration:
     def test_telemetry_sent_once_with_other_kedro_command(
         self, mocker, dummy_project_path
     ):
-        from kedro_telemetry.plugin import telemetry_hook
+        from kedro_telemetry.plugin import telemetry_hook  # noqa: PLC0415
 
         telemetry_hook.consent = None
         telemetry_hook._sent = False
@@ -41,7 +41,7 @@ class TestKedroTelemetryHookIntegration:
         mocked_heap_call.assert_called_once()
 
     def test_telemetry_sent_once_with_session_run(self, mocker, dummy_project_path):
-        from kedro_telemetry.plugin import telemetry_hook
+        from kedro_telemetry.plugin import telemetry_hook  # noqa: PLC0415
 
         telemetry_hook.consent = None
         telemetry_hook._sent = False


### PR DESCRIPTION
## Description
Ruff was pinned to an old version.

## Development notes


## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Updated `jsonschema/kedro-catalog-X.XX.json` if necessary
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
- [ ] Received approvals from at least half of the TSC (required for adding a new, non-experimental dataset)
