### PR TITLE
fix(datasets): Pin delta-spark upper bound to 4.1

### DIFF
--- a/kedro-datasets/pyproject.toml
+++ b/kedro-datasets/pyproject.toml
@@ -274,7 +274,7 @@ test = [
     "dask[complete]>=2021.10",
     "deltalake>=0.10.0",
     "delta-spark>=1.0, <3.0; python_version <= '3.11'",
-    "delta-spark>=4.0; python_version >= '3.12'",
+    "delta-spark>=4.0, <4.1; python_version >= '3.12'",
     "dill~=0.3.1",
     "filelock>=3.4.0, <4.0",
     "fiona >=1.8, <2.0",
@@ -380,7 +380,7 @@ experimental = [
 
 experimental_test = [
     "delta-spark>=1.0, <3.0; python_version <= '3.11'",
-    "delta-spark>=4.0; python_version >= '3.12'",
+    "delta-spark>=4.0, <4.1; python_version >= '3.12'",
     "langchain-openai",
     "langchain-cohere",
     "langchain-anthropic",


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->

`delta-spark 4.1.0` was released [last Friday (20/02/2026)](https://pypi.org/project/delta-spark/4.1.0/) and is incompatible with pyspark 4.0.x. It was compiled against a PySpark 4.1 internal API `(ParserInterface.$init$)` that does not exist in PySpark 4.0, causing a `NoSuchMethodError` when any Delta Lake Spark extension is loaded:

```py
java.lang.NoSuchMethodError: 'void org.apache.spark.sql.catalyst.parser.ParserInterface.$init$(org.apache.spark.sql.catalyst.parser.ParserInterface)'
    at io.delta.sql.parser.DeltaSqlParser.<init>(DeltaSqlParser.scala:75)
```

The current pyproject.toml has `pyspark>=4.0, <4.1` in the test dependencies (already anticipating this, with the comment "Temporary pin till delta-spark is compatible") but `delta-spark>=4.0` with no upper limit.

## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Updated `jsonschema/kedro-catalog-X.XX.json` if necessary
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
- [ ] Received approvals from at least half of the TSC (required for adding a new, non-experimental dataset)
