### PR TITLE
fix(datasets): Convert dict to tuple when creating ChatPromptTemplate on LangChainPromptDataset

### DIFF
--- a/kedro-datasets/kedro_datasets_experimental/langchain/langchain_prompt_dataset.py
+++ b/kedro-datasets/kedro_datasets_experimental/langchain/langchain_prompt_dataset.py
@@ -291,6 +291,11 @@ class LangChainPromptDataset(AbstractDataset[Union[PromptTemplate, ChatPromptTem
             ChatPromptTemplate(messages=[...])
         """
         messages = self._validate_chat_prompt_data(data)
+
+        # Convert dict messages to tuples if necessary (for compatibility with older LangChain versions)
+        if isinstance(messages, list) and all(isinstance(m, dict) for m in messages):
+            return ChatPromptTemplate.from_messages([(m["role"], m["content"]) for m in messages])
+
         return ChatPromptTemplate.from_messages(messages)
 
     def save(self, data: Any) -> None:

--- a/kedro-datasets/kedro_datasets_experimental/tests/langchain/test_langchain_prompt_dataset.py
+++ b/kedro-datasets/kedro_datasets_experimental/tests/langchain/test_langchain_prompt_dataset.py
@@ -259,8 +259,8 @@ class TestLangChainPromptDataset:
         [
             ({}, "ChatPromptTemplate requires a non-empty list of messages"),
             ([], "ChatPromptTemplate requires a non-empty list of messages"),
-            ([{"role": "user"}], "Expected dict to have exact keys 'role' and 'content'"),
-            ([{"content": "hello"}], "Expected dict to have exact keys 'role' and 'content'"),
+            ([{"role": "user"}], "Failed to create ChatPromptTemplate: 'content"),
+            ([{"content": "hello"}], "Failed to create ChatPromptTemplate: 'role'"),
         ]
     )
     def test_invalid_yaml_chat_prompt(self, tmp_path: Path, bad_data: any, error_pattern: str) -> None:


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->

LangChain <0.3.0's ChatPromptTemplate rejects plain dicts as messages (it expects LangChain Message objects). This is causing some tests to fail when run on older versions.

Explicitly converting dicts to tuples when loading the data into a ChatPromptTemplate solves the issue.

## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Updated `jsonschema/kedro-catalog-X.XX.json` if necessary
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
- [ ] Received approvals from at least half of the TSC (required for adding a new, non-experimental dataset)
