### PR TITLE
fix(datasets): Skip network-dependent `HFDataset` loading in doctests

### DIFF
--- a/kedro-datasets/kedro_datasets/huggingface/hugging_face_dataset.py
+++ b/kedro-datasets/kedro_datasets/huggingface/hugging_face_dataset.py
@@ -28,9 +28,10 @@ class HFDataset(AbstractDataset):
         >>> disable_progress_bar()  # for doctest to pass
         >>> set_verbosity(ERROR)  # for doctest to pass
         >>>
-        >>> dataset = HFDataset(dataset_name="yelp_review_full")
-        >>> ds = dataset.load()
-
+        >>> dataset = HFDataset(dataset_name="openai_humaneval")
+        >>> ds = dataset.load()  # doctest: +SKIP
+        >>> assert "test" in ds  # doctest: +SKIP
+        >>> assert len(ds["test"]) == 164  # doctest: +SKIP
     """
 
     def __init__(


### PR DESCRIPTION
## Description
This PR updates the `HFDataset` docstring examples to avoid executing network-dependent code during doctest runs.

Loading Hugging Face datasets requires external network access and valid SSL configuration. In CI environments (and some local setups), this can fail due to SSL certificate verification or restricted network access, causing doctest failures.

To make the documentation examples robust and CI-safe, the dataset loading and assertions are now marked with 
`# doctest: +SKIP`. The example remains fully visible and runnable for users in environments with internet access, while avoiding flaky test failures in automated environments.

## Development notes
Also downstream issue was opened for proper investigation, as similar behaviour can be reproduced locally: https://github.com/kedro-org/kedro-plugins/issues/1294

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Updated `jsonschema/kedro-catalog-X.XX.json` if necessary
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
- [ ] Received approvals from at least half of the TSC (required for adding a new, non-experimental dataset)
