### PR TITLE
fix(datasets): `nightly-builds` failing

### DIFF
--- a/kedro-datasets/pyproject.toml
+++ b/kedro-datasets/pyproject.toml
@@ -299,7 +299,7 @@ test = [
     "pyodbc~=5.0",
     "pyspark>=3.0, <4.0; python_version < '3.11'",
     "pyspark>=3.4, <4.0; python_version == '3.11'",
-    "pyspark>=4.0, <4.1; python_version >= '3.12'",
+    "pyspark>=4.0, <4.1; python_version >= '3.12'",  # Temporary pin till delta-spark is compatible
     "pytest-cov~=3.0",
     "pytest-mock>=1.7.1, <2.0",
     "pytest-xdist[psutil]~=2.2.1",


### PR DESCRIPTION
## Description
Fix https://github.com/kedro-org/kedro-plugins/issues/1267

Nightly builds started failing on Dec 17 due to PySpark 4.1.0 being released on Dec 16 and picked up by an unbounded dependency. delta-spark is still on 4.0.0 and not yet compatible with PySpark 4.1.0

Change
- Pin PySpark to <4.1 for Python ≥3.12 to restore compatibility with delta-spark 4.0.0.

Short-term vs Long-term
- Short-term (this PR): Pin PySpark to avoid the breaking upgrade.
- Long-term: Once delta-spark releases a PySpark 4.1+ compatible version, upgrade both dependencies and remove the PySpark upper bound.

## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Updated `jsonschema/kedro-catalog-X.XX.json` if necessary
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
- [ ] Received approvals from at least half of the TSC (required for adding a new, non-experimental dataset)
