### PR TITLE
test(datasets): Fix tests after `__str__` removal

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -91,10 +91,6 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
-      "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".secrets.baseline"
-    },
-    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -247,22 +243,6 @@
         "line_number": 108
       }
     ],
-    "kedro-datasets/tests/matplotlib/test_matplotlib_writer.py": [
-      {
-        "type": "Secret Keyword",
-        "filename": "kedro-datasets/tests/matplotlib/test_matplotlib_writer.py",
-        "hashed_secret": "dc724af18fbdd4e59189f5fe768a5f8311527050",
-        "is_verified": false,
-        "line_number": 16
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "kedro-datasets/tests/matplotlib/test_matplotlib_writer.py",
-        "hashed_secret": "727d8ff68b6b550f2cf6e737b3cad5149c65fe5b",
-        "is_verified": false,
-        "line_number": 59
-      }
-    ],
     "kedro-datasets/tests/pandas/test_csv_dataset.py": [
       {
         "type": "Secret Keyword",
@@ -344,35 +324,35 @@
         "filename": "kedro-datasets/tests/partitions/test_partitioned_dataset.py",
         "hashed_secret": "76f747de912e8682e29a23cb506dd5bf0de080d2",
         "is_verified": false,
-        "line_number": 471
+        "line_number": 475
       },
       {
         "type": "Secret Keyword",
         "filename": "kedro-datasets/tests/partitions/test_partitioned_dataset.py",
         "hashed_secret": "9027cc5a2c1321de60a2d71ccde6229d1152d6d3",
         "is_verified": false,
-        "line_number": 472
+        "line_number": 476
       },
       {
         "type": "Secret Keyword",
         "filename": "kedro-datasets/tests/partitions/test_partitioned_dataset.py",
         "hashed_secret": "5dcbdf371f181b9b7a41a4be7be70f8cbee67da7",
         "is_verified": false,
-        "line_number": 508
+        "line_number": 512
       },
       {
         "type": "Secret Keyword",
         "filename": "kedro-datasets/tests/partitions/test_partitioned_dataset.py",
         "hashed_secret": "727d8ff68b6b550f2cf6e737b3cad5149c65fe5b",
         "is_verified": false,
-        "line_number": 559
+        "line_number": 563
       },
       {
         "type": "Secret Keyword",
         "filename": "kedro-datasets/tests/partitions/test_partitioned_dataset.py",
         "hashed_secret": "adb5fabe51f5b45e83fdd91b71c92156fec4a63e",
         "is_verified": false,
-        "line_number": 579
+        "line_number": 583
       }
     ],
     "kedro-datasets/tests/plotly/test_html_dataset.py": [
@@ -494,5 +474,5 @@
       }
     ]
   },
-  "generated_at": "2025-06-27T02:56:04Z"
+  "generated_at": "2025-07-03T18:25:11Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -324,35 +324,35 @@
         "filename": "kedro-datasets/tests/partitions/test_partitioned_dataset.py",
         "hashed_secret": "76f747de912e8682e29a23cb506dd5bf0de080d2",
         "is_verified": false,
-        "line_number": 475
+        "line_number": 471
       },
       {
         "type": "Secret Keyword",
         "filename": "kedro-datasets/tests/partitions/test_partitioned_dataset.py",
         "hashed_secret": "9027cc5a2c1321de60a2d71ccde6229d1152d6d3",
         "is_verified": false,
-        "line_number": 476
+        "line_number": 472
       },
       {
         "type": "Secret Keyword",
         "filename": "kedro-datasets/tests/partitions/test_partitioned_dataset.py",
         "hashed_secret": "5dcbdf371f181b9b7a41a4be7be70f8cbee67da7",
         "is_verified": false,
-        "line_number": 512
+        "line_number": 508
       },
       {
         "type": "Secret Keyword",
         "filename": "kedro-datasets/tests/partitions/test_partitioned_dataset.py",
         "hashed_secret": "727d8ff68b6b550f2cf6e737b3cad5149c65fe5b",
         "is_verified": false,
-        "line_number": 563
+        "line_number": 559
       },
       {
         "type": "Secret Keyword",
         "filename": "kedro-datasets/tests/partitions/test_partitioned_dataset.py",
         "hashed_secret": "adb5fabe51f5b45e83fdd91b71c92156fec4a63e",
         "is_verified": false,
-        "line_number": 583
+        "line_number": 579
       }
     ],
     "kedro-datasets/tests/plotly/test_html_dataset.py": [
@@ -474,5 +474,5 @@
       }
     ]
   },
-  "generated_at": "2025-07-03T18:25:11Z"
+  "generated_at": "2025-07-04T16:21:58Z"
 }

--- a/kedro-datasets/kedro_datasets/huggingface/hugging_face_dataset.py
+++ b/kedro-datasets/kedro_datasets/huggingface/hugging_face_dataset.py
@@ -49,7 +49,8 @@ class HFDataset(AbstractDataset):
         self.metadata = metadata
 
     def load(self):
-        return load_dataset(self.dataset_name, **self._dataset_kwargs)
+        # TODO: Replace suppression with the solution from here: https://github.com/kedro-org/kedro-plugins/issues/1131
+        return load_dataset(self.dataset_name, **self._dataset_kwargs)  # nosec
 
     def save(self):
         raise NotImplementedError("Not yet implemented")

--- a/kedro-datasets/tests/biosequence/test_biosequence_dataset.py
+++ b/kedro-datasets/tests/biosequence/test_biosequence_dataset.py
@@ -75,7 +75,7 @@ class TestBioSequenceDataset:
 
     def test_load_missing_file(self, biosequence_dataset):
         """Check the error when trying to load missing file."""
-        pattern = r"Failed while loading data from dataset BioSequenceDataset\(.*\)"
+        pattern = r"Failed while loading data from dataset kedro_datasets.biosequence.biosequence_dataset.BioSequenceDataset\(.*\)"
         with pytest.raises(DatasetError, match=pattern):
             biosequence_dataset.load()
 

--- a/kedro-datasets/tests/dask/test_csv_dataset.py
+++ b/kedro-datasets/tests/dask/test_csv_dataset.py
@@ -84,7 +84,7 @@ class TestCSVDataset:
     @pytest.mark.parametrize("bad_credentials", [{"key": None, "secret": None}])
     def test_empty_credentials_load(self, bad_credentials):
         csv_dataset = CSVDataset(filepath=S3_PATH, credentials=bad_credentials)
-        pattern = r"Failed while loading data from dataset CSVDataset\(.+\)"
+        pattern = r"Failed while loading data from dataset kedro_datasets.polars.csv_dataset.CSVDataset\(.+\)"
         with pytest.raises(DatasetError, match=pattern):
             csv_dataset.load().compute()
 
@@ -94,7 +94,7 @@ class TestCSVDataset:
         client instantiation on creating S3 connection."""
         client_mock = mocker.patch("botocore.session.Session.create_client")
         s3_dataset = CSVDataset(filepath=S3_PATH, credentials=AWS_CREDENTIALS)
-        pattern = r"Failed while loading data from dataset CSVDataset\(.+\)"
+        pattern = r"Failed while loading data from dataset kedro_datasets.polars.csv_dataset.CSVDataset\(.+\)"
         with pytest.raises(DatasetError, match=pattern):
             s3_dataset.load().compute()
 

--- a/kedro-datasets/tests/dask/test_csv_dataset.py
+++ b/kedro-datasets/tests/dask/test_csv_dataset.py
@@ -84,7 +84,7 @@ class TestCSVDataset:
     @pytest.mark.parametrize("bad_credentials", [{"key": None, "secret": None}])
     def test_empty_credentials_load(self, bad_credentials):
         csv_dataset = CSVDataset(filepath=S3_PATH, credentials=bad_credentials)
-        pattern = r"Failed while loading data from dataset kedro_datasets.polars.csv_dataset.CSVDataset\(.+\)"
+        pattern = r"Failed while loading data from dataset kedro_datasets.dask.csv_dataset.CSVDataset\(.+\)"
         with pytest.raises(DatasetError, match=pattern):
             csv_dataset.load().compute()
 
@@ -94,7 +94,7 @@ class TestCSVDataset:
         client instantiation on creating S3 connection."""
         client_mock = mocker.patch("botocore.session.Session.create_client")
         s3_dataset = CSVDataset(filepath=S3_PATH, credentials=AWS_CREDENTIALS)
-        pattern = r"Failed while loading data from dataset kedro_datasets.polars.csv_dataset.CSVDataset\(.+\)"
+        pattern = r"Failed while loading data from dataset kedro_datasets.dask.csv_dataset.CSVDataset\(.+\)"
         with pytest.raises(DatasetError, match=pattern):
             s3_dataset.load().compute()
 

--- a/kedro-datasets/tests/dask/test_parquet_dataset.py
+++ b/kedro-datasets/tests/dask/test_parquet_dataset.py
@@ -87,7 +87,7 @@ class TestParquetDataset:
     @pytest.mark.parametrize("bad_credentials", [{"key": None, "secret": None}])
     def test_empty_credentials_load(self, bad_credentials):
         parquet_dataset = ParquetDataset(filepath=S3_PATH, credentials=bad_credentials)
-        pattern = r"Failed while loading data from dataset kedro_datasets.pandas.parquet_dataset.ParquetDataset\(.+\)"
+        pattern = r"Failed while loading data from dataset kedro_datasets.dask.parquet_dataset.ParquetDataset\(.+\)"
         with pytest.raises(DatasetError, match=pattern):
             parquet_dataset.load().compute()
 
@@ -97,7 +97,7 @@ class TestParquetDataset:
         client instantiation on creating S3 connection."""
         client_mock = mocker.patch("botocore.session.Session.create_client")
         s3_dataset = ParquetDataset(filepath=S3_PATH, credentials=AWS_CREDENTIALS)
-        pattern = r"Failed while loading data from dataset kedro_datasets.pandas.parquet_dataset.ParquetDataset\(.+\)"
+        pattern = r"Failed while loading data from dataset kedro_datasets.dask.parquet_dataset.ParquetDataset\(.+\)"
         with pytest.raises(DatasetError, match=pattern):
             s3_dataset.load().compute()
 

--- a/kedro-datasets/tests/dask/test_parquet_dataset.py
+++ b/kedro-datasets/tests/dask/test_parquet_dataset.py
@@ -87,7 +87,7 @@ class TestParquetDataset:
     @pytest.mark.parametrize("bad_credentials", [{"key": None, "secret": None}])
     def test_empty_credentials_load(self, bad_credentials):
         parquet_dataset = ParquetDataset(filepath=S3_PATH, credentials=bad_credentials)
-        pattern = r"Failed while loading data from dataset ParquetDataset\(.+\)"
+        pattern = r"Failed while loading data from dataset kedro_datasets.pandas.parquet_dataset.ParquetDataset\(.+\)"
         with pytest.raises(DatasetError, match=pattern):
             parquet_dataset.load().compute()
 
@@ -97,7 +97,7 @@ class TestParquetDataset:
         client instantiation on creating S3 connection."""
         client_mock = mocker.patch("botocore.session.Session.create_client")
         s3_dataset = ParquetDataset(filepath=S3_PATH, credentials=AWS_CREDENTIALS)
-        pattern = r"Failed while loading data from dataset ParquetDataset\(.+\)"
+        pattern = r"Failed while loading data from dataset kedro_datasets.pandas.parquet_dataset.ParquetDataset\(.+\)"
         with pytest.raises(DatasetError, match=pattern):
             s3_dataset.load().compute()
 

--- a/kedro-datasets/tests/email/test_message_dataset.py
+++ b/kedro-datasets/tests/email/test_message_dataset.py
@@ -91,7 +91,7 @@ class TestEmailMessageDataset:
 
     def test_load_missing_file(self, message_dataset):
         """Check the error when trying to load missing file."""
-        pattern = r"Failed while loading data from dataset EmailMessageDataset\(.*\)"
+        pattern = r"Failed while loading data from dataset kedro_datasets.email.message_dataset.EmailMessageDataset\(.*\)"
         with pytest.raises(DatasetError, match=pattern):
             message_dataset.load()
 

--- a/kedro-datasets/tests/email/test_message_dataset.py
+++ b/kedro-datasets/tests/email/test_message_dataset.py
@@ -156,7 +156,7 @@ class TestEmailMessageDatasetVersioned:
 
     def test_no_versions(self, versioned_message_dataset):
         """Check the error if no versions are available for load."""
-        pattern = r"Did not find any versions for EmailMessageDataset\(.+\)"
+        pattern = r"Did not find any versions for kedro_datasets.email.message_dataset.EmailMessageDataset\(.+\)"
         with pytest.raises(DatasetError, match=pattern):
             versioned_message_dataset.load()
 
