### PR TITLE
fix(airflow): e2e tests

### DIFF
--- a/kedro-airflow/pyproject.toml
+++ b/kedro-airflow/pyproject.toml
@@ -33,7 +33,7 @@ test = [
     "pytest-mock",
     "pytest-xdist",
     "wheel",
-    "flask-limiter<=3.13",
+    "flask-limiter<3.13",
 ]
 
 lint = [


### PR DESCRIPTION
## Description
I've checked the diff of `pip freeze` between the last successful e2e tests runs: https://github.com/kedro-org/kedro-plugins/actions/workflows/nightly-build.yml
```
flask-limiter==3.12 -> flask-limiter==3.13
rich==13.9.4 -> rich==14.1.0
```

Pinning `flask-limiter<3.13` solves the problem.

In the long term, we need to unpin it when the fix is merged on their side: https://github.com/alisaifee/flask-limiter/issues/479

## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Updated `jsonschema/kedro-catalog-X.XX.json` if necessary
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
- [ ] Received approvals from at least half of the TSC (required for adding a new, non-experimental dataset)
