### PR TITLE
chore(airflow): Add support to Python 3.13 to kedro-airflow

### DIFF
--- a/.github/workflows/kedro-airflow.yml
+++ b/.github/workflows/kedro-airflow.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest ]
-        python-version: [ "3.10", "3.11", "3.12" ]
+        python-version: [ "3.10", "3.11", "3.12", "3.13" ]
     uses: ./.github/workflows/unit-tests.yml
     with:
       plugin: kedro-airflow
@@ -43,7 +43,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        python-version: [ "3.10", "3.11", "3.12" ]
+        python-version: [ "3.10", "3.11", "3.12", "3.13" ]
     uses: ./.github/workflows/e2e-tests.yml
     with:
       plugin: kedro-airflow

--- a/kedro-airflow/README.md
+++ b/kedro-airflow/README.md
@@ -1,7 +1,7 @@
 # Kedro-Airflow
 
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![Python Version](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12-blue.svg)](https://pypi.org/project/kedro-airflow/)
+[![Python Version](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13-blue.svg)](https://pypi.org/project/kedro-airflow/)
 [![PyPI Version](https://badge.fury.io/py/kedro-airflow.svg)](https://pypi.org/project/kedro-airflow/)
 [![Code Style: Black](https://img.shields.io/badge/code%20style-black-black.svg)](https://github.com/ambv/black)
 

--- a/kedro-airflow/RELEASE.md
+++ b/kedro-airflow/RELEASE.md
@@ -1,6 +1,7 @@
 # Upcoming Release
 * Update for Kedro 1.0.0 compatibility by using `pipeline.group_nodes_by()` for grouping by namespace or `None`, and applying the new `DataCatalog` API syntax.
 * Dropped support for Python 3.9 (EOL Oct 2025). Minimum supported version is now 3.10.
+* Added support for Python 3.13.
 
 # Release 0.10.0
 * Fixed check whether a dataset is a `MemoryDataset`.

--- a/kedro-airflow/pyproject.toml
+++ b/kedro-airflow/pyproject.toml
@@ -24,8 +24,8 @@ Tracker = "https://github.com/kedro-org/kedro-plugins/issues"
 
 [project.optional-dependencies]
 test = [
-    "apache-airflow<3.0; python_version < 3.13",
-    "apache-airflow~=3.1.3; python_version >= 3.13",
+    "apache-airflow<3.0; python_version < '3.13'",
+    "apache-airflow~=3.1.3; python_version >= '3.13'",
     "behave",
     "coverage>=7.2.0",
     "kedro-datasets",

--- a/kedro-airflow/pyproject.toml
+++ b/kedro-airflow/pyproject.toml
@@ -24,7 +24,7 @@ Tracker = "https://github.com/kedro-org/kedro-plugins/issues"
 
 [project.optional-dependencies]
 test = [
-    "apache-airflow<3.0",
+    "apache-airflow~=3.1.3",
     "behave",
     "coverage>=7.2.0",
     "kedro-datasets",

--- a/kedro-airflow/pyproject.toml
+++ b/kedro-airflow/pyproject.toml
@@ -24,7 +24,8 @@ Tracker = "https://github.com/kedro-org/kedro-plugins/issues"
 
 [project.optional-dependencies]
 test = [
-    "apache-airflow~=3.1.3",
+    "apache-airflow<3.0; python_version < 3.13",
+    "apache-airflow~=3.1.3; python_version >= 3.13",
     "behave",
     "coverage>=7.2.0",
     "kedro-datasets",


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->

Bump up `airflow` version on `kedro-airflow` tests to make it run on Python 3.13.

## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Updated `jsonschema/kedro-catalog-X.XX.json` if necessary
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
- [ ] Received approvals from at least half of the TSC (required for adding a new, non-experimental dataset)