@@ -171,7 +171,7 @@ class TestEmailMessageDatasetVersioned:
         corresponding text file for a given save version already exists."""
         versioned_message_dataset.save(dummy_msg)
         pattern = (
-            r"Save path \'.+\' for EmailMessageDataset\(.+\) must "
+            r"Save path \'.+\' for kedro_datasets.email.message_dataset.EmailMessageDataset\(.+\) must "
             r"not exist if versioning is enabled\."
         )
         with pytest.raises(DatasetError, match=pattern):

--- a/kedro-datasets/tests/email/test_message_dataset.py
+++ b/kedro-datasets/tests/email/test_message_dataset.py
@@ -191,7 +191,7 @@ class TestEmailMessageDatasetVersioned:
         pattern = (
             f"Save version '{save_version}' did not match "
             f"load version '{load_version}' for "
-            r"EmailMessageDataset\(.+\)"
+            r"kedro_datasets.email.message_dataset.EmailMessageDataset\(.+\)"
         )
         with pytest.warns(UserWarning, match=pattern):
             versioned_message_dataset.save(dummy_msg)

--- a/kedro-datasets/tests/geopandas/test_generic_dataset.py
+++ b/kedro-datasets/tests/geopandas/test_generic_dataset.py
@@ -149,7 +149,7 @@ class TestGenericDataset:
     @pytest.mark.parametrize("geojson_dataset", [{"index": False}], indirect=True)
     def test_load_missing_file(self, geojson_dataset):
         """Check the error while trying to load from missing source."""
-        pattern = r"Failed while loading data from dataset GenericDataset"
+        pattern = r"Failed while loading data from dataset kedro_datasets.geopandas.generic_dataset.GenericDataset"
         with pytest.raises(DatasetError, match=pattern):
             geojson_dataset.load()
 
@@ -173,7 +173,7 @@ class TestGenericDataset:
         self, parquet_dataset_bad_config, dummy_dataframe, filepath_parquet
     ):
         dummy_dataframe.to_parquet(filepath_parquet)
-        pattern = r"Failed while loading data from dataset GenericDataset(.*)"
+        pattern = r"Failed while loading data from dataset kedro_datasets.geopandas.generic_dataset.GenericDataset(.*)"
         with pytest.raises(DatasetError, match=pattern):
             parquet_dataset_bad_config.load()
 
@@ -273,7 +273,7 @@ class TestGenericDatasetVersioned:
 
     def test_no_versions(self, versioned_geojson_dataset):
         """Check the error if no versions are available for load."""
-        pattern = r"Did not find any versions for GenericDataset\(.+\)"
+        pattern = r"Did not find any versions for kedro_datasets.geopandas.generic_dataset.GenericDataset\(.+\)"
         with pytest.raises(DatasetError, match=pattern):
             versioned_geojson_dataset.load()
 
@@ -288,7 +288,7 @@ class TestGenericDatasetVersioned:
         version."""
         versioned_geojson_dataset.save(dummy_dataframe)
         pattern = (
-            r"Save path \'.+\' for GenericDataset\(.+\) must not "
+            r"Save path \'.+\' for kedro_datasets.geopandas.generic_dataset.GenericDataset\(.+\) must not "
             r"exist if versioning is enabled"
         )
         with pytest.raises(DatasetError, match=pattern):
@@ -307,7 +307,7 @@ class TestGenericDatasetVersioned:
         the subsequent load path."""
         pattern = (
             rf"Save version '{save_version}' did not match load version "
-            rf"'{load_version}' for GenericDataset\(.+\)"
+            rf"'{load_version}' for kedro_datasets.geopandas.generic_dataset.GenericDataset\(.+\)"
         )
         with pytest.warns(UserWarning, match=pattern):
             versioned_geojson_dataset.save(dummy_dataframe)

--- a/kedro-datasets/tests/holoviews/test_holoviews_writer.py
+++ b/kedro-datasets/tests/holoviews/test_holoviews_writer.py
@@ -144,7 +144,7 @@ class TestHoloviewsWriterVersioned:
         corresponding file for a given save version already exists."""
         versioned_hv_writer.save(dummy_hv_object)
         pattern = (
-            r"Save path \'.+\' for HoloviewsWriter\(.+\) must "
+            r"Save path \'.+\' for kedro_datasets.holoviews.holoviews_writer.HoloviewsWriter\(.+\) must "
             r"not exist if versioning is enabled\."
         )
         with pytest.raises(DatasetError, match=pattern):
@@ -163,7 +163,7 @@ class TestHoloviewsWriterVersioned:
         the subsequent load path."""
         pattern = (
             rf"Save version '{save_version}' did not match load version "
-            rf"'{load_version}' for HoloviewsWriter\(.+\)"
+            rf"'{load_version}' for kedro_datasets.holoviews.holoviews_writer.HoloviewsWriter\(.+\)"
         )
         with pytest.warns(UserWarning, match=pattern):
             versioned_hv_writer.save(dummy_hv_object)

--- a/kedro-datasets/tests/ibis/test_file_dataset.py
+++ b/kedro-datasets/tests/ibis/test_file_dataset.py
@@ -230,7 +230,7 @@ class TestFileDatasetVersioned:
 
     def test_no_versions(self, versioned_file_dataset):
         """Check the error if no versions are available for load."""
-        pattern = r"Did not find any versions for FileDataset\(.+\)"
+        pattern = r"Did not find any versions for kedro_datasets.ibis.file_dataset.FileDataset\(.+\)"
         with pytest.raises(DatasetError, match=pattern):
             versioned_file_dataset.load()
 
@@ -245,7 +245,7 @@ class TestFileDatasetVersioned:
         corresponding CSV file for a given save version already exists."""
         versioned_file_dataset.save(dummy_table)
         pattern = (
-            r"Save path \'.+\' for FileDataset\(.+\) must "
+            r"Save path \'.+\' for kedro_datasets.ibis.file_dataset.FileDataset\(.+\) must "
             r"not exist if versioning is enabled\."
         )
         with pytest.raises(DatasetError, match=pattern):
@@ -264,7 +264,7 @@ class TestFileDatasetVersioned:
         the subsequent load path."""
         pattern = (
             rf"Save version '{save_version}' did not match load version "
-            rf"'{load_version}' for FileDataset\(.+\)"
+            rf"'{load_version}' for kedro_datasets.ibis.file_dataset.FileDataset\(.+\)"
         )
         with pytest.warns(UserWarning, match=pattern):
             versioned_file_dataset.save(dummy_table)

--- a/kedro-datasets/tests/json/test_json_dataset.py
+++ b/kedro-datasets/tests/json/test_json_dataset.py
@@ -132,7 +132,7 @@ class TestJSONDatasetVersioned:
 
     def test_no_versions(self, versioned_json_dataset):
         """Check the error if no versions are available for load."""
-        pattern = r"Did not find any versions for JSONDataset\(.+\)"
+        pattern = r"Did not find any versions for kedro_datasets.pandas.json_dataset.JSONDataset\(.+\)"
         with pytest.raises(DatasetError, match=pattern):
             versioned_json_dataset.load()
 
@@ -147,7 +147,7 @@ class TestJSONDatasetVersioned:
         corresponding json file for a given save version already exists."""
         versioned_json_dataset.save(dummy_data)
         pattern = (
-            r"Save path \'.+\' for JSONDataset\(.+\) must "
+            r"Save path \'.+\' for kedro_datasets.pandas.json_dataset.JSONDataset\(.+\) must "
             r"not exist if versioning is enabled\."
         )
         with pytest.raises(DatasetError, match=pattern):

--- a/kedro-datasets/tests/json/test_json_dataset.py
+++ b/kedro-datasets/tests/json/test_json_dataset.py
@@ -69,7 +69,7 @@ class TestJSONDataset:
 
     def test_load_missing_file(self, json_dataset):
         """Check the error when trying to load missing file."""
-        pattern = r"Failed while loading data from dataset JSONDataset\(.*\)"
+        pattern = r"Failed while loading data from dataset kedro_datasets.plotly.json_dataset.JSONDataset\(.*\)"
         with pytest.raises(DatasetError, match=pattern):
             json_dataset.load()
 

--- a/kedro-datasets/tests/json/test_json_dataset.py
+++ b/kedro-datasets/tests/json/test_json_dataset.py
@@ -167,7 +167,7 @@ class TestJSONDatasetVersioned:
         pattern = (
             f"Save version '{save_version}' did not match "
             f"load version '{load_version}' for "
-            r"JSONDataset\(.+\)"
+            r"kedro_datasets.json.json_dataset.JSONDataset\(.+\)"
         )
         with pytest.warns(UserWarning, match=pattern):
             versioned_json_dataset.save(dummy_data)

--- a/kedro-datasets/tests/json/test_json_dataset.py
+++ b/kedro-datasets/tests/json/test_json_dataset.py
@@ -69,7 +69,7 @@ class TestJSONDataset:
 
     def test_load_missing_file(self, json_dataset):
         """Check the error when trying to load missing file."""
-        pattern = r"Failed while loading data from dataset kedro_datasets.plotly.json_dataset.JSONDataset\(.*\)"
+        pattern = r"Failed while loading data from dataset kedro_datasets.json.json_dataset.JSONDataset\(.*\)"
         with pytest.raises(DatasetError, match=pattern):
             json_dataset.load()
 
@@ -132,7 +132,7 @@ class TestJSONDatasetVersioned:
 
     def test_no_versions(self, versioned_json_dataset):
         """Check the error if no versions are available for load."""
-        pattern = r"Did not find any versions for kedro_datasets.pandas.json_dataset.JSONDataset\(.+\)"
+        pattern = r"Did not find any versions for kedro_datasets.json.json_dataset.JSONDataset\(.+\)"
         with pytest.raises(DatasetError, match=pattern):
             versioned_json_dataset.load()
 
@@ -147,7 +147,7 @@ class TestJSONDatasetVersioned:
         corresponding json file for a given save version already exists."""
         versioned_json_dataset.save(dummy_data)
         pattern = (
-            r"Save path \'.+\' for kedro_datasets.pandas.json_dataset.JSONDataset\(.+\) must "
+            r"Save path \'.+\' for kedro_datasets.json.json_dataset.JSONDataset\(.+\) must "
             r"not exist if versioning is enabled\."
         )
         with pytest.raises(DatasetError, match=pattern):

--- a/kedro-datasets/tests/matlab/test_matlab_dataset.py
+++ b/kedro-datasets/tests/matlab/test_matlab_dataset.py
@@ -69,7 +69,7 @@ class TestMatlabDataset:
 
     def test_load_missing_file(self, matlab_dataset):
         """Check the error when trying to load missing file."""
-        pattern = r"Failed while loading data from dataset MatlabDataset\(.*\)"
+        pattern = r"Failed while loading data from dataset kedro_datasets.matlab.matlab_dataset.MatlabDataset\(.*\)"
         with pytest.raises(DatasetError, match=pattern):
             matlab_dataset.load()
 
@@ -132,7 +132,7 @@ class TestMatlabDatasetVersioned:
 
     def test_no_versions(self, versioned_matlab_dataset):
         """Check the error if no versions are available for load."""
-        pattern = r"Did not find any versions for MatlabDataset\(.+\)"
+        pattern = r"Did not find any versions for kedro_datasets.matlab.matlab_dataset.MatlabDataset\(.+\)"
         with pytest.raises(DatasetError, match=pattern):
             versioned_matlab_dataset.load()
 
@@ -147,7 +147,7 @@ class TestMatlabDatasetVersioned:
         corresponding json file for a given save version already exists."""
         versioned_matlab_dataset.save(dummy_data)
         pattern = (
-            r"Save path \'.+\' for MatlabDataset\(.+\) must "
+            r"Save path \'.+\' for kedro_datasets.matlab.matlab_dataset.MatlabDataset\(.+\) must "
             r"not exist if versioning is enabled\."
         )
         with pytest.raises(DatasetError, match=pattern):

--- a/kedro-datasets/tests/matlab/test_matlab_dataset.py
+++ b/kedro-datasets/tests/matlab/test_matlab_dataset.py
@@ -167,7 +167,7 @@ class TestMatlabDatasetVersioned:
         pattern = (
             f"Save version '{save_version}' did not match "
             f"load version '{load_version}' for "
-            r"MatlabDataset\(.+\)"
+            r"kedro_datasets.matlab.matlab_dataset.MatlabDataset\(.+\)"
         )
         with pytest.warns(UserWarning, match=pattern):
             versioned_matlab_dataset.save(dummy_data)

--- a/kedro-datasets/tests/matplotlib/test_matplotlib_dataset.py
+++ b/kedro-datasets/tests/matplotlib/test_matplotlib_dataset.py
@@ -287,7 +287,7 @@ class TestMatplotlibDatasetVersioned:
         corresponding matplotlib file for a given save version already exists."""
         versioned_plot_dataset.save(mock_single_plot)
         pattern = (
-            r"Save path \'.+\' for MatplotlibDataset\(.+\) must "
+            r"Save path \'.+\' for kedro_datasets.matplotlib.matplotlib_dataset.MatplotlibDataset\(.+\) must "
             r"not exist if versioning is enabled\."
         )
         with pytest.raises(DatasetError, match=pattern):
@@ -320,7 +320,7 @@ class TestMatplotlibDatasetVersioned:
         the subsequent load path."""
         pattern = (
             rf"Save version '{save_version}' did not match load version "
-            rf"'{load_version}' for MatplotlibDataset\(.+\)"
+            rf"'{load_version}' for kedro_datasets.matplotlib.matplotlib_dataset.MatplotlibDataset\(.+\)"
         )
         with pytest.warns(UserWarning, match=pattern):
             versioned_plot_dataset.save(mock_single_plot)

--- a/kedro-datasets/tests/networkx/test_gml_dataset.py
+++ b/kedro-datasets/tests/networkx/test_gml_dataset.py
@@ -60,7 +60,7 @@ class TestGMLDataset:
 
     def test_load_missing_file(self, gml_dataset):
         """Check the error when trying to load missing file."""
-        pattern = r"Failed while loading data from dataset GMLDataset\(.*\)"
+        pattern = r"Failed while loading data from dataset kedro_datasets.networkx.gml_dataset.GMLDataset\(.*\)"
         with pytest.raises(DatasetError, match=pattern):
             assert gml_dataset.load()
 

--- a/kedro-datasets/tests/networkx/test_gml_dataset.py
+++ b/kedro-datasets/tests/networkx/test_gml_dataset.py
@@ -109,7 +109,7 @@ class TestGMLDatasetVersioned:
 
     def test_no_versions(self, versioned_gml_dataset):
         """Check the error if no versions are available for load."""
-        pattern = r"Did not find any versions for GMLDataset\(.+\)"
+        pattern = r"Did not find any versions for kedro_datasets.networkx.gml_dataset.GMLDataset\(.+\)"
         with pytest.raises(DatasetError, match=pattern):
             versioned_gml_dataset.load()
 
