### PR TITLE
Set telemetry consent to false on CI/CD setup

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,5 +1,8 @@
 name: Run unit tests
 
+env:
+  KEDRO_DISABLE_TELEMETRY: "true"
+
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->

Sets telemetry consent to `false` on Github CI configuration, to avoid generating unnecessary noise in our own telemetry dataset.

https://github.com/kedro-org/kedro/issues/4999

## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Updated `jsonschema/kedro-catalog-X.XX.json` if necessary
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
- [ ] Received approvals from at least half of the TSC (required for adding a new, non-experimental dataset)
