### PR TITLE
chore(datasets): Unpin `triad` and `sqlglot`

### DIFF
--- a/kedro-datasets/pyproject.toml
+++ b/kedro-datasets/pyproject.toml
@@ -334,7 +334,6 @@ test = [
     "transformers[torch]",
 ]
 
-
 # Lint requirements
 lint = [
     "bandit>=1.6.2, <2.0",


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
Fix for nightly build https://github.com/kedro-org/kedro-plugins/issues/1296

## Development notes
* Unpin `sqlglot` which was pinned in #1235 because of an upstream issue which has been fixed since
* Unpin `triad`: `dask.ParquetDataset` which uses `triad` which was pinned to `<1.0`. The failures were because of the new release of `setuptools` which gets rid of `pkg_resources`. The problem was that `triad` uses `fs` which is an abandoned project which was using `pkg_resources`. `triad` got rid of its dependency on `fs` in the newer versions >= 1.0.

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Updated `jsonschema/kedro-catalog-X.XX.json` if necessary
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
- [ ] Received approvals from at least half of the TSC (required for adding a new, non-experimental dataset)