@@ -124,7 +124,7 @@ class TestGMLDatasetVersioned:
         version."""
         versioned_gml_dataset.save(dummy_graph_data)
         pattern = (
-            r"Save path \'.+\' for GMLDataset\(.+\) must not "
+            r"Save path \'.+\' for kedro_datasets.networkx.gml_dataset.GMLDataset\(.+\) must not "
             r"exist if versioning is enabled"
         )
         with pytest.raises(DatasetError, match=pattern):
@@ -143,7 +143,7 @@ class TestGMLDatasetVersioned:
         the subsequent load path."""
         pattern = (
             rf"Save version '{save_version}' did not match "
-            rf"load version '{load_version}' for GMLDataset\(.+\)"
+            rf"load version '{load_version}' for kedro_datasets.networkx.gml_dataset.GMLDataset\(.+\)"
         )
         with pytest.warns(UserWarning, match=pattern):
             versioned_gml_dataset.save(dummy_graph_data)

--- a/kedro-datasets/tests/networkx/test_graphml_dataset.py
+++ b/kedro-datasets/tests/networkx/test_graphml_dataset.py
@@ -60,7 +60,7 @@ class TestGraphMLDataset:
 
     def test_load_missing_file(self, graphml_dataset):
         """Check the error when trying to load missing file."""
-        pattern = r"Failed while loading data from dataset GraphMLDataset\(.*\)"
+        pattern = r"Failed while loading data from dataset kedro_datasets.networkx.graphml_dataset.GraphMLDataset\(.*\)"
         with pytest.raises(DatasetError, match=pattern):
             assert graphml_dataset.load()
 
@@ -109,7 +109,7 @@ class TestGraphMLDatasetVersioned:
 
     def test_no_versions(self, versioned_graphml_dataset):
         """Check the error if no versions are available for load."""
-        pattern = r"Did not find any versions for GraphMLDataset\(.+\)"
+        pattern = r"Did not find any versions for kedro_datasets.networkx.graphml_dataset.GraphMLDataset\(.+\)"
         with pytest.raises(DatasetError, match=pattern):
             versioned_graphml_dataset.load()
 
@@ -124,7 +124,7 @@ class TestGraphMLDatasetVersioned:
         version."""
         versioned_graphml_dataset.save(dummy_graph_data)
         pattern = (
-            r"Save path \'.+\' for GraphMLDataset\(.+\) must not "
+            r"Save path \'.+\' for kedro_datasets.networkx.graphml_dataset.GraphMLDataset\(.+\) must not "
             r"exist if versioning is enabled"
         )
         with pytest.raises(DatasetError, match=pattern):
@@ -143,7 +143,7 @@ class TestGraphMLDatasetVersioned:
         the subsequent load path."""
         pattern = (
             rf"Save version '{save_version}' did not match "
-            rf"load version '{load_version}' for GraphMLDataset\(.+\)"
+            rf"load version '{load_version}' for kedro_datasets.networkx.graphml_dataset.GraphMLDataset\(.+\)"
         )
         with pytest.warns(UserWarning, match=pattern):
             versioned_graphml_dataset.save(dummy_graph_data)

--- a/kedro-datasets/tests/networkx/test_json_dataset.py
+++ b/kedro-datasets/tests/networkx/test_json_dataset.py
@@ -156,7 +156,7 @@ class TestJSONDatasetVersioned:
 
     def test_no_versions(self, versioned_json_dataset):
         """Check the error if no versions are available for load."""
-        pattern = r"Did not find any versions for JSONDataset\(.+\)"
+        pattern = r"Did not find any versions for kedro_datasets.pandas.json_dataset.JSONDataset\(.+\)"
         with pytest.raises(DatasetError, match=pattern):
             versioned_json_dataset.load()
 
@@ -171,7 +171,7 @@ class TestJSONDatasetVersioned:
         version."""
         versioned_json_dataset.save(dummy_graph_data)
         pattern = (
-            r"Save path \'.+\' for JSONDataset\(.+\) must not "
+            r"Save path \'.+\' for kedro_datasets.pandas.json_dataset.JSONDataset\(.+\) must not "
             r"exist if versioning is enabled"
         )
         with pytest.raises(DatasetError, match=pattern):
@@ -190,7 +190,7 @@ class TestJSONDatasetVersioned:
         the subsequent load path."""
         pattern = (
             rf"Save version '{save_version}' did not match load version "
-            rf"'{load_version}' for JSONDataset\(.+\)"
+            rf"'{load_version}' for kedro_datasets.pandas.json_dataset.JSONDataset\(.+\)"
         )
         with pytest.warns(UserWarning, match=pattern):
             versioned_json_dataset.save(dummy_graph_data)

--- a/kedro-datasets/tests/networkx/test_json_dataset.py
+++ b/kedro-datasets/tests/networkx/test_json_dataset.py
@@ -156,7 +156,7 @@ class TestJSONDatasetVersioned:
 
     def test_no_versions(self, versioned_json_dataset):
         """Check the error if no versions are available for load."""
-        pattern = r"Did not find any versions for kedro_datasets.pandas.json_dataset.JSONDataset\(.+\)"
+        pattern = r"Did not find any versions for kedro_datasets.networkx.json_dataset.JSONDataset\(.+\)"
         with pytest.raises(DatasetError, match=pattern):
             versioned_json_dataset.load()
 
@@ -171,7 +171,7 @@ class TestJSONDatasetVersioned:
         version."""
         versioned_json_dataset.save(dummy_graph_data)
         pattern = (
-            r"Save path \'.+\' for kedro_datasets.pandas.json_dataset.JSONDataset\(.+\) must not "
+            r"Save path \'.+\' for kedro_datasets.networkx.json_dataset.JSONDataset\(.+\) must not "
             r"exist if versioning is enabled"
         )
         with pytest.raises(DatasetError, match=pattern):
@@ -190,7 +190,7 @@ class TestJSONDatasetVersioned:
         the subsequent load path."""
         pattern = (
             rf"Save version '{save_version}' did not match load version "
-            rf"'{load_version}' for kedro_datasets.pandas.json_dataset.JSONDataset\(.+\)"
+            rf"'{load_version}' for kedro_datasets.networkx.json_dataset.JSONDataset\(.+\)"
         )
         with pytest.warns(UserWarning, match=pattern):
             versioned_json_dataset.save(dummy_graph_data)

--- a/kedro-datasets/tests/networkx/test_json_dataset.py
+++ b/kedro-datasets/tests/networkx/test_json_dataset.py
@@ -58,7 +58,7 @@ class TestJSONDataset:
 
     def test_load_missing_file(self, json_dataset):
         """Check the error when trying to load missing file."""
-        pattern = r"Failed while loading data from dataset JSONDataset\(.*\)"
+        pattern = r"Failed while loading data from dataset kedro_datasets.plotly.json_dataset.JSONDataset\(.*\)"
         with pytest.raises(DatasetError, match=pattern):
             assert json_dataset.load()
 

--- a/kedro-datasets/tests/networkx/test_json_dataset.py
+++ b/kedro-datasets/tests/networkx/test_json_dataset.py
@@ -58,7 +58,7 @@ class TestJSONDataset:
 
     def test_load_missing_file(self, json_dataset):
         """Check the error when trying to load missing file."""
-        pattern = r"Failed while loading data from dataset kedro_datasets.plotly.json_dataset.JSONDataset\(.*\)"
+        pattern = r"Failed while loading data from dataset kedro_datasets.networkx.json_dataset.JSONDataset\(.*\)"
         with pytest.raises(DatasetError, match=pattern):
             assert json_dataset.load()
 

--- a/kedro-datasets/tests/pandas/test_csv_dataset.py
+++ b/kedro-datasets/tests/pandas/test_csv_dataset.py
@@ -332,7 +332,7 @@ class TestCSVDatasetVersioned:
 
     def test_no_versions(self, versioned_csv_dataset):
         """Check the error if no versions are available for load."""
-        pattern = r"Did not find any versions for CSVDataset\(.+\)"
+        pattern = r"Did not find any versions for kedro_datasets.polars.csv_dataset.CSVDataset\(.+\)"
         with pytest.raises(DatasetError, match=pattern):
             versioned_csv_dataset.load()
 
@@ -347,7 +347,7 @@ class TestCSVDatasetVersioned:
         corresponding CSV file for a given save version already exists."""
         versioned_csv_dataset.save(dummy_dataframe)
         pattern = (
-            r"Save path \'.+\' for CSVDataset\(.+\) must "
+            r"Save path \'.+\' for kedro_datasets.polars.csv_dataset.CSVDataset\(.+\) must "
             r"not exist if versioning is enabled\."
         )
         with pytest.raises(DatasetError, match=pattern):
@@ -366,7 +366,7 @@ class TestCSVDatasetVersioned:
         the subsequent load path."""
         pattern = (
             rf"Save version '{save_version}' did not match load version "
-            rf"'{load_version}' for CSVDataset\(.+\)"
+            rf"'{load_version}' for kedro_datasets.polars.csv_dataset.CSVDataset\(.+\)"
         )
         with pytest.warns(UserWarning, match=pattern):
             versioned_csv_dataset.save(dummy_dataframe)

--- a/kedro-datasets/tests/pandas/test_csv_dataset.py
+++ b/kedro-datasets/tests/pandas/test_csv_dataset.py
@@ -195,7 +195,7 @@ class TestCSVDataset:
 
     def test_load_missing_file(self, csv_dataset):
         """Check the error when trying to load missing file."""
-        pattern = r"Failed while loading data from dataset CSVDataset\(.*\)"
+        pattern = r"Failed while loading data from dataset kedro_datasets.polars.csv_dataset.CSVDataset\(.*\)"
         with pytest.raises(DatasetError, match=pattern):
             csv_dataset.load()
 

--- a/kedro-datasets/tests/pandas/test_csv_dataset.py
+++ b/kedro-datasets/tests/pandas/test_csv_dataset.py
@@ -195,7 +195,7 @@ class TestCSVDataset:
 
     def test_load_missing_file(self, csv_dataset):
         """Check the error when trying to load missing file."""
-        pattern = r"Failed while loading data from dataset kedro_datasets.polars.csv_dataset.CSVDataset\(.*\)"
+        pattern = r"Failed while loading data from dataset kedro_datasets.pandas.csv_dataset.CSVDataset\(.*\)"
         with pytest.raises(DatasetError, match=pattern):
             csv_dataset.load()
 
@@ -332,7 +332,7 @@ class TestCSVDatasetVersioned:
 
     def test_no_versions(self, versioned_csv_dataset):
         """Check the error if no versions are available for load."""
-        pattern = r"Did not find any versions for kedro_datasets.polars.csv_dataset.CSVDataset\(.+\)"
+        pattern = r"Did not find any versions for kedro_datasets.pandas.csv_dataset.CSVDataset\(.+\)"
         with pytest.raises(DatasetError, match=pattern):
             versioned_csv_dataset.load()
 
@@ -347,7 +347,7 @@ class TestCSVDatasetVersioned:
         corresponding CSV file for a given save version already exists."""
         versioned_csv_dataset.save(dummy_dataframe)
         pattern = (
-            r"Save path \'.+\' for kedro_datasets.polars.csv_dataset.CSVDataset\(.+\) must "
+            r"Save path \'.+\' for kedro_datasets.pandas.csv_dataset.CSVDataset\(.+\) must "
             r"not exist if versioning is enabled\."
         )
         with pytest.raises(DatasetError, match=pattern):
@@ -366,7 +366,7 @@ class TestCSVDatasetVersioned:
         the subsequent load path."""
         pattern = (
             rf"Save version '{save_version}' did not match load version "
-            rf"'{load_version}' for kedro_datasets.polars.csv_dataset.CSVDataset\(.+\)"
+            rf"'{load_version}' for kedro_datasets.pandas.csv_dataset.CSVDataset\(.+\)"
         )
         with pytest.warns(UserWarning, match=pattern):
             versioned_csv_dataset.save(dummy_dataframe)

--- a/kedro-datasets/tests/pandas/test_excel_dataset.py
+++ b/kedro-datasets/tests/pandas/test_excel_dataset.py
@@ -169,7 +169,7 @@ class TestExcelDataset:
 
     def test_load_missing_file(self, excel_dataset):
         """Check the error when trying to load missing file."""
-        pattern = r"Failed while loading data from dataset ExcelDataset\(.*\)"
+        pattern = r"Failed while loading data from dataset kedro_datasets.pandas.excel_dataset.ExcelDataset\(.*\)"
         with pytest.raises(DatasetError, match=pattern):
             excel_dataset.load()
 

--- a/kedro-datasets/tests/pandas/test_excel_dataset.py
+++ b/kedro-datasets/tests/pandas/test_excel_dataset.py
@@ -233,8 +233,8 @@ class TestExcelDatasetVersioned:
         # Default save_args and load_args
         assert "save_args={'index': False}" in str(ds)
         assert "save_args={'index': False}" in str(ds_versioned)
-        assert "load_args={'engine': openpyxl}" in str(ds_versioned)
-        assert "load_args={'engine': openpyxl}" in str(ds)
+        assert "load_args={'engine': 'openpyxl'}" in str(ds_versioned)
+        assert "load_args={'engine': 'openpyxl'}" in str(ds)
 
     def test_save_and_load(self, versioned_excel_dataset, dummy_dataframe):
         """Test that saved and reloaded data matches the original one for

--- a/kedro-datasets/tests/pandas/test_excel_dataset.py
+++ b/kedro-datasets/tests/pandas/test_excel_dataset.py
@@ -245,7 +245,7 @@ class TestExcelDatasetVersioned:
 
     def test_no_versions(self, versioned_excel_dataset):
         """Check the error if no versions are available for load."""
-        pattern = r"Did not find any versions for ExcelDataset\(.+\)"
+        pattern = r"Did not find any versions for kedro_datasets.pandas.excel_dataset.ExcelDataset\(.+\)"
         with pytest.raises(DatasetError, match=pattern):
             versioned_excel_dataset.load()
 
@@ -274,7 +274,7 @@ class TestExcelDatasetVersioned:
         corresponding Excel file for a given save version already exists."""
         versioned_excel_dataset.save(dummy_dataframe)
         pattern = (
-            r"Save path \'.+\' for ExcelDataset\(.+\) must "
+            r"Save path \'.+\' for kedro_datasets.pandas.excel_dataset.ExcelDataset\(.+\) must "
             r"not exist if versioning is enabled\."
         )
         with pytest.raises(DatasetError, match=pattern):
