### PR TITLE
chore: UPDATE biosequence, message and geopandas datasets use of os.PathLike

### DIFF
--- a/kedro-datasets/kedro_datasets/biosequence/biosequence_dataset.py
+++ b/kedro-datasets/kedro_datasets/biosequence/biosequence_dataset.py
@@ -3,12 +3,12 @@ file.
 """
 from __future__ import annotations
 
+import os
 from copy import deepcopy
 from pathlib import PurePosixPath
 from typing import Any
 
 import fsspec
-import os
 from Bio import SeqIO
 from kedro.io.core import AbstractDataset, get_filepath_str, get_protocol_and_path
 

--- a/kedro-datasets/kedro_datasets/email/message_dataset.py
+++ b/kedro-datasets/kedro_datasets/email/message_dataset.py
@@ -4,6 +4,7 @@ using an underlying filesystem (e.g.: local, S3, GCS). It uses the
 """
 from __future__ import annotations
 
+import os
 from copy import deepcopy
 from email.generator import Generator
 from email.message import Message
@@ -13,7 +14,6 @@ from pathlib import PurePosixPath
 from typing import Any
 
 import fsspec
-import os
 from kedro.io.core import (
     AbstractVersionedDataset,
     DatasetError,

--- a/kedro-datasets/kedro_datasets/geopandas/generic_dataset.py
+++ b/kedro-datasets/kedro_datasets/geopandas/generic_dataset.py
@@ -11,7 +11,6 @@ from pathlib import PurePosixPath
 from typing import Any
 
 import fsspec
-import os
 import geopandas as gpd
 from kedro.io.core import (
     AbstractVersionedDataset,


### PR DESCRIPTION
## Description
Solves part of #1316. Updates the filepath type hint from str to str | os.PathLike for the following Datasets:

BioSequence
Email
Geopandas

## Development notes
Unit tests working for the changes implemented.

## Checklist

- [X] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Updated `jsonschema/kedro-catalog-X.XX.json` if necessary
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
- [ ] Received approvals from at least half of the TSC (required for adding a new, non-experimental dataset)
