### PR TITLE
Fix missing values in boolean column renders of pandas.CSVDataset

### DIFF
--- a/kedro-datasets/kedro_datasets/pandas/csv_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/csv_dataset.py
@@ -215,4 +215,8 @@ class CSVDataset(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
         dataset_copy._load_args["nrows"] = nrows  # type: ignore[attr-defined]
         data = dataset_copy.load()
 
+        # Convert boolean columns to strings for rendering.
+        bool_cols = data.select_dtypes(include="bool").columns
+        data[bool_cols] = data[bool_cols].astype(str)
+
         return data.to_dict(orient="split")

--- a/kedro-datasets/tests/pandas/test_csv_dataset.py
+++ b/kedro-datasets/tests/pandas/test_csv_dataset.py
@@ -45,6 +45,10 @@ def versioned_csv_dataset(filepath_csv, load_version, save_version):
 def dummy_dataframe():
     return pd.DataFrame({"col1": [1, 2], "col2": [4, 5], "col3": [5, 6]})
 
+@pytest.fixture
+def dummy_dataframe_with_bool():
+    return pd.DataFrame({"col1": [1, 2], "col2": [4, 5], "col3-bool": [True, False]})
+
 
 @pytest.fixture
 def partitioned_data_pandas():
@@ -192,6 +196,20 @@ class TestCSVDataset:
         assert (
             inspect.signature(csv_dataset.preview).return_annotation == "TablePreview"
         )
+
+    def test_preview_bool_col(self, csv_dataset, dummy_dataframe):
+        """Test preview returns string values for boolean columns."""
+        expected =  {
+            "index": [0, 1],
+            "columns": ["col1", "col2", "col3"],
+            "data": [[1, 4, "True"], [2, 5, "True"]],
+        }
+
+        dummy_dataframe.loc["col3"] = True
+        csv_dataset.save(dummy_dataframe)
+        previewed = csv_dataset.preview()
+        assert previewed == expected
+
 
     def test_load_missing_file(self, csv_dataset):
         """Check the error when trying to load missing file."""


### PR DESCRIPTION
Addresses https://github.com/kedro-org/kedro-viz/issues/2456

## Description
Fixes missing values in boolean column renders of pandas.CSVDataset

## Development notes
I've added detection of boolean columns to the `preview()` method, and conversion of these values to strings. I've added a simple test to confirm it works.

Might better involve a change in JS. And if python is the right place, should probably change other previews for pandas objects.

Thanks!

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Updated `jsonschema/kedro-catalog-X.XX.json` if necessary
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
- [ ] Received approvals from at least half of the TSC (required for adding a new, non-experimental dataset)