@@ -293,7 +293,7 @@ class TestExcelDatasetVersioned:
         the subsequent load path."""
         pattern = (
             rf"Save version '{save_version}' did not match load version "
-            rf"'{load_version}' for ExcelDataset\(.+\)"
+            rf"'{load_version}' for kedro_datasets.pandas.excel_dataset.ExcelDataset\(.+\)"
         )
         with pytest.warns(UserWarning, match=pattern):
             versioned_excel_dataset.save(dummy_dataframe)

--- a/kedro-datasets/tests/pandas/test_feather_dataset.py
+++ b/kedro-datasets/tests/pandas/test_feather_dataset.py
@@ -161,7 +161,7 @@ class TestFeatherDatasetVersioned:
 
     def test_no_versions(self, versioned_feather_dataset):
         """Check the error if no versions are available for load."""
-        pattern = r"Did not find any versions for FeatherDataset\(.+\)"
+        pattern = r"Did not find any versions for kedro_datasets.pandas.feather_dataset.FeatherDataset\(.+\)"
         with pytest.raises(DatasetError, match=pattern):
             versioned_feather_dataset.load()
 
@@ -176,7 +176,7 @@ class TestFeatherDatasetVersioned:
         corresponding feather file for a given save version already exists."""
         versioned_feather_dataset.save(dummy_dataframe)
         pattern = (
-            r"Save path \'.+\' for FeatherDataset\(.+\) must "
+            r"Save path \'.+\' for kedro_datasets.pandas.feather_dataset.FeatherDataset\(.+\) must "
             r"not exist if versioning is enabled\."
         )
         with pytest.raises(DatasetError, match=pattern):
@@ -195,7 +195,7 @@ class TestFeatherDatasetVersioned:
         the subsequent load path."""
         pattern = (
             rf"Save version '{save_version}' did not match load version "
-            rf"'{load_version}' for FeatherDataset\(.+\)"
+            rf"'{load_version}' for kedro_datasets.pandas.feather_dataset.FeatherDataset\(.+\)"
         )
         with pytest.warns(UserWarning, match=pattern):
             versioned_feather_dataset.save(dummy_dataframe)

--- a/kedro-datasets/tests/pandas/test_feather_dataset.py
+++ b/kedro-datasets/tests/pandas/test_feather_dataset.py
@@ -92,7 +92,7 @@ class TestFeatherDataset:
 
     def test_load_missing_file(self, feather_dataset):
         """Check the error when trying to load missing file."""
-        pattern = r"Failed while loading data from dataset FeatherDataset\(.*\)"
+        pattern = r"Failed while loading data from dataset kedro_datasets.pandas.feather_dataset.FeatherDataset\(.*\)"
         with pytest.raises(DatasetError, match=pattern):
             feather_dataset.load()
 

--- a/kedro-datasets/tests/pandas/test_gbq_dataset.py
+++ b/kedro-datasets/tests/pandas/test_gbq_dataset.py
@@ -95,7 +95,7 @@ class TestGBQDataset:
 
     def test_load_missing_file(self, gbq_dataset, mocker):
         """Check the error when trying to load missing table."""
-        pattern = r"Failed while loading data from dataset GBQTableDataset\(.*\)"
+        pattern = r"Failed while loading data from dataset kedro_datasets.pandas.gbq_dataset.GBQTableDataset\(.*\)"
         mocked_read_gbq = mocker.patch(
             "kedro_datasets.pandas.gbq_dataset.pd_gbq.read_gbq"
         )

--- a/kedro-datasets/tests/pandas/test_gbq_dataset.py
+++ b/kedro-datasets/tests/pandas/test_gbq_dataset.py
@@ -339,7 +339,7 @@ class TestGBQQueryDataset:
         """Test the dataset instance string representation"""
         str_repr = str(gbq_sql_dataset)
         assert (
-            f"kedro_datasets.pandas.gbq_dataset.GBQQueryDataset(sql=`{SQL_QUERY}`, filepath=`None`, load_args=`{{}}`)"
+            f"kedro_datasets.pandas.gbq_dataset.GBQQueryDataset(sql='{SQL_QUERY}', filepath='None', load_args='{{}}')"
             in str_repr
         )
         assert sql_file not in str_repr
@@ -348,7 +348,7 @@ class TestGBQQueryDataset:
         """Test the dataset instance string representation with filepath arg."""
         str_repr = str(gbq_sql_file_dataset)
         assert (
-            f"kedro_datasets.pandas.gbq_dataset.GBQQueryDataset(sql=`None`, filepath=`{str(sql_file)}`, load_args=`{{}}`)"
+            f"kedro_datasets.pandas.gbq_dataset.GBQQueryDataset(sql='None', filepath='{str(sql_file)}', load_args='{{}}')"
             in str_repr
         )
         assert SQL_QUERY not in str_repr

--- a/kedro-datasets/tests/pandas/test_gbq_dataset.py
+++ b/kedro-datasets/tests/pandas/test_gbq_dataset.py
@@ -339,7 +339,7 @@ class TestGBQQueryDataset:
         """Test the dataset instance string representation"""
         str_repr = str(gbq_sql_dataset)
         assert (
-            f"GBQQueryDataset(filepath=None, load_args={{}}, sql={SQL_QUERY})"
+            f"kedro_datasets.pandas.gbq_dataset.GBQQueryDataset(sql=`{SQL_QUERY}`, filepath=`None`, load_args=`{{}}`)"
             in str_repr
         )
         assert sql_file not in str_repr
@@ -348,7 +348,7 @@ class TestGBQQueryDataset:
         """Test the dataset instance string representation with filepath arg."""
         str_repr = str(gbq_sql_file_dataset)
         assert (
-            f"GBQQueryDataset(filepath={str(sql_file)}, load_args={{}}, sql=None)"
+            f"kedro_datasets.pandas.gbq_dataset.GBQQueryDataset(sql=`None`, filepath=`{str(sql_file)}`, load_args=`{{}}`)"
             in str_repr
         )
         assert SQL_QUERY not in str_repr

--- a/kedro-datasets/tests/pandas/test_generic_dataset.py
+++ b/kedro-datasets/tests/pandas/test_generic_dataset.py
@@ -266,7 +266,7 @@ class TestGenericCSVDatasetVersioned:
 
     def test_no_versions(self, versioned_csv_dataset):
         """Check the error if no versions are available for load."""
-        pattern = r"Did not find any versions for GenericDataset\(.+\)"
+        pattern = r"Did not find any versions for kedro_datasets.pandas.generic_dataset.GenericDataset\(.+\)"
         with pytest.raises(DatasetError, match=pattern):
             versioned_csv_dataset.load()
 
@@ -281,7 +281,7 @@ class TestGenericCSVDatasetVersioned:
         corresponding Generic (csv) file for a given save version already exists."""
         versioned_csv_dataset.save(dummy_dataframe)
         pattern = (
-            r"Save path \'.+\' for GenericDataset\(.+\) must "
+            r"Save path \'.+\' for kedro_datasets.pandas.generic_dataset.GenericDataset\(.+\) must "
             r"not exist if versioning is enabled\."
         )
         with pytest.raises(DatasetError, match=pattern):
@@ -300,7 +300,7 @@ class TestGenericCSVDatasetVersioned:
         the subsequent load path."""
         pattern = (
             rf"Save version '{save_version}' did not match load version "
-            rf"'{load_version}' for GenericDataset\(.+\)"
+            rf"'{load_version}' for kedro_datasets.pandas.generic_dataset.GenericDataset\(.+\)"
         )
         with pytest.warns(UserWarning, match=pattern):
             versioned_csv_dataset.save(dummy_dataframe)

--- a/kedro-datasets/tests/pandas/test_hdf_dataset.py
+++ b/kedro-datasets/tests/pandas/test_hdf_dataset.py
@@ -173,7 +173,7 @@ class TestHDFDatasetVersioned:
 
     def test_no_versions(self, versioned_hdf_dataset):
         """Check the error if no versions are available for load."""
-        pattern = r"Did not find any versions for HDFDataset\(.+\)"
+        pattern = r"Did not find any versions for kedro_datasets.pandas.hdf_dataset.HDFDataset\(.+\)"
         with pytest.raises(DatasetError, match=pattern):
             versioned_hdf_dataset.load()
 
@@ -188,7 +188,7 @@ class TestHDFDatasetVersioned:
         corresponding hdf file for a given save version already exists."""
         versioned_hdf_dataset.save(dummy_dataframe)
         pattern = (
-            r"Save path \'.+\' for HDFDataset\(.+\) must "
+            r"Save path \'.+\' for kedro_datasets.pandas.hdf_dataset.HDFDataset\(.+\) must "
             r"not exist if versioning is enabled\."
         )
         with pytest.raises(DatasetError, match=pattern):
@@ -207,7 +207,7 @@ class TestHDFDatasetVersioned:
         the subsequent load path."""
         pattern = (
             rf"Save version '{save_version}' did not match load version "
-            rf"'{load_version}' for HDFDataset\(.+\)"
+            rf"'{load_version}' for kedro_datasets.pandas.hdf_dataset.HDFDataset\(.+\)"
         )
         with pytest.warns(UserWarning, match=pattern):
             versioned_hdf_dataset.save(dummy_dataframe)

--- a/kedro-datasets/tests/pandas/test_hdf_dataset.py
+++ b/kedro-datasets/tests/pandas/test_hdf_dataset.py
@@ -86,7 +86,7 @@ class TestHDFDataset:
 
     def test_load_missing_file(self, hdf_dataset):
         """Check the error when trying to load missing file."""
-        pattern = r"Failed while loading data from dataset HDFDataset\(.*\)"
+        pattern = r"Failed while loading data from dataset kedro_datasets.pandas.hdf_dataset.HDFDataset\(.*\)"
         with pytest.raises(DatasetError, match=pattern):
             hdf_dataset.load()
 

--- a/kedro-datasets/tests/pandas/test_json_dataset.py
+++ b/kedro-datasets/tests/pandas/test_json_dataset.py
@@ -117,7 +117,7 @@ class TestJSONDataset:
 
     def test_load_missing_file(self, json_dataset):
         """Check the error when trying to load missing file."""
-        pattern = r"Failed while loading data from dataset kedro_datasets.plotly.json_dataset.JSONDataset\(.*\)"
+        pattern = r"Failed while loading data from dataset kedro_datasets.pandas.json_dataset.JSONDataset\(.*\)"
         with pytest.raises(DatasetError, match=pattern):
             json_dataset.load()
 
@@ -215,7 +215,7 @@ class TestJSONDatasetVersioned:
 
     def test_no_versions(self, versioned_json_dataset):
         """Check the error if no versions are available for load."""
-        pattern = r"Did not find any versions for JSONDataset\(.+\)"
+        pattern = r"Did not find any versions for kedro_datasets.pandas.json_dataset.JSONDataset\(.+\)"
         with pytest.raises(DatasetError, match=pattern):
             versioned_json_dataset.load()
 
@@ -230,7 +230,7 @@ class TestJSONDatasetVersioned:
         corresponding hdf file for a given save version already exists."""
         versioned_json_dataset.save(dummy_dataframe)
         pattern = (
-            r"Save path \'.+\' for JSONDataset\(.+\) must "
+            r"Save path \'.+\' for kedro_datasets.pandas.json_dataset.JSONDataset\(.+\) must "
             r"not exist if versioning is enabled\."
         )
         with pytest.raises(DatasetError, match=pattern):
