### PR TITLE
fix(airflow): fix KedroSession type causing mypy error.

### DIFF
--- a/kedro-airflow/kedro_airflow/plugin.py
+++ b/kedro-airflow/kedro_airflow/plugin.py
@@ -163,7 +163,8 @@ def create(  # noqa: PLR0913, PLR0912
         raise click.BadParameter(
             "The `--all` and `--pipeline` option are mutually exclusive."
         )
-    with KedroSession.create(project_path=metadata.project_path, env=env) as session:
+    session = KedroSession.create(project_path=metadata.project_path, env=env)
+    with session:
         context = session.load_context()
         config_airflow = _load_config(context)
 


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->

Attempt to correct this error causing a build failure: https://github.com/kedro-org/kedro-plugins/actions/runs/24320109004/job/71169621033

The lint CI installs kedro from the Kedro main branch, and I believe the [recent changes to the KedroSession](https://github.com/kedro-org/kedro/pull/5441) might have led mypy to resolve `session` inside with `KedroSession.create(...)` as AbstractSession, which has no load_context        
  attribute, causing the mypy failure. 

The fix separates the create() call from the `with` statement. Since `KedroSession.create()` is explicitly annotated as `-> KedroSession`, assigning it to a variable first preserves that type through the with block, regardless of what `__enter__` returns.

## Development notes
<!-- What have you changed, and how has this been tested? -->

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Updated `jsonschema/kedro-catalog-X.XX.json` if necessary
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
- [ ] Received approvals from at least half of the TSC (required for adding a new, non-experimental dataset)