@@ -249,7 +249,7 @@ class TestJSONDatasetVersioned:
         the subsequent load path."""
         pattern = (
             rf"Save version '{save_version}' did not match load version "
-            rf"'{load_version}' for JSONDataset\(.+\)"
+            rf"'{load_version}' for kedro_datasets.pandas.json_dataset.JSONDataset\(.+\)"
         )
         with pytest.warns(UserWarning, match=pattern):
             versioned_json_dataset.save(dummy_dataframe)

--- a/kedro-datasets/tests/pandas/test_json_dataset.py
+++ b/kedro-datasets/tests/pandas/test_json_dataset.py
@@ -117,7 +117,7 @@ class TestJSONDataset:
 
     def test_load_missing_file(self, json_dataset):
         """Check the error when trying to load missing file."""
-        pattern = r"Failed while loading data from dataset JSONDataset\(.*\)"
+        pattern = r"Failed while loading data from dataset kedro_datasets.plotly.json_dataset.JSONDataset\(.*\)"
         with pytest.raises(DatasetError, match=pattern):
             json_dataset.load()
 

--- a/kedro-datasets/tests/pandas/test_parquet_dataset.py
+++ b/kedro-datasets/tests/pandas/test_parquet_dataset.py
@@ -131,7 +131,7 @@ class TestParquetDataset:
 
     def test_load_missing_file(self, parquet_dataset):
         """Check the error when trying to load missing file."""
-        pattern = r"Failed while loading data from dataset ParquetDataset\(.*\)"
+        pattern = r"Failed while loading data from dataset kedro_datasets.pandas.parquet_dataset.ParquetDataset\(.*\)"
         with pytest.raises(DatasetError, match=pattern):
             parquet_dataset.load()
 

--- a/kedro-datasets/tests/pandas/test_parquet_dataset.py
+++ b/kedro-datasets/tests/pandas/test_parquet_dataset.py
@@ -238,7 +238,7 @@ class TestParquetDataset:
     def test_preview(
         self, parquet_dataset, dummy_dataframe_preview, nrows, expected_rows
     ):
-        """Test the preview functionality for ParquetDataset."""
+        """Test the preview functionality for kedro_datasets.pandas.parquet_dataset.ParquetDataset."""
         parquet_dataset.save(dummy_dataframe_preview)
         previewed_data = parquet_dataset.preview(nrows=nrows)
 
@@ -284,7 +284,7 @@ class TestParquetDatasetVersioned:
 
     def test_no_versions(self, versioned_parquet_dataset):
         """Check the error if no versions are available for load."""
-        pattern = r"Did not find any versions for ParquetDataset\(.+\)"
+        pattern = r"Did not find any versions for kedro_datasets.pandas.parquet_dataset.ParquetDataset\(.+\)"
         with pytest.raises(DatasetError, match=pattern):
             versioned_parquet_dataset.load()
 
@@ -309,7 +309,7 @@ class TestParquetDatasetVersioned:
         )
         versioned_parquet_dataset.save(dummy_dataframe)
         pattern = (
-            r"Save path \'.+\' for ParquetDataset\(.+\) must "
+            r"Save path \'.+\' for kedro_datasets.pandas.parquet_dataset.ParquetDataset\(.+\) must "
             r"not exist if versioning is enabled\."
         )
         with pytest.raises(DatasetError, match=pattern):
@@ -333,7 +333,7 @@ class TestParquetDatasetVersioned:
         the subsequent load path."""
         pattern = (
             rf"Save version '{save_version}' did not match load version "
-            rf"'{load_version}' for ParquetDataset\(.+\)"
+            rf"'{load_version}' for kedro_datasets.pandas.parquet_dataset.ParquetDataset\(.+\)"
         )
         mocker.patch(
             "pyarrow.fs._ensure_filesystem",

--- a/kedro-datasets/tests/pandas/test_sql_dataset.py
+++ b/kedro-datasets/tests/pandas/test_sql_dataset.py
@@ -141,7 +141,7 @@ class TestSQLTableDataset:
         """Test the dataset instance string representation"""
         str_repr = str(table_dataset)
         assert (
-            f"kedro_datasets.pandas.sql_dataset.SQLTableDataset(table_name='{TABLE_NAME}'), load_args='{{}}', save_args={'index': False}"
+            f"kedro_datasets.pandas.sql_dataset.SQLTableDataset(table_name='{TABLE_NAME}'), load_args='{{}}', save_args={{'index': False}}"
             in str_repr
         )
         assert CONNECTION not in str(str_repr)
@@ -433,8 +433,8 @@ class TestSQLQueryDataset:
         """Test the dataset instance string representation"""
         str_repr = str(query_dataset)
         assert (
-            f"kedro_datasets.pandas.sql_dataset.SQLQueryDataset(sql=`{SQL_QUERY}`), filepath=`None`, "
-            f"load_args=`{{}}`, execution_options=`{{}}`" in str_repr
+            f"kedro_datasets.pandas.sql_dataset.SQLQueryDataset(sql='{SQL_QUERY}'), filepath='None', "
+            f"load_args='{{}}', execution_options='{{}}'" in str_repr
         )
         assert CONNECTION not in str_repr
         assert sql_file not in str_repr

--- a/kedro-datasets/tests/pandas/test_sql_dataset.py
+++ b/kedro-datasets/tests/pandas/test_sql_dataset.py
@@ -141,8 +141,8 @@ class TestSQLTableDataset:
         """Test the dataset instance string representation"""
         str_repr = str(table_dataset)
         assert (
-            "SQLTableDataset(load_args={}, save_args={'index': False}, "
-            f"table_name={TABLE_NAME})" in str_repr
+            f"kedro_datasets.pandas.sql_dataset.SQLTableDataset(table_name=`{TABLE_NAME}`), load_args=`{{}}`, save_args={'index': False}"
+            in str_repr
         )
         assert CONNECTION not in str(str_repr)
 
@@ -433,8 +433,8 @@ class TestSQLQueryDataset:
         """Test the dataset instance string representation"""
         str_repr = str(query_dataset)
         assert (
-            "SQLQueryDataset(execution_options={}, filepath=None, "
-            f"load_args={{}}, sql={SQL_QUERY})" in str_repr
+            f"kedro_datasets.pandas.sql_dataset.SQLQueryDataset(sql=`{SQL_QUERY}`), filepath=`None`, "
+            f"load_args=`{{}}`, execution_options=`{{}}`" in str_repr
         )
         assert CONNECTION not in str_repr
         assert sql_file not in str_repr
@@ -443,8 +443,8 @@ class TestSQLQueryDataset:
         """Test the dataset instance string representation with filepath arg."""
         str_repr = str(query_file_dataset)
         assert (
-            f"SQLQueryDataset(execution_options={{}}, filepath={str(sql_file)}, "
-            "load_args={}, sql=None)" in str_repr
+            f"kedro_datasets.pandas.sql_dataset.SQLQueryDataset(sql=`None`, filepath=`{str(sql_file)}`, "
+            f"load_args=`{{}}`, execution_options=`{{}}`)" in str_repr
         )
         assert CONNECTION not in str_repr
         assert SQL_QUERY not in str_repr

--- a/kedro-datasets/tests/pandas/test_sql_dataset.py
+++ b/kedro-datasets/tests/pandas/test_sql_dataset.py
@@ -141,7 +141,7 @@ class TestSQLTableDataset:
         """Test the dataset instance string representation"""
         str_repr = str(table_dataset)
         assert (
-            f"kedro_datasets.pandas.sql_dataset.SQLTableDataset(table_name=`{TABLE_NAME}`), load_args=`{{}}`, save_args={'index': False}"
+            f"kedro_datasets.pandas.sql_dataset.SQLTableDataset(table_name='{TABLE_NAME}'), load_args='{{}}', save_args={'index': False}"
             in str_repr
         )
         assert CONNECTION not in str(str_repr)
@@ -443,14 +443,14 @@ class TestSQLQueryDataset:
         """Test the dataset instance string representation with filepath arg."""
         str_repr = str(query_file_dataset)
         assert (
-            f"kedro_datasets.pandas.sql_dataset.SQLQueryDataset(sql=`None`, filepath=`{str(sql_file)}`, "
-            f"load_args=`{{}}`, execution_options=`{{}}`)" in str_repr
+            f"kedro_datasets.pandas.sql_dataset.SQLQueryDataset(sql='None', filepath='{str(sql_file)}', "
+            f"load_args='{{}}', execution_options='{{}}')" in str_repr
         )
         assert CONNECTION not in str_repr
         assert SQL_QUERY not in str_repr
 
     def test_sql_and_filepath_args(self, sql_file):
-        """Test that an error is raised when both `sql` and `filepath` args are given."""
+        """Test that an error is raised when both 'sql' and 'filepath' args are given."""
         pattern = (
             r"'sql' and 'filepath' arguments cannot both be provided."
             r"Please only provide one."

--- a/kedro-datasets/tests/pandas/test_sql_dataset.py
+++ b/kedro-datasets/tests/pandas/test_sql_dataset.py
@@ -141,7 +141,7 @@ class TestSQLTableDataset:
         """Test the dataset instance string representation"""
         str_repr = str(table_dataset)
         assert (
-            f"kedro_datasets.pandas.sql_dataset.SQLTableDataset(table_name='{TABLE_NAME}'), load_args='{{}}', save_args={{'index': False}}"
+            f"kedro_datasets.pandas.sql_dataset.SQLTableDataset(table_name='{TABLE_NAME}', load_args={{}}, save_args={{'index': False}})"
             in str_repr
         )
         assert CONNECTION not in str(str_repr)
@@ -433,8 +433,8 @@ class TestSQLQueryDataset:
         """Test the dataset instance string representation"""
         str_repr = str(query_dataset)
         assert (
-            f"kedro_datasets.pandas.sql_dataset.SQLQueryDataset(sql='{SQL_QUERY}'), filepath='None', "
-            f"load_args='{{}}', execution_options='{{}}'" in str_repr
+            f"kedro_datasets.pandas.sql_dataset.SQLQueryDataset(sql='{SQL_QUERY}', filepath='None', "
+            f"load_args='{{}}', execution_options='{{}}')" in str_repr
         )
         assert CONNECTION not in str_repr
         assert sql_file not in str_repr

--- a/kedro-datasets/tests/pandas/test_xml_dataset.py
+++ b/kedro-datasets/tests/pandas/test_xml_dataset.py
@@ -94,7 +94,7 @@ class TestXMLDataset:
 
     def test_load_missing_file(self, xml_dataset):
         """Check the error when trying to load missing file."""
-        pattern = r"Failed while loading data from dataset XMLDataset\(.*\)"
+        pattern = r"Failed while loading data from dataset kedro_datasets.pandas.xml_dataset.XMLDataset\(.*\)"
         with pytest.raises(DatasetError, match=pattern):
             xml_dataset.load()
 
@@ -172,7 +172,7 @@ class TestXMLDatasetVersioned:
 
     def test_no_versions(self, versioned_xml_dataset):
         """Check the error if no versions are available for load."""
-        pattern = r"Did not find any versions for XMLDataset\(.+\)"
+        pattern = r"Did not find any versions for kedro_datasets.pandas.xml_dataset.XMLDataset\(.+\)"
         with pytest.raises(DatasetError, match=pattern):
             versioned_xml_dataset.load()
 
@@ -187,7 +187,7 @@ class TestXMLDatasetVersioned:
         corresponding hdf file for a given save version already exists."""
         versioned_xml_dataset.save(dummy_dataframe)
         pattern = (
-            r"Save path \'.+\' for XMLDataset\(.+\) must "
+            r"Save path \'.+\' for kedro_datasets.pandas.xml_dataset.XMLDataset\(.+\) must "
             r"not exist if versioning is enabled\."
         )
         with pytest.raises(DatasetError, match=pattern):
@@ -206,7 +206,7 @@ class TestXMLDatasetVersioned:
         the subsequent load path."""
         pattern = (
             rf"Save version '{save_version}' did not match "
-            rf"load version '{load_version}' for XMLDataset\(.+\)"
+            rf"load version '{load_version}' for kedro_datasets.pandas.xml_dataset.XMLDataset\(.+\)"
         )
         with pytest.warns(UserWarning, match=pattern):
             versioned_xml_dataset.save(dummy_dataframe)

--- a/kedro-datasets/tests/partitions/test_partitioned_dataset.py
+++ b/kedro-datasets/tests/partitions/test_partitioned_dataset.py
@@ -326,7 +326,7 @@ class TestPartitionedDatasetLocal:
         loaded_partitions = pds.load()
 
         for partition, df_loader in loaded_partitions.items():
-            pattern = r"Failed while loading data from dataset ParquetDataset(.*)"
+            pattern = r"Failed while loading data from dataset kedro_datasets.pandas.parquet_dataset.ParquetDataset(.*)"
             with pytest.raises(DatasetError, match=pattern) as exc_info:
                 df_loader()
             error_message = str(exc_info.value)

--- a/kedro-datasets/tests/partitions/test_partitioned_dataset.py
+++ b/kedro-datasets/tests/partitions/test_partitioned_dataset.py
@@ -249,11 +249,11 @@ class TestPartitionedDatasetLocal:
     @pytest.mark.parametrize("dataset", LOCAL_DATASET_DEFINITION)
     def test_describe(self, dataset):
         path = str(Path.cwd())
-        pds = PartitionedDataset(path=path, dataset=dataset)
+        pds_descr = PartitionedDataset(path=path, dataset=dataset)._describe()
 
-        assert f"path={path}" in str(pds)
-        assert "dataset_type=CSVDataset" in str(pds)
-        assert "dataset_config" in str(pds)
+        assert "path" in pds_descr and pds_descr["path"] == path
+        assert "dataset_type" in pds_descr and pds_descr["dataset_type"] == "CSVDataset"
+        assert "dataset_config" in pds_descr
 
     def test_load_args(self, mocker):
         fake_partition_name = "fake_partition"
@@ -699,9 +699,5 @@ class TestPartitionedDatasetS3:
         pds_descr = PartitionedDataset(path=path, dataset=dataset)._describe()
 
         assert "path" in pds_descr and pds_descr["path"] == path
-        assert (
-            "dataset_type" in pds_descr
-            and pds_descr["dataset_type"]
-            == "kedro_datasets.pandas.csv_dataset.CSVDataset()"
-        )
+        assert "dataset_type" in pds_descr and pds_descr["dataset_type"] == "CSVDataset"
         assert "dataset_config" in pds_descr

--- a/kedro-datasets/tests/partitions/test_partitioned_dataset.py
+++ b/kedro-datasets/tests/partitions/test_partitioned_dataset.py
@@ -596,7 +596,11 @@ class TestPartitionedDatasetS3:
         path = mocked_csvs_in_s3.split("://", 1)[1]
         s3a_path = f"s3a://{path}"
 
+        # Create a MagicMock to act as the dataset type
         mocked_dataset_type = mocker.MagicMock()
+        mocked_dataset_type.__name__ = "MockedDataset"
+
+        # Patch parse_dataset_definition to return the mocked dataset type and empty config
         mocker.patch(
             "kedro_datasets.partitions.partitioned_dataset.parse_dataset_definition",
             return_value=(mocked_dataset_type, {}),
@@ -635,8 +639,9 @@ class TestPartitionedDatasetS3:
         path = mocked_csvs_in_s3.split("://", 1)[1]
         s3a_path = f"s3a://{path}"
 
-        # Patch parse_dataset_definition to control _dataset_type
+        # Create a MagicMock to act as the dataset type
         mocked_dataset_type = mocker.MagicMock()
+        mocked_dataset_type.__name__ = "MockedDataset"
         mocker.patch(
             "kedro_datasets.partitions.partitioned_dataset.parse_dataset_definition",
             return_value=(mocked_dataset_type, {}),

--- a/kedro-datasets/tests/partitions/test_partitioned_dataset.py
+++ b/kedro-datasets/tests/partitions/test_partitioned_dataset.py
@@ -651,24 +651,18 @@ class TestPartitionedDatasetS3:
     @pytest.mark.parametrize(
         "dataset_class, dataset_kwargs",
         [
-            ("pandas.CSVDataset", {}),
-            ("pandas.HDFDataset", {"key": "data"}),
+            {"type": "pandas.CSVDataset"},
+            {"type": "pandas.HDFDataset", "key": "data"},
         ],
     )
-    def test_exists(self, dataset_class, dataset_kwargs, mocked_csvs_in_s3):
-        assert PartitionedDataset(
-            path=mocked_csvs_in_s3, dataset=dataset_class, **dataset_kwargs
-        ).exists()
+    def test_exists(self, dataset, mocked_csvs_in_s3):
+        assert PartitionedDataset(path=mocked_csvs_in_s3, dataset=dataset).exists()
 
         empty_folder = "/".join([mocked_csvs_in_s3, "empty", "folder"])
-        assert not PartitionedDataset(
-            path=empty_folder, dataset=dataset_class, **dataset_kwargs
-        ).exists()
+        assert not PartitionedDataset(path=empty_folder, dataset=dataset).exists()
 
         s3fs.S3FileSystem().mkdir(empty_folder)
-        assert not PartitionedDataset(
-            path=empty_folder, dataset=dataset_class, **dataset_kwargs
-        ).exists()
+        assert not PartitionedDataset(path=empty_folder, dataset=dataset).exists()
 
     @pytest.mark.parametrize("dataset", S3_DATASET_DEFINITION)
     def test_release(self, dataset, mocked_csvs_in_s3):

--- a/kedro-datasets/tests/partitions/test_partitioned_dataset.py
+++ b/kedro-datasets/tests/partitions/test_partitioned_dataset.py
@@ -251,9 +251,9 @@ class TestPartitionedDatasetLocal:
         path = str(Path.cwd())
         pds = PartitionedDataset(path=path, dataset=dataset)
 
-        assert f"path={path}" in str(pds)
-        assert "dataset_type=CSVDataset" in str(pds)
-        assert "dataset_config" in str(pds)
+        assert f"path={path}" in pds._describe()
+        assert "dataset_type=CSVDataset" in pds._describe()
+        assert "dataset_config" in pds._describe()
 
     def test_load_args(self, mocker):
         fake_partition_name = "fake_partition"
@@ -690,6 +690,6 @@ class TestPartitionedDatasetS3:
         path = f"s3://{BUCKET_NAME}/foo/bar"
         pds = PartitionedDataset(path=path, dataset=dataset)
 
-        assert f"path={path}" in str(pds)
-        assert "dataset_type=CSVDataset" in str(pds)
-        assert "dataset_config" in str(pds)
+        assert f"path={path}" in pds._describe()
+        assert "dataset_type=CSVDataset" in pds._describe()
+        assert "dataset_config" in pds._describe()

--- a/kedro-datasets/tests/partitions/test_partitioned_dataset.py
+++ b/kedro-datasets/tests/partitions/test_partitioned_dataset.py
@@ -251,9 +251,13 @@ class TestPartitionedDatasetLocal:
         path = str(Path.cwd())
         pds = PartitionedDataset(path=path, dataset=dataset)
 
-        assert f"path={path}" in pds._describe()
-        assert "dataset_type=CSVDataset" in pds._describe()
-        assert "dataset_config" in pds._describe()
+        pds_description = pds._describe()
+        assert "path" in pds_description and path in pds_description["path"]
+        assert (
+            "dataset_type" in pds_description
+            and "CSVDataset" in pds_description["dataset_type"]
+        )
+        assert "dataset_config" in pds_description
 
     def test_load_args(self, mocker):
         fake_partition_name = "fake_partition"
@@ -690,6 +694,10 @@ class TestPartitionedDatasetS3:
         path = f"s3://{BUCKET_NAME}/foo/bar"
         pds = PartitionedDataset(path=path, dataset=dataset)
 
-        assert f"path={path}" in pds._describe()
-        assert "dataset_type=CSVDataset" in pds._describe()
-        assert "dataset_config" in pds._describe()
+        pds_description = pds._describe()
+        assert "path" in pds_description and path in pds_description["path"]
+        assert (
+            "dataset_type" in pds_description
+            and "CSVDataset" in pds_description["dataset_type"]
+        )
+        assert "dataset_config" in pds_description

--- a/kedro-datasets/tests/partitions/test_partitioned_dataset.py
+++ b/kedro-datasets/tests/partitions/test_partitioned_dataset.py
@@ -695,9 +695,13 @@ class TestPartitionedDatasetS3:
 
     @pytest.mark.parametrize("dataset", S3_DATASET_DEFINITION)
     def test_describe(self, dataset):
-        path = f"'s3://{BUCKET_NAME}/foo/bar'"
-        pds = PartitionedDataset(path=path, dataset=dataset)
+        path = f"s3://{BUCKET_NAME}/foo/bar"
+        pds_descr = PartitionedDataset(path=path, dataset=dataset)._describe()
 
-        assert f"filepath={path}" in str(pds)
-        assert "dataset_type=CSVDataset" in str(pds)
-        assert "dataset_config" in str(pds)
+        assert "path" in pds_descr and pds_descr["path"] == path
+        assert (
+            "dataset_type" in pds_descr
+            and pds_descr["dataset_type"]
+            == "kedro_datasets.pandas.csv_dataset.CSVDataset()"
+        )
+        assert "dataset_config" in pds_descr

--- a/kedro-datasets/tests/partitions/test_partitioned_dataset.py
+++ b/kedro-datasets/tests/partitions/test_partitioned_dataset.py
@@ -649,7 +649,7 @@ class TestPartitionedDatasetS3:
         mocked_ds.return_value.save.assert_called_once_with(data)
 
     @pytest.mark.parametrize(
-        "dataset_class, dataset_kwargs",
+        "dataset",
         [
             {"type": "pandas.CSVDataset"},
             {"type": "pandas.HDFDataset", "key": "data"},

--- a/kedro-datasets/tests/partitions/test_partitioned_dataset.py
+++ b/kedro-datasets/tests/partitions/test_partitioned_dataset.py
@@ -657,17 +657,17 @@ class TestPartitionedDatasetS3:
     )
     def test_exists(self, dataset_class, dataset_kwargs, mocked_csvs_in_s3):
         assert PartitionedDataset(
-            path=mocked_csvs_in_s3, dataset=dataset_class, dataset_kwargs=dataset_kwargs
+            path=mocked_csvs_in_s3, dataset=dataset_class, **dataset_kwargs
         ).exists()
 
         empty_folder = "/".join([mocked_csvs_in_s3, "empty", "folder"])
         assert not PartitionedDataset(
-            path=empty_folder, dataset=dataset_class, dataset_kwargs=dataset_kwargs
+            path=empty_folder, dataset=dataset_class, **dataset_kwargs
         ).exists()
 
         s3fs.S3FileSystem().mkdir(empty_folder)
         assert not PartitionedDataset(
-            path=empty_folder, dataset=dataset_class, dataset_kwargs=dataset_kwargs
+            path=empty_folder, dataset=dataset_class, **dataset_kwargs
         ).exists()
 
     @pytest.mark.parametrize("dataset", S3_DATASET_DEFINITION)

--- a/kedro-datasets/tests/partitions/test_partitioned_dataset.py
+++ b/kedro-datasets/tests/partitions/test_partitioned_dataset.py
@@ -597,7 +597,7 @@ class TestPartitionedDatasetS3:
         s3a_path = f"s3a://{path}"
 
         mocked_ds = mocker.patch(
-            "kedro_datasets.partitioned_dataset.PartitionedDataset._dataset_type"
+            "kedro_datasets.partitions.partitioned_dataset.PartitionedDataset._dataset_type"
         )
         mocked_ds.__name__ = "mocked"
 
@@ -638,7 +638,7 @@ class TestPartitionedDatasetS3:
 
         # Patch BEFORE creating the PartitionedDataset
         mocked_ds = mocker.patch(
-            "kedro_datasets.partitioned_dataset.PartitionedDataset._dataset_type"
+            "kedro_datasets.partitions.partitioned_dataset.PartitionedDataset._dataset_type"
         )
         mocked_ds.__name__ = "mocked"
 

--- a/kedro-datasets/tests/partitions/test_partitioned_dataset.py
+++ b/kedro-datasets/tests/partitions/test_partitioned_dataset.py
@@ -322,7 +322,7 @@ class TestPartitionedDatasetLocal:
         loaded_partitions = pds.load()
 
         for partition, df_loader in loaded_partitions.items():
-            pattern = r"Failed while loading data from dataset ParquetDataset(.*)"
+            pattern = r"Failed while loading data from dataset kedro_datasets.pandas.parquet_dataset.ParquetDataset(.*)"
             with pytest.raises(DatasetError, match=pattern) as exc_info:
                 df_loader()
             error_message = str(exc_info.value)
@@ -698,6 +698,6 @@ class TestPartitionedDatasetS3:
         path = f"s3://{BUCKET_NAME}/foo/bar"
         pds = PartitionedDataset(path=path, dataset=dataset)
 
-        assert f"path={path}" in str(pds)
+        assert f"filepath={path}" in str(pds)
         assert "dataset_type=CSVDataset" in str(pds)
         assert "dataset_config" in str(pds)

--- a/kedro-datasets/tests/partitions/test_partitioned_dataset.py
+++ b/kedro-datasets/tests/partitions/test_partitioned_dataset.py
@@ -695,7 +695,7 @@ class TestPartitionedDatasetS3:
 
     @pytest.mark.parametrize("dataset", S3_DATASET_DEFINITION)
     def test_describe(self, dataset):
-        path = f"s3://{BUCKET_NAME}/foo/bar"
+        path = f"'s3://{BUCKET_NAME}/foo/bar'"
         pds = PartitionedDataset(path=path, dataset=dataset)
 
         assert f"filepath={path}" in str(pds)

--- a/kedro-datasets/tests/pickle/test_pickle_dataset.py
+++ b/kedro-datasets/tests/pickle/test_pickle_dataset.py
@@ -196,7 +196,7 @@ class TestPickleDatasetVersioned:
 
     def test_no_versions(self, versioned_pickle_dataset):
         """Check the error if no versions are available for load."""
-        pattern = r"Did not find any versions for PickleDataset\(.+\)"
+        pattern = r"Did not find any versions for kedro_datasets.pickle.pickle_dataset.PickleDataset\(.+\)"
         with pytest.raises(DatasetError, match=pattern):
             versioned_pickle_dataset.load()
 
@@ -211,7 +211,7 @@ class TestPickleDatasetVersioned:
         corresponding Pickle file for a given save version already exists."""
         versioned_pickle_dataset.save(dummy_dataframe)
         pattern = (
-            r"Save path \'.+\' for PickleDataset\(.+\) must "
+            r"Save path \'.+\' for kedro_datasets.pickle.pickle_dataset.PickleDataset\(.+\) must "
             r"not exist if versioning is enabled\."
         )
         with pytest.raises(DatasetError, match=pattern):
@@ -230,7 +230,7 @@ class TestPickleDatasetVersioned:
         the subsequent load path."""
         pattern = (
             rf"Save version '{save_version}' did not match load version "
-            rf"'{load_version}' for PickleDataset\(.+\)"
+            rf"'{load_version}' for kedro_datasets.pickle.pickle_dataset.PickleDataset\(.+\)"
         )
         with pytest.warns(UserWarning, match=pattern):
             versioned_pickle_dataset.save(dummy_dataframe)

--- a/kedro-datasets/tests/pickle/test_pickle_dataset.py
+++ b/kedro-datasets/tests/pickle/test_pickle_dataset.py
@@ -98,7 +98,7 @@ class TestPickleDataset:
 
     def test_load_missing_file(self, pickle_dataset):
         """Check the error when trying to load missing file."""
-        pattern = r"Failed while loading data from dataset PickleDataset\(.*\)"
+        pattern = r"Failed while loading data from dataset kedro_datasets.pickle.pickle_dataset.PickleDataset\(.*\)"
         with pytest.raises(DatasetError, match=pattern):
             pickle_dataset.load()
 

--- a/kedro-datasets/tests/pillow/test_image_dataset.py
+++ b/kedro-datasets/tests/pillow/test_image_dataset.py
@@ -80,7 +80,7 @@ class TestImageDataset:
 
     def test_load_missing_file(self, image_dataset):
         """Check the error when trying to load missing file."""
-        pattern = r"Failed while loading data from dataset ImageDataset\(.*\)"
+        pattern = r"Failed while loading data from dataset kedro_datasets.pillow.image_dataset.ImageDataset\(.*\)"
         with pytest.raises(DatasetError, match=pattern):
             image_dataset.load()
 

--- a/kedro-datasets/tests/pillow/test_image_dataset.py
+++ b/kedro-datasets/tests/pillow/test_image_dataset.py
@@ -177,7 +177,7 @@ class TestImageDatasetVersioned:
 
     def test_no_versions(self, versioned_image_dataset):
         """Check the error if no versions are available for load."""
-        pattern = r"Did not find any versions for ImageDataset\(.+\)"
+        pattern = r"Did not find any versions for kedro_datasets.pillow.image_dataset.ImageDataset\(.+\)"
         with pytest.raises(DatasetError, match=pattern):
             versioned_image_dataset.load()
 
@@ -192,7 +192,7 @@ class TestImageDatasetVersioned:
         corresponding image file for a given save version already exists."""
         versioned_image_dataset.save(image_object)
         pattern = (
-            r"Save path \'.+\' for ImageDataset\(.+\) must "
+            r"Save path \'.+\' for kedro_datasets.pillow.image_dataset.ImageDataset\(.+\) must "
             r"not exist if versioning is enabled\."
         )
         with pytest.raises(DatasetError, match=pattern):
@@ -211,7 +211,7 @@ class TestImageDatasetVersioned:
         the subsequent load path."""
         pattern = (
             rf"Save version '{save_version}' did not match load version "
-            rf"'{load_version}' for ImageDataset\(.+\)"
+            rf"'{load_version}' for kedro_datasets.pillow.image_dataset.ImageDataset\(.+\)"
         )
         with pytest.warns(UserWarning, match=pattern):
             versioned_image_dataset.save(image_object)

--- a/kedro-datasets/tests/plotly/test_json_dataset.py
+++ b/kedro-datasets/tests/plotly/test_json_dataset.py
@@ -51,7 +51,7 @@ class TestJSONDataset:
 
     def test_load_missing_file(self, json_dataset):
         """Check the error when trying to load missing file."""
-        pattern = r"Failed while loading data from dataset JSONDataset\(.*\)"
+        pattern = r"Failed while loading data from dataset kedro_datasets.plotly.json_dataset.JSONDataset\(.*\)"
         with pytest.raises(DatasetError, match=pattern):
             json_dataset.load()
 

--- a/kedro-datasets/tests/plotly/test_plotly_dataset.py
+++ b/kedro-datasets/tests/plotly/test_plotly_dataset.py
@@ -63,7 +63,7 @@ class TestPlotlyDataset:
 
     def test_load_missing_file(self, plotly_dataset):
         """Check the error when trying to load missing file."""
-        pattern = r"Failed while loading data from dataset PlotlyDataset\(.*\)"
+        pattern = r"Failed while loading data from dataset kedro_datasets.plotly.plotly_dataset.PlotlyDataset\(.*\)"
         with pytest.raises(DatasetError, match=pattern):
             plotly_dataset.load()
 

--- a/kedro-datasets/tests/polars/test_csv_dataset.py
+++ b/kedro-datasets/tests/polars/test_csv_dataset.py
@@ -278,7 +278,7 @@ class TestCSVDatasetVersioned:
 
     def test_no_versions(self, versioned_csv_dataset):
         """Check the error if no versions are available for load."""
-        pattern = r"Did not find any versions for CSVDataset\(.+\)"
+        pattern = r"Did not find any versions for kedro_datasets.polars.csv_dataset.CSVDataset\(.+\)"
         with pytest.raises(DatasetError, match=pattern):
             versioned_csv_dataset.load()
 
@@ -293,7 +293,7 @@ class TestCSVDatasetVersioned:
         corresponding CSV file for a given save version already exists."""
         versioned_csv_dataset.save(dummy_dataframe)
         pattern = (
-            r"Save path \'.+\' for CSVDataset\(.+\) must "
+            r"Save path \'.+\' for kedro_datasets.polars.csv_dataset.CSVDataset\(.+\) must "
             r"not exist if versioning is enabled\."
         )
         with pytest.raises(DatasetError, match=pattern):
@@ -312,7 +312,7 @@ class TestCSVDatasetVersioned:
         the subsequent load path."""
         pattern = (
             rf"Save version '{save_version}' did not match load version "
-            rf"'{load_version}' for CSVDataset\(.+\)"
+            rf"'{load_version}' for kedro_datasets.polars.csv_dataset.CSVDataset\(.+\)"
         )
         with pytest.warns(UserWarning, match=pattern):
             versioned_csv_dataset.save(dummy_dataframe)

--- a/kedro-datasets/tests/polars/test_csv_dataset.py
+++ b/kedro-datasets/tests/polars/test_csv_dataset.py
@@ -141,7 +141,7 @@ class TestCSVDataset:
 
     def test_load_missing_file(self, csv_dataset):
         """Check the error when trying to load missing file."""
-        pattern = r"Failed while loading data from dataset CSVDataset\(.*\)"
+        pattern = r"Failed while loading data from dataset kedro_datasets.polars.csv_dataset.CSVDataset\(.*\)"
         with pytest.raises(DatasetError, match=pattern):
             csv_dataset.load()
 

--- a/kedro-datasets/tests/polars/test_eager_polars_dataset.py
+++ b/kedro-datasets/tests/polars/test_eager_polars_dataset.py
@@ -442,7 +442,7 @@ class TestEagerCSVDatasetVersioned:
 
     def test_no_versions(self, versioned_csv_dataset):
         """Check the error if no versions are available for load."""
-        pattern = r"Did not find any versions for EagerPolarsDataset\(.+\)"
+        pattern = r"Did not find any versions for kedro_datasets.polars.eager_polars_dataset.EagerPolarsDataset\(.+\)"
         with pytest.raises(DatasetError, match=pattern):
             versioned_csv_dataset.load()
 
@@ -457,7 +457,7 @@ class TestEagerCSVDatasetVersioned:
         corresponding Generic (csv) file for a given save version already exists."""
         versioned_csv_dataset.save(dummy_dataframe)
         pattern = (
-            r"Save path \'.+\' for EagerPolarsDataset\(.+\) must "
+            r"Save path \'.+\' for kedro_datasets.polars.eager_polars_dataset.EagerPolarsDataset\(.+\) must "
             r"not exist if versioning is enabled\."
         )
         with pytest.raises(DatasetError, match=pattern):
@@ -476,7 +476,7 @@ class TestEagerCSVDatasetVersioned:
         the subsequent load path."""
         pattern = (
             rf"Save version '{save_version}' did not match load version "
-            rf"'{load_version}' for EagerPolarsDataset\(.+\)"
+            rf"'{load_version}' for kedro_datasets.polars.eager_polars_dataset.EagerPolarsDataset\(.+\)"
         )
         with pytest.warns(UserWarning, match=pattern):
             versioned_csv_dataset.save(dummy_dataframe)

--- a/kedro-datasets/tests/polars/test_lazy_polars_dataset.py
+++ b/kedro-datasets/tests/polars/test_lazy_polars_dataset.py
@@ -137,7 +137,7 @@ class TestLazyCSVDataset:
 
     def test_load_missing_file(self, csv_dataset):
         """Check the error when trying to load missing file."""
-        pattern = r"Failed while loading data from dataset LazyPolarsDataset\(.*\)"
+        pattern = r"Failed while loading data from dataset kedro_datasets.polars.lazy_polars_dataset.LazyPolarsDataset\(.*\)"
         with pytest.raises(DatasetError, match=pattern):
             csv_dataset.load()
 

--- a/kedro-datasets/tests/polars/test_lazy_polars_dataset.py
+++ b/kedro-datasets/tests/polars/test_lazy_polars_dataset.py
@@ -345,7 +345,7 @@ class TestLazyParquetDatasetVersioned:
 
     def test_no_versions(self, versioned_parquet_dataset):
         """Check the error if no versions are available for load."""
-        pattern = r"Did not find any versions for kedro_datasets.polars.lazy_polars_dataset.LazyPolarsDataset(\(.+\)"
+        pattern = r"Did not find any versions for kedro_datasets.polars.lazy_polars_dataset.LazyPolarsDataset\(.+\)"
         with pytest.raises(DatasetError, match=pattern):
             versioned_parquet_dataset.load()
 
@@ -354,7 +354,7 @@ class TestLazyParquetDatasetVersioned:
         corresponding Generic (parquet) file for a given save version already exists."""
         versioned_parquet_dataset.save(dummy_dataframe)
         pattern = (
-            r"Save path \'.+\' for kedro_datasets.polars.lazy_polars_dataset.LazyPolarsDataset(\(.+\) must "
+            r"Save path \'.+\' for kedro_datasets.polars.lazy_polars_dataset.LazyPolarsDataset\(.+\) must "
             r"not exist if versioning is enabled\."
         )
         with pytest.raises(DatasetError, match=pattern):
@@ -373,7 +373,7 @@ class TestLazyParquetDatasetVersioned:
         the subsequent load path."""
         pattern = (
             rf"Save version '{save_version}' did not match load version "
-            rf"'{load_version}' for kedro_datasets.polars.lazy_polars_dataset.LazyPolarsDataset(\(.+\)"
+            rf"'{load_version}' for kedro_datasets.polars.lazy_polars_dataset.LazyPolarsDataset\(.+\)"
         )
         with pytest.warns(UserWarning, match=pattern):
             versioned_parquet_dataset.save(dummy_dataframe)

--- a/kedro-datasets/tests/polars/test_lazy_polars_dataset.py
+++ b/kedro-datasets/tests/polars/test_lazy_polars_dataset.py
@@ -345,7 +345,7 @@ class TestLazyParquetDatasetVersioned:
 
     def test_no_versions(self, versioned_parquet_dataset):
         """Check the error if no versions are available for load."""
-        pattern = r"Did not find any versions for LazyPolarsDataset\(.+\)"
+        pattern = r"Did not find any versions for kedro_datasets.polars.lazy_polars_dataset.LazyPolarsDataset(\(.+\)"
         with pytest.raises(DatasetError, match=pattern):
             versioned_parquet_dataset.load()
 
@@ -354,7 +354,7 @@ class TestLazyParquetDatasetVersioned:
         corresponding Generic (parquet) file for a given save version already exists."""
         versioned_parquet_dataset.save(dummy_dataframe)
         pattern = (
-            r"Save path \'.+\' for LazyPolarsDataset\(.+\) must "
+            r"Save path \'.+\' for kedro_datasets.polars.lazy_polars_dataset.LazyPolarsDataset(\(.+\) must "
             r"not exist if versioning is enabled\."
         )
         with pytest.raises(DatasetError, match=pattern):
@@ -373,7 +373,7 @@ class TestLazyParquetDatasetVersioned:
         the subsequent load path."""
         pattern = (
             rf"Save version '{save_version}' did not match load version "
-            rf"'{load_version}' for LazyPolarsDataset\(.+\)"
+            rf"'{load_version}' for kedro_datasets.polars.lazy_polars_dataset.LazyPolarsDataset(\(.+\)"
         )
         with pytest.warns(UserWarning, match=pattern):
             versioned_parquet_dataset.save(dummy_dataframe)

--- a/kedro-datasets/tests/spark/test_memory_dataset.py
+++ b/kedro-datasets/tests/spark/test_memory_dataset.py
@@ -63,4 +63,6 @@ def test_load_returns_same_spark_object(memory_dataset, spark_data_frame):
 
 def test_str_representation(memory_dataset):
     """Test string representation of the dataset"""
-    assert "MemoryDataset(data=<DataFrame>)" in str(memory_dataset)
+    assert "kedro.io.memory_dataset.MemoryDataset(data=<DataFrame>)" in str(
+        memory_dataset
+    )

--- a/kedro-datasets/tests/spark/test_memory_dataset.py
+++ b/kedro-datasets/tests/spark/test_memory_dataset.py
@@ -63,6 +63,6 @@ def test_load_returns_same_spark_object(memory_dataset, spark_data_frame):
 
 def test_str_representation(memory_dataset):
     """Test string representation of the dataset"""
-    assert "kedro.io.memory_dataset.MemoryDataset(data=<DataFrame>)" in str(
+    assert "kedro.io.memory_dataset.MemoryDataset(data='<DataFrame>')" in str(
         memory_dataset
     )

--- a/kedro-datasets/tests/spark/test_spark_dataset.py
+++ b/kedro-datasets/tests/spark/test_spark_dataset.py
@@ -343,7 +343,9 @@ class TestSparkDataset:
             spark_dataset = SparkDataset(
                 filepath=filepath, file_format="csv", load_args={"header": True}
             )
-            assert "SparkDataset" in str(spark_dataset)
+            assert "kedro_datasets.spark.spark_dataset.SparkDataset" in str(
+                spark_dataset
+            )
             assert f"filepath={filepath}" in str(spark_dataset)
 
     def test_save_overwrite_fail(self, tmp_path, sample_spark_df):
@@ -488,7 +490,7 @@ class TestSparkDataset:
 
 class TestSparkDatasetVersionedLocal:
     def test_no_version(self, versioned_dataset_local):
-        pattern = r"Did not find any versions for SparkDataset\(.+\)"
+        pattern = r"Did not find any versions for kedro_datasets.spark.spark_dataset.SparkDataset\(.+\)"
         with pytest.raises(DatasetError, match=pattern):
             versioned_dataset_local.load()
 
@@ -731,7 +733,7 @@ class TestSparkDatasetVersionedS3:
 
     @pytest.mark.xfail
     def test_no_version(self, versioned_dataset_s3):
-        pattern = r"Did not find any versions for SparkDataset\(.+\)"
+        pattern = r"Did not find any versions for kedro_datasets.spark.spark_dataset.SparkDataset\(.+\)"
         with pytest.raises(DatasetError, match=pattern):
             versioned_dataset_s3.load()
 

--- a/kedro-datasets/tests/spark/test_spark_dataset.py
+++ b/kedro-datasets/tests/spark/test_spark_dataset.py
@@ -346,7 +346,7 @@ class TestSparkDataset:
             assert "kedro_datasets.spark.spark_dataset.SparkDataset" in str(
                 spark_dataset
             )
-            assert f"filepath={filepath}" in str(spark_dataset)
+            assert f"filepath='{filepath}" in str(spark_dataset)
 
     def test_save_overwrite_fail(self, tmp_path, sample_spark_df):
         # Writes a data frame twice and expects it to fail.
@@ -827,7 +827,7 @@ class TestSparkDatasetVersionedS3:
         )
 
         dataset_s3 = SparkDataset(filepath=f"s3a://{BUCKET_NAME}/{FILENAME}")
-        assert "filepath=s3a://" in str(dataset_s3)
+        assert "filepath='s3a://" in str(dataset_s3)
         assert "version=" not in str(dataset_s3)
 
 

--- a/kedro-datasets/tests/spark/test_spark_dataset.py
+++ b/kedro-datasets/tests/spark/test_spark_dataset.py
@@ -529,7 +529,7 @@ class TestSparkDatasetVersionedLocal:
 
         pattern = (
             rf"Save version '{exact_version.save}' did not match load version "
-            rf"'{exact_version.load}' for SparkDataset\(.+\)"
+            rf"'{exact_version.load}' for kedro_datasets.spark.spark_dataset.SparkDataset\(.+\)"
         )
         with pytest.warns(UserWarning, match=pattern):
             ds_local.save(sample_spark_df)
@@ -544,7 +544,7 @@ class TestSparkDatasetVersionedLocal:
         versioned_local.save(sample_spark_df)
 
         pattern = (
-            r"Save path '.+' for SparkDataset\(.+\) must not exist "
+            r"Save path '.+' for kedro_datasets.spark.spark_dataset.SparkDataset\(.+\) must not exist "
             r"if versioning is enabled"
         )
         with pytest.raises(DatasetError, match=pattern):
@@ -796,7 +796,7 @@ class TestSparkDatasetVersionedS3:
 
         pattern = (
             rf"Save version '{exact_version.save}' did not match load version "
-            rf"'{exact_version.load}' for SparkDataset\(.+\)"
+            rf"'{exact_version.load}' for kedro_datasets.spark.spark_dataset.SparkDataset\(.+\)"
         )
         with pytest.warns(UserWarning, match=pattern):
             ds_s3.save(mocked_spark_df)
@@ -810,7 +810,7 @@ class TestSparkDatasetVersionedS3:
         mocker.patch.object(versioned_dataset_s3, "_exists_function", return_value=True)
 
         pattern = (
-            r"Save path '.+' for SparkDataset\(.+\) must not exist "
+            r"Save path '.+' for kedro_datasets.spark.spark_dataset.SparkDataset\(.+\) must not exist "
             r"if versioning is enabled"
         )
         with pytest.raises(DatasetError, match=pattern):
@@ -819,7 +819,7 @@ class TestSparkDatasetVersionedS3:
         mocked_spark_df.write.save.assert_not_called()
 
     def test_repr(self, versioned_dataset_s3, version):
-        assert "filepath=s3a://" in str(versioned_dataset_s3)
+        assert "filepath='s3a://" in str(versioned_dataset_s3)
         assert f"version=Version(load=None, save='{version.save}')" in str(
             versioned_dataset_s3
         )
@@ -838,7 +838,7 @@ class TestSparkDatasetVersionedHdfs:
 
         versioned_hdfs = SparkDataset(filepath=f"hdfs://{HDFS_PREFIX}", version=version)
 
-        pattern = r"Did not find any versions for SparkDataset\(.+\)"
+        pattern = r"Did not find any versions for kedro_datasets.spark.spark_dataset.SparkDataset\(.+\)"
         with pytest.raises(DatasetError, match=pattern):
             versioned_hdfs.load()
 
@@ -922,7 +922,7 @@ class TestSparkDatasetVersionedHdfs:
 
         pattern = (
             rf"Save version '{exact_version.save}' did not match load version "
-            rf"'{exact_version.load}' for SparkDataset\(.+\)"
+            rf"'{exact_version.load}' for kedro_datasets.spark.spark_dataset.SparkDataset\(.+\)"
         )
 
         with pytest.warns(UserWarning, match=pattern):
@@ -943,7 +943,7 @@ class TestSparkDatasetVersionedHdfs:
         mocked_spark_df = mocker.Mock()
 
         pattern = (
-            r"Save path '.+' for SparkDataset\(.+\) must not exist "
+            r"Save path '.+' for kedro_datasets.spark.spark_dataset.SparkDataset\(.+\) must not exist "
             r"if versioning is enabled"
         )
         with pytest.raises(DatasetError, match=pattern):
@@ -965,13 +965,13 @@ class TestSparkDatasetVersionedHdfs:
 
     def test_repr(self, version):
         versioned_hdfs = SparkDataset(filepath=f"hdfs://{HDFS_PREFIX}", version=version)
-        assert "filepath=hdfs://" in str(versioned_hdfs)
+        assert "filepath='hdfs://" in str(versioned_hdfs)
         assert f"version=Version(load=None, save='{version.save}')" in str(
             versioned_hdfs
         )
 
         dataset_hdfs = SparkDataset(filepath=f"hdfs://{HDFS_PREFIX}")
-        assert "filepath=hdfs://" in str(dataset_hdfs)
+        assert "filepath='hdfs://" in str(dataset_hdfs)
         assert "version=" not in str(dataset_hdfs)
 
 

--- a/kedro-datasets/tests/svmlight/test_svmlight_dataset.py
+++ b/kedro-datasets/tests/svmlight/test_svmlight_dataset.py
@@ -82,7 +82,7 @@ class TestSVMLightDataset:
 
     def test_load_missing_file(self, svm_dataset):
         """Check the error when trying to load missing file."""
-        pattern = r"Failed while loading data from dataset SVMLightDataset\(.*\)"
+        pattern = r"Failed while loading data from dataset kedro_datasets.svmlight.svmlight_dataset.SVMLightDataset\(.*\)"
         with pytest.raises(DatasetError, match=pattern):
             svm_dataset.load()
 
@@ -144,7 +144,7 @@ class TestSVMLightDatasetVersioned:
 
     def test_no_versions(self, versioned_svm_dataset):
         """Check the error if no versions are available for load."""
-        pattern = r"Did not find any versions for SVMLightDataset\(.+\)"
+        pattern = r"Did not find any versions for kedro_datasets.svmlight.svmlight_dataset.SVMLightDataset\(.+\)"
         with pytest.raises(DatasetError, match=pattern):
             versioned_svm_dataset.load()
 
@@ -159,7 +159,7 @@ class TestSVMLightDatasetVersioned:
         corresponding json file for a given save version already exists."""
         versioned_svm_dataset.save(dummy_data)
         pattern = (
-            r"Save path \'.+\' for SVMLightDataset\(.+\) must "
+            r"Save path \'.+\' for kedro_datasets.svmlight.svmlight_dataset.SVMLightDataset\(.+\) must "
             r"not exist if versioning is enabled\."
         )
         with pytest.raises(DatasetError, match=pattern):
@@ -179,7 +179,7 @@ class TestSVMLightDatasetVersioned:
         pattern = (
             f"Save version '{save_version}' did not match "
             f"load version '{load_version}' for "
-            r"SVMLightDataset\(.+\)"
+            r"kedro_datasets.svmlight.svmlight_dataset.SVMLightDataset\(.+\)"
         )
         with pytest.warns(UserWarning, match=pattern):
             versioned_svm_dataset.save(dummy_data)

--- a/kedro-datasets/tests/tensorflow/test_tensorflow_model_dataset.py
+++ b/kedro-datasets/tests/tensorflow/test_tensorflow_model_dataset.py
@@ -155,7 +155,7 @@ class TestTensorFlowModelDataset:
 
     def test_load_missing_model(self, tf_model_dataset):
         """Test error message when trying to load missing model."""
-        pattern = r"Failed while loading data from dataset TensorFlowModelDataset\(.*\)"
+        pattern = r"Failed while loading data from dataset kedro_datasets.tensorflow.tensorflow_model_dataset.TensorFlowModelDataset\(.*\)"
         with pytest.raises(DatasetError, match=pattern):
             tf_model_dataset.load()
 
@@ -336,7 +336,7 @@ class TestTensorFlowModelDatasetVersioned:
         corresponding file for a given save version already exists."""
         versioned_tf_model_dataset.save(dummy_tf_base_model)
         pattern = (
-            r"Save path \'.+\' for TensorFlowModelDataset\(.+\) must "
+            r"Save path \'.+\' for kedro_datasets.tensorflow.tensorflow_model_dataset.TensorFlowModelDataset\(.+\) must "
             r"not exist if versioning is enabled\."
         )
         with pytest.raises(DatasetError, match=pattern):
@@ -358,7 +358,7 @@ class TestTensorFlowModelDatasetVersioned:
         the subsequent load path."""
         pattern = (
             rf"Save version '{save_version}' did not match load version '{load_version}' "
-            rf"for TensorFlowModelDataset\(.+\)"
+            rf"for kedro_datasets.tensorflow.tensorflow_model_dataset.TensorFlowModelDataset\(.+\)"
         )
         with pytest.warns(UserWarning, match=pattern):
             versioned_tf_model_dataset.save(dummy_tf_base_model)
@@ -379,7 +379,7 @@ class TestTensorFlowModelDatasetVersioned:
 
     def test_no_versions(self, versioned_tf_model_dataset):
         """Check the error if no versions are available for load."""
-        pattern = r"Did not find any versions for TensorFlowModelDataset\(.+\)"
+        pattern = r"Did not find any versions for kedro_datasets.tensorflow.tensorflow_model_dataset.TensorFlowModelDataset\(.+\)"
         with pytest.raises(DatasetError, match=pattern):
             versioned_tf_model_dataset.load()
 

--- a/kedro-datasets/tests/text/test_text_dataset.py
+++ b/kedro-datasets/tests/text/test_text_dataset.py
@@ -56,7 +56,7 @@ class TestTextDataset:
 
     def test_load_missing_file(self, txt_dataset):
         """Check the error when trying to load missing file."""
-        pattern = r"Failed while loading data from dataset TextDataset\(.*\)"
+        pattern = r"Failed while loading data from dataset kedro_datasets.text.text_dataset.TextDataset\(.*\)"
         with pytest.raises(DatasetError, match=pattern):
             txt_dataset.load()
 
@@ -116,7 +116,7 @@ class TestTextDatasetVersioned:
 
     def test_no_versions(self, versioned_txt_dataset):
         """Check the error if no versions are available for load."""
-        pattern = r"Did not find any versions for TextDataset\(.+\)"
+        pattern = r"Did not find any versions for kedro_datasets.text.text_dataset.TextDataset\(.+\)"
         with pytest.raises(DatasetError, match=pattern):
             versioned_txt_dataset.load()
 
@@ -131,7 +131,7 @@ class TestTextDatasetVersioned:
         corresponding text file for a given save version already exists."""
         versioned_txt_dataset.save(STRING)
         pattern = (
-            r"Save path \'.+\' for TextDataset\(.+\) must "
+            r"Save path \'.+\' for kedro_datasets.text.text_dataset.TextDataset\(.+\) must "
             r"not exist if versioning is enabled\."
         )
         with pytest.raises(DatasetError, match=pattern):
@@ -150,7 +150,7 @@ class TestTextDatasetVersioned:
         the subsequent load path."""
         pattern = (
             rf"Save version '{save_version}' did not match load version "
-            rf"'{load_version}' for TextDataset\(.+\)"
+            rf"'{load_version}' for kedro_datasets.text.text_dataset.TextDataset\(.+\)"
         )
         with pytest.warns(UserWarning, match=pattern):
             versioned_txt_dataset.save(STRING)

--- a/kedro-datasets/tests/yaml/test_yaml_dataset.py
+++ b/kedro-datasets/tests/yaml/test_yaml_dataset.py
@@ -72,7 +72,7 @@ class TestYAMLDataset:
 
     def test_load_missing_file(self, yaml_dataset):
         """Check the error when trying to load missing file."""
-        pattern = r"Failed while loading data from dataset YAMLDataset\(.*\)"
+        pattern = r"Failed while loading data from dataset kedro_datasets.yaml.yaml_dataset.YAMLDataset\(.*\)"
         with pytest.raises(DatasetError, match=pattern):
             yaml_dataset.load()
 
@@ -144,7 +144,7 @@ class TestYAMLDatasetVersioned:
 
     def test_no_versions(self, versioned_yaml_dataset):
         """Check the error if no versions are available for load."""
-        pattern = r"Did not find any versions for YAMLDataset\(.+\)"
+        pattern = r"Did not find any versions for kedro_datasets.yaml.yaml_dataset.YAMLDataset\(.+\)"
         with pytest.raises(DatasetError, match=pattern):
             versioned_yaml_dataset.load()
 
@@ -159,7 +159,7 @@ class TestYAMLDatasetVersioned:
         corresponding yaml file for a given save version already exists."""
         versioned_yaml_dataset.save(dummy_data)
         pattern = (
-            r"Save path \'.+\' for YAMLDataset\(.+\) must "
+            r"Save path \'.+\' for kedro_datasets.yaml.yaml_dataset.YAMLDataset\(.+\) must "
             r"not exist if versioning is enabled\."
         )
         with pytest.raises(DatasetError, match=pattern):
@@ -178,7 +178,7 @@ class TestYAMLDatasetVersioned:
         the subsequent load path."""
         pattern = (
             rf"Save version '{save_version}' did not match load version "
-            rf"'{load_version}' for YAMLDataset\(.+\)"
+            rf"'{load_version}' for kedro_datasets.yaml.yaml_dataset.YAMLDataset\(.+\)"
         )
         with pytest.warns(UserWarning, match=pattern):
             versioned_yaml_dataset.save(dummy_data)


### PR DESCRIPTION
## Description
Solves https://github.com/kedro-org/kedro-plugins/issues/1123

## Development notes
Bandit warning is suppressed for now to make the lint checks pass and unblock all the hanging PRs. Left a TODO to fix it based on the solution from here: https://github.com/kedro-org/kedro-plugins/issues/1131

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Updated `jsonschema/kedro-catalog-X.XX.json` if necessary
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
- [ ] Received approvals from at least half of the TSC (required for adding a new, non-experimental dataset)
