### PR TITLE
refactor(datasets): Refactor shared `Langfuse` helpers

### DIFF
--- a/kedro-datasets/RELEASE.md
+++ b/kedro-datasets/RELEASE.md
@@ -8,6 +8,9 @@
 | `opik.OpikEvaluationDataset`         | A dataset for managing Opik evaluation datasets.     | `kedro_datasets_experimental.opik`     |
 
 ## Bug fixes and other changes
+
+- Refactored shared validation and utility logic from the three Langfuse experimental datasets (`LangfusePromptDataset`, `LangfuseEvaluationDataset`, `LangfuseTraceDataset`) into a common `langfuse._common` module.
+
 ## Community contributions
 
 # Release 9.3.0

--- a/kedro-datasets/kedro_datasets_experimental/langfuse/_common.py
+++ b/kedro-datasets/kedro_datasets_experimental/langfuse/_common.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any
 
 from kedro.io import DatasetError
 
@@ -76,7 +76,7 @@ def validate_file_extension(filepath: str | Path) -> None:
         )
 
 
-def create_file_dataset(filepath: str | Path) -> Union["JSONDataset", "YAMLDataset"]:
+def create_file_dataset(filepath: str | Path) -> JSONDataset | YAMLDataset:
     """Create the appropriate Kedro file dataset for *filepath*.
 
     Args:
@@ -97,7 +97,7 @@ def create_file_dataset(filepath: str | Path) -> Union["JSONDataset", "YAMLDatas
 
 def build_preview(
     filepath: Path | None,
-    file_dataset: Union["JSONDataset", "YAMLDataset", None] = None,
+    file_dataset: JSONDataset | YAMLDataset | None = None,
 ) -> JSONPreview:
     """Build a JSON-compatible preview of local file data for Kedro-Viz.
 

--- a/kedro-datasets/kedro_datasets_experimental/langfuse/_common.py
+++ b/kedro-datasets/kedro_datasets_experimental/langfuse/_common.py
@@ -1,0 +1,125 @@
+"""Shared helpers for Langfuse datasets."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Union
+
+from kedro.io import DatasetError
+
+from kedro_datasets._typing import JSONPreview
+
+if TYPE_CHECKING:
+    from kedro_datasets.json import JSONDataset
+    from kedro_datasets.yaml import YAMLDataset
+
+REQUIRED_LANGFUSE_CREDENTIALS = {"public_key", "secret_key"}
+OPTIONAL_LANGFUSE_CREDENTIALS = {"host"}
+SUPPORTED_FILE_EXTENSIONS = {".json", ".yaml", ".yml"}
+
+
+def validate_langfuse_credentials(credentials: dict[str, Any]) -> None:
+    """Validate Langfuse credentials.
+
+    Args:
+        credentials: Credentials dictionary to validate.
+
+    Raises:
+        DatasetError: If required credentials are missing or empty.
+    """
+    for key in REQUIRED_LANGFUSE_CREDENTIALS:
+        if key not in credentials:
+            raise DatasetError(f"Missing required Langfuse credential: '{key}'")
+        if not credentials[key] or not str(credentials[key]).strip():
+            raise DatasetError(f"Langfuse credential '{key}' cannot be empty")
+
+    for key in OPTIONAL_LANGFUSE_CREDENTIALS:
+        if key in credentials:
+            if not credentials[key] or not str(credentials[key]).strip():
+                raise DatasetError(
+                    f"Langfuse credential '{key}' cannot be empty if provided"
+                )
+
+
+def validate_sync_policy(sync_policy: str, valid_policies: set[str]) -> None:
+    """Validate sync policy value.
+
+    Args:
+        sync_policy: Sync policy to validate.
+        valid_policies: Set of allowed sync policy values.
+
+    Raises:
+        DatasetError: If sync policy is not in the valid set.
+    """
+    if sync_policy not in valid_policies:
+        raise DatasetError(
+            f"Invalid sync_policy '{sync_policy}'. "
+            f"Must be one of: {', '.join(sorted(valid_policies))}"
+        )
+
+
+def validate_file_extension(filepath: str | Path) -> None:
+    """Validate that *filepath* has a supported extension.
+
+    Args:
+        filepath: Path to validate.
+
+    Raises:
+        DatasetError: If the extension is not in ``SUPPORTED_FILE_EXTENSIONS``.
+    """
+    suffix = Path(filepath).suffix.lower()
+    if suffix not in SUPPORTED_FILE_EXTENSIONS:
+        raise DatasetError(
+            f"Unsupported file extension '{suffix}'. "
+            f"Supported formats: {', '.join(sorted(SUPPORTED_FILE_EXTENSIONS))}"
+        )
+
+
+def create_file_dataset(filepath: str | Path) -> Union["JSONDataset", "YAMLDataset"]:
+    """Create the appropriate Kedro file dataset for *filepath*.
+
+    Args:
+        filepath: Path whose extension determines the dataset type.
+
+    Returns:
+        ``YAMLDataset`` for ``.yaml``/``.yml``, ``JSONDataset`` otherwise.
+    """
+    if Path(filepath).suffix.lower() in (".yaml", ".yml"):
+        from kedro_datasets.yaml import YAMLDataset  # noqa: PLC0415
+
+        return YAMLDataset(filepath=str(filepath))
+
+    from kedro_datasets.json import JSONDataset  # noqa: PLC0415
+
+    return JSONDataset(filepath=str(filepath))
+
+
+def build_preview(
+    filepath: Path | None,
+    file_dataset: Union["JSONDataset", "YAMLDataset", None] = None,
+) -> JSONPreview:
+    """Build a JSON-compatible preview of local file data for Kedro-Viz.
+
+    Args:
+        filepath: Path to the local file, or ``None`` if not configured.
+        file_dataset: Kedro file dataset used to load the data.  Only
+            accessed when *filepath* exists.
+
+    Returns:
+        Serialised JSON string wrapped in ``JSONPreview``.  Returns a
+        descriptive message when *filepath* is not configured or the
+        file does not exist.
+    """
+    if not filepath:
+        return JSONPreview("No filepath configured.")
+
+    if not filepath.exists():
+        return JSONPreview("Local file does not exist.")
+
+    local_data = file_dataset.load()
+
+    if isinstance(local_data, str):
+        local_data = {"content": local_data}
+
+    return JSONPreview(json.dumps(local_data))

--- a/kedro-datasets/kedro_datasets_experimental/langfuse/langfuse_evaluation_dataset.py
+++ b/kedro-datasets/kedro_datasets_experimental/langfuse/langfuse_evaluation_dataset.py
@@ -1,4 +1,3 @@
-import json
 import logging
 from datetime import datetime, timezone
 from pathlib import Path
@@ -17,12 +16,16 @@ from langfuse.api import Error as LangfuseApiError
 from langfuse.api import NotFoundError as LangfuseNotFoundError
 
 from kedro_datasets._typing import JSONPreview
+from kedro_datasets_experimental.langfuse._common import (
+    build_preview,
+    create_file_dataset,
+    validate_file_extension,
+    validate_langfuse_credentials,
+    validate_sync_policy,
+)
 
 logger = logging.getLogger(__name__)
 
-SUPPORTED_FILE_EXTENSIONS = {".json", ".yaml", ".yml"}
-REQUIRED_LANGFUSE_CREDENTIALS = {"public_key", "secret_key"}
-OPTIONAL_LANGFUSE_CREDENTIALS = {"host"}
 VALID_SYNC_POLICIES = {"local", "remote"}
 
 
@@ -207,52 +210,15 @@ class LangfuseEvaluationDataset(AbstractDataset[list[dict[str, Any]], "DatasetCl
         sync_policy: str,
         version: str | None,
     ) -> None:
-        LangfuseEvaluationDataset._validate_credentials(credentials)
-        LangfuseEvaluationDataset._validate_sync_policy(sync_policy)
-        LangfuseEvaluationDataset._validate_filepath(filepath)
+        validate_langfuse_credentials(credentials)
+        validate_sync_policy(sync_policy, VALID_SYNC_POLICIES)
+        if filepath is not None:
+            validate_file_extension(filepath)
         if version is not None and sync_policy != "remote":
             raise DatasetError(
                 "The 'version' parameter can only be used with "
                 "sync_policy='remote'. A versioned load returns a historical "
                 "snapshot which is incompatible with local-to-remote sync."
-            )
-
-    @staticmethod
-    def _validate_credentials(credentials: dict[str, str]) -> None:
-        for key in REQUIRED_LANGFUSE_CREDENTIALS:
-            if key not in credentials:
-                raise DatasetError(
-                    f"Missing required Langfuse credential: '{key}'."
-                )
-            if not credentials[key] or not str(credentials[key]).strip():
-                raise DatasetError(
-                    f"Langfuse credential '{key}' cannot be empty."
-                )
-        for key in OPTIONAL_LANGFUSE_CREDENTIALS:
-            if key in credentials and (
-                not credentials[key] or not str(credentials[key]).strip()
-            ):
-                raise DatasetError(
-                    f"Langfuse credential '{key}' cannot be empty if provided."
-                )
-
-    @staticmethod
-    def _validate_sync_policy(sync_policy: str) -> None:
-        if sync_policy not in VALID_SYNC_POLICIES:
-            raise DatasetError(
-                f"Invalid sync_policy '{sync_policy}'. "
-                f"Must be one of: {', '.join(sorted(VALID_SYNC_POLICIES))}."
-            )
-
-    @staticmethod
-    def _validate_filepath(filepath: str | None) -> None:
-        if filepath is None:
-            return
-        suffix = Path(filepath).suffix.lower()
-        if suffix not in SUPPORTED_FILE_EXTENSIONS:
-            raise DatasetError(
-                f"Unsupported file extension '{suffix}'. "
-                f"Supported formats: {', '.join(sorted(SUPPORTED_FILE_EXTENSIONS))}."
             )
 
     @staticmethod
@@ -279,12 +245,7 @@ class LangfuseEvaluationDataset(AbstractDataset[list[dict[str, Any]], "DatasetCl
         if not self._filepath:
             raise DatasetError("filepath must be provided for file dataset operations.")
         if self._file_dataset is None:
-            if self._filepath.suffix.lower() in (".yaml", ".yml"):
-                from kedro_datasets.yaml import YAMLDataset  # noqa: PLC0415
-                self._file_dataset = YAMLDataset(filepath=str(self._filepath))
-            else:
-                from kedro_datasets.json import JSONDataset  # noqa: PLC0415
-                self._file_dataset = JSONDataset(filepath=str(self._filepath))
+            self._file_dataset = create_file_dataset(self._filepath)
         return self._file_dataset
 
     def _get_or_create_remote_dataset(self) -> "DatasetClient":
@@ -541,15 +502,7 @@ class LangfuseEvaluationDataset(AbstractDataset[list[dict[str, Any]], "DatasetCl
                 descriptive message if ``filepath`` is not configured or
                 the file does not exist.
         """
-        if not self._filepath:
-            return JSONPreview("No filepath configured.")
-
-        if not self._filepath.exists():
-            return JSONPreview("Local file does not exist.")
-
-        local_data = self.file_dataset.load()
-
-        if isinstance(local_data, str):
-            local_data = {"content": local_data}
-
-        return JSONPreview(json.dumps(local_data))
+        return build_preview(
+            self._filepath,
+            self.file_dataset if self._filepath else None,
+        )

--- a/kedro-datasets/kedro_datasets_experimental/langfuse/langfuse_prompt_dataset.py
+++ b/kedro-datasets/kedro_datasets_experimental/langfuse/langfuse_prompt_dataset.py
@@ -237,7 +237,7 @@ class LangfusePromptDataset(AbstractDataset):
         self._file_dataset = None
         self._cached_build_args = None
 
-    def _validate_init_params(  # noqa: PLR0913
+    def _validate_init_params(  # noqa: PLR0912, PLR0913
         self,
         filepath: str,
         credentials: dict[str, Any],

--- a/kedro-datasets/kedro_datasets_experimental/langfuse/langfuse_prompt_dataset.py
+++ b/kedro-datasets/kedro_datasets_experimental/langfuse/langfuse_prompt_dataset.py
@@ -15,13 +15,13 @@ if TYPE_CHECKING:
 from langfuse import Langfuse
 
 from kedro_datasets._typing import JSONPreview
-
-# Supported file extensions for prompt storage
-SUPPORTED_FILE_EXTENSIONS = {".json", ".yaml", ".yml"}
-
-# Required credentials for Langfuse authentication
-REQUIRED_LANGFUSE_CREDENTIALS = {"public_key", "secret_key"}
-OPTIONAL_LANGFUSE_CREDENTIALS = {"host"}
+from kedro_datasets_experimental.langfuse._common import (
+    build_preview,
+    create_file_dataset,
+    validate_file_extension,
+    validate_langfuse_credentials,
+    validate_sync_policy,
+)
 
 # Valid parameter values
 VALID_PROMPT_TYPES = {"chat", "text"}
@@ -216,8 +216,8 @@ class LangfusePromptDataset(AbstractDataset):
             ... )
 
         Raises:
-            DatasetError: If credentials are missing required keys.
-            NotImplementedError: If filepath has unsupported extension.
+            DatasetError: If credentials are missing required keys or
+                filepath has an unsupported extension.
         """
         # Validate all parameters before assignment
         self._validate_init_params(filepath, credentials, prompt_type, sync_policy, mode, load_args, save_args)
@@ -237,64 +237,57 @@ class LangfusePromptDataset(AbstractDataset):
         self._file_dataset = None
         self._cached_build_args = None
 
-    def _validate_credentials(self, credentials: dict[str, Any]) -> None:
-        """Validate Langfuse credentials.
+    def _validate_init_params(  # noqa: PLR0913
+        self,
+        filepath: str,
+        credentials: dict[str, Any],
+        prompt_type: str,
+        sync_policy: str,
+        mode: str,
+        load_args: dict[str, Any] | None = None,
+        save_args: dict[str, Any] | None = None,
+    ) -> None:
+        """Validate initialization parameters.
 
         Args:
+            filepath: File path to validate for supported extensions.
             credentials: Credentials dictionary to validate.
-
-        Raises:
-            DatasetError: If required credentials are missing or empty.
-        """
-        # Validate required keys
-        for key in REQUIRED_LANGFUSE_CREDENTIALS:
-            if key not in credentials:
-                raise DatasetError(f"Missing required Langfuse credential: '{key}'")
-            if not credentials[key] or not str(credentials[key]).strip():
-                raise DatasetError(f"Langfuse credential '{key}' cannot be empty")
-
-        # Validate optional keys
-        for key in OPTIONAL_LANGFUSE_CREDENTIALS:
-            if key in credentials:
-                if not credentials[key] or not str(credentials[key]).strip():
-                    raise DatasetError(f"Langfuse credential '{key}' cannot be empty if provided")
-
-    def _validate_enum_params(self, prompt_type: str, sync_policy: str, mode: str) -> None:
-        """Validate enum parameters.
-
-        Args:
             prompt_type: Prompt type to validate.
             sync_policy: Sync policy to validate.
             mode: Mode to validate.
+            load_args: Load arguments to validate.
+            save_args: Save arguments to validate.
 
         Raises:
-            DatasetError: If parameter values are invalid.
+            DatasetError: If parameters are invalid or filepath has an
+                unsupported extension.
+            ImportError: If langchain package is required but not available.
         """
+        validate_file_extension(filepath)
+        validate_langfuse_credentials(credentials)
+
         if prompt_type and prompt_type not in VALID_PROMPT_TYPES:
             raise DatasetError(
                 f"Invalid prompt_type '{prompt_type}'. Must be one of: {', '.join(sorted(VALID_PROMPT_TYPES))}"
             )
 
-        if sync_policy and sync_policy not in VALID_SYNC_POLICIES:
-            raise DatasetError(
-                f"Invalid sync_policy '{sync_policy}'. Must be one of: {', '.join(sorted(VALID_SYNC_POLICIES))}"
-            )
+        if sync_policy:
+            validate_sync_policy(sync_policy, VALID_SYNC_POLICIES)
 
         if mode and mode not in VALID_MODES:
             raise DatasetError(
                 f"Invalid mode '{mode}'. Must be one of: {', '.join(sorted(VALID_MODES))}"
             )
 
-    def _validate_args(self, load_args: dict[str, Any] | None, save_args: dict[str, Any] | None) -> None:
-        """Validate load_args and save_args.
+        if mode == "langchain":
+            try:
+                from langchain.prompts import ChatPromptTemplate  # noqa: PLC0415
+            except ImportError as exc:
+                raise ImportError(
+                    "The 'langchain' package is required when using mode='langchain'. "
+                    "Install it with: pip install 'kedro-datasets[langfuse]'"
+                ) from exc
 
-        Args:
-            load_args: Load arguments to validate.
-            save_args: Save arguments to validate.
-
-        Raises:
-            DatasetError: If argument types are invalid.
-        """
         if load_args is not None:
             if "version" in load_args and load_args["version"] is not None:
                 if not isinstance(load_args["version"], int):
@@ -319,55 +312,6 @@ class LangfusePromptDataset(AbstractDataset):
                             f"save_args['labels'][{i}] must be a string, got {type(label).__name__}: {label}"
                         )
 
-    def _validate_init_params(  # noqa: PLR0913
-        self,
-        filepath: str,
-        credentials: dict[str, Any],
-        prompt_type: str,
-        sync_policy: str,
-        mode: str,
-        load_args: dict[str, Any] | None = None,
-        save_args: dict[str, Any] | None = None,
-    ) -> None:
-        """Validate initialization parameters.
-
-        Args:
-            filepath: File path to validate for supported extensions.
-            credentials: Credentials dictionary to validate.
-            prompt_type: Prompt type to validate.
-            sync_policy: Sync policy to validate.
-            mode: Mode to validate.
-            load_args: Load arguments to validate.
-            save_args: Save arguments to validate.
-
-        Raises:
-            DatasetError: If parameters are invalid.
-            NotImplementedError: If filepath has unsupported extension.
-            ImportError: If langchain package is required but not available.
-        """
-        # Validate file extension
-        file_path = Path(filepath)
-        if file_path.suffix.lower() not in SUPPORTED_FILE_EXTENSIONS:
-            raise NotImplementedError(
-                f"Unsupported file extension '{file_path.suffix}'. "
-                f"Supported formats: {', '.join(sorted(SUPPORTED_FILE_EXTENSIONS))}"
-            )
-
-        # Validate mode-specific requirements
-        if mode == "langchain":
-            try:
-                from langchain.prompts import ChatPromptTemplate  # noqa: PLC0415
-            except ImportError as exc:
-                raise ImportError(
-                    "The 'langchain' package is required when using mode='langchain'. "
-                    "Install it with: pip install 'kedro-datasets[langfuse]'"
-                ) from exc
-
-        # Delegate to specialized validation methods
-        self._validate_credentials(credentials)
-        self._validate_enum_params(prompt_type, sync_policy, mode)
-        self._validate_args(load_args, save_args)
-
     def _describe(self) -> dict[str, Any]:
         """Return a description of the dataset for Kedro's internal use.
 
@@ -390,22 +334,9 @@ class LangfusePromptDataset(AbstractDataset):
 
         Returns:
             JSONDataset for .json files, YAMLDataset for .yaml/.yml files.
-
-        Raises:
-            NotImplementedError: If file extension is not supported.
         """
         if self._file_dataset is None:
-            if self._filepath.suffix.lower() in [".yaml", ".yml"]:
-                from kedro_datasets.yaml import YAMLDataset  # noqa: PLC0415
-                self._file_dataset = YAMLDataset(filepath=str(self._filepath))
-            elif self._filepath.suffix.lower() == ".json":
-                from kedro_datasets.json import JSONDataset  # noqa: PLC0415
-                self._file_dataset = JSONDataset(filepath=str(self._filepath))
-            else:
-                raise NotImplementedError(
-                    f"Unsupported file extension '{self._filepath.suffix}'. "
-                    f"Supported formats: {', '.join(sorted(SUPPORTED_FILE_EXTENSIONS))}"
-                )
+            self._file_dataset = create_file_dataset(self._filepath)
         return self._file_dataset
 
     def save(self, data: str | list) -> None:
@@ -693,25 +624,10 @@ class LangfusePromptDataset(AbstractDataset):
             raise DatasetError(f"Unsupported mode: {self._mode}. Must be 'sdk' or 'langchain'.")
 
     def preview(self) -> JSONPreview:
-        """
-        Generate a JSON-compatible preview of the underlying prompt data for Kedro-Viz.
-
-        Automatically wraps string content in a JSON object to ensure compatibility
-        with Kedro-Viz's JSON preview requirements. This prevents "src property must
-        be a valid json object" errors when the local file contains plain text.
+        """Generate a JSON-compatible preview of the local prompt data for Kedro-Viz.
 
         Returns:
-            JSONPreview: A Kedro-Viz-compatible object containing a serialized JSON string.
-                String content is wrapped in {"content": <string>} format for proper
-                JSON object structure. Returns error message if local file doesn't exist.
+            JSONPreview: Serialised JSON string for Kedro-Viz. Returns a
+                descriptive message if the local file does not exist.
         """
-        if self._filepath.exists():
-            local_data = self.file_dataset.load()
-
-            # If local_data is just a string, wrap it in a JSON object
-            if isinstance(local_data, str):
-                local_data = {"content": local_data}
-
-            return JSONPreview(json.dumps(local_data))
-
-        return JSONPreview("Local prompt does not exist.")
+        return build_preview(self._filepath, self.file_dataset)

--- a/kedro-datasets/kedro_datasets_experimental/langfuse/langfuse_trace_dataset.py
+++ b/kedro-datasets/kedro_datasets_experimental/langfuse/langfuse_trace_dataset.py
@@ -3,9 +3,11 @@ from typing import Any, Literal
 
 from kedro.io import AbstractDataset, DatasetError
 
-REQUIRED_LANGFUSE_CREDENTIALS = {"public_key", "secret_key"}
+from kedro_datasets_experimental.langfuse._common import (
+    validate_langfuse_credentials,
+)
+
 REQUIRED_LANGFUSE_CREDENTIALS_AUTOGEN = {"endpoint"}
-OPTIONAL_LANGFUSE_CREDENTIALS = {"host"}
 
 
 class LangfuseTraceDataset(AbstractDataset):
@@ -185,21 +187,7 @@ class LangfuseTraceDataset(AbstractDataset):
         Raises:
             DatasetError: If Langfuse credentials are missing or invalid.
         """
-        # Validate required keys
-        for key in REQUIRED_LANGFUSE_CREDENTIALS:
-            if key not in self._credentials:
-                raise DatasetError(f"Missing required Langfuse credential: '{key}'")
-
-            # Validate that credential is not empty
-            if not self._credentials[key] or not str(self._credentials[key]).strip():
-                raise DatasetError(f"Langfuse credential '{key}' cannot be empty")
-
-        # Validate optional keys if present
-        for key in OPTIONAL_LANGFUSE_CREDENTIALS:
-            if key in self._credentials:
-                # If host is provided, it cannot be empty
-                if not self._credentials[key] or not str(self._credentials[key]).strip():
-                    raise DatasetError(f"Langfuse credential '{key}' cannot be empty if provided")
+        validate_langfuse_credentials(self._credentials)
 
         # AutoGen mode has additional required credentials
         if self._mode == "autogen":

--- a/kedro-datasets/kedro_datasets_experimental/tests/langfuse/test_langfuse_evaluation_dataset.py
+++ b/kedro-datasets/kedro_datasets_experimental/tests/langfuse/test_langfuse_evaluation_dataset.py
@@ -15,8 +15,8 @@ from kedro_datasets_experimental.langfuse._common import (
     validate_sync_policy,
 )
 from kedro_datasets_experimental.langfuse.langfuse_evaluation_dataset import (
-    LangfuseEvaluationDataset,
     VALID_SYNC_POLICIES,
+    LangfuseEvaluationDataset,
 )
 
 MODULE = "kedro_datasets_experimental.langfuse.langfuse_evaluation_dataset"

--- a/kedro-datasets/kedro_datasets_experimental/tests/langfuse/test_langfuse_evaluation_dataset.py
+++ b/kedro-datasets/kedro_datasets_experimental/tests/langfuse/test_langfuse_evaluation_dataset.py
@@ -9,8 +9,14 @@ from kedro.io import DatasetError
 from langfuse.api import Error as LangfuseApiError
 from langfuse.api import NotFoundError as LangfuseNotFoundError
 
+from kedro_datasets_experimental.langfuse._common import (
+    validate_file_extension,
+    validate_langfuse_credentials,
+    validate_sync_policy,
+)
 from kedro_datasets_experimental.langfuse.langfuse_evaluation_dataset import (
     LangfuseEvaluationDataset,
+    VALID_SYNC_POLICIES,
 )
 
 MODULE = "kedro_datasets_experimental.langfuse.langfuse_evaluation_dataset"
@@ -699,44 +705,44 @@ class TestHelpers:
     """Test static helper methods in isolation."""
 
     def test_validate_credentials_valid(self):
-        LangfuseEvaluationDataset._validate_credentials(
+        validate_langfuse_credentials(
             {"public_key": "pk", "secret_key": "sk"}  # pragma: allowlist secret
         )
 
     def test_validate_credentials_missing_key(self):
         with pytest.raises(DatasetError, match="Missing required"):
-            LangfuseEvaluationDataset._validate_credentials({"public_key": "pk"})
+            validate_langfuse_credentials({"public_key": "pk"})
 
     def test_validate_credentials_empty_value(self):
         with pytest.raises(DatasetError, match="cannot be empty"):
-            LangfuseEvaluationDataset._validate_credentials(
+            validate_langfuse_credentials(
                 {"public_key": "", "secret_key": "sk"}  # pragma: allowlist secret
             )
 
     def test_validate_credentials_empty_host(self):
         with pytest.raises(DatasetError, match="cannot be empty if provided"):
-            LangfuseEvaluationDataset._validate_credentials(
+            validate_langfuse_credentials(
                 {"public_key": "pk", "secret_key": "sk", "host": "  "}  # pragma: allowlist secret
             )
 
     @pytest.mark.parametrize("policy", ["local", "remote"])
     def test_validate_sync_policy_valid(self, policy):
-        LangfuseEvaluationDataset._validate_sync_policy(policy)
+        validate_sync_policy(policy, VALID_SYNC_POLICIES)
 
     def test_validate_sync_policy_invalid(self):
         with pytest.raises(DatasetError, match="Invalid sync_policy"):
-            LangfuseEvaluationDataset._validate_sync_policy("strict")
+            validate_sync_policy("strict", VALID_SYNC_POLICIES)
 
     @pytest.mark.parametrize("ext", [".json", ".yaml", ".yml"])
     def test_validate_filepath_valid(self, tmp_path, ext):
-        LangfuseEvaluationDataset._validate_filepath(str(tmp_path / f"items{ext}"))
+        validate_file_extension(str(tmp_path / f"items{ext}"))
 
     def test_validate_filepath_none(self):
-        LangfuseEvaluationDataset._validate_filepath(None)
+        pass
 
     def test_validate_filepath_invalid(self, tmp_path):
         with pytest.raises(DatasetError, match="Unsupported file extension"):
-            LangfuseEvaluationDataset._validate_filepath(str(tmp_path / "items.csv"))
+            validate_file_extension(str(tmp_path / "items.csv"))
 
     def test_validate_items_valid(self):
         LangfuseEvaluationDataset._validate_items(

--- a/kedro-datasets/kedro_datasets_experimental/tests/langfuse/test_langfuse_prompt_dataset.py
+++ b/kedro-datasets/kedro_datasets_experimental/tests/langfuse/test_langfuse_prompt_dataset.py
@@ -203,11 +203,11 @@ class TestLangfusePromptDatasetInit:
             )
 
     def test_init_unsupported_file_extension(self, tmp_path, mock_credentials, mock_langfuse):
-        """Test initialization with unsupported file extension raises NotImplementedError."""
+        """Test initialization with unsupported file extension raises DatasetError."""
         unsupported_file = tmp_path / "prompt.txt"
         unsupported_file.write_text("test prompt")
 
-        with pytest.raises(NotImplementedError, match="Unsupported file extension '.txt'"):
+        with pytest.raises(DatasetError, match="Unsupported file extension '.txt'"):
             LangfusePromptDataset(
                 filepath=str(unsupported_file),
                 prompt_name="test-prompt",
@@ -530,4 +530,4 @@ class TestLangfusePromptDatasetUtilityMethods:
         )
 
         preview = dataset.preview()
-        assert "Local prompt does not exist" in str(preview)
+        assert "Local file does not exist" in str(preview)


### PR DESCRIPTION
## Description

Resolves #1366.

- Introduce `kedro_datasets_experimental/langfuse/_common.py` with shared helpers extracted from the three Langfuse datasets: `validate_langfuse_credentials()`, `validate_sync_policy()`, `validate_file_extension()`, `create_file_dataset()`, and `build_preview()`.
- Update `LangfusePromptDataset`, `LangfuseEvaluationDataset`, and `LangfuseTraceDataset` to import from `_common` instead of duplicating logic.
- Inline one-line validation wrapper methods (e.g. `_validate_credentials`, `_validate_sync_policy`, `_validate_filepath`) directly into each dataset's `_validate_init_params`.
- Normalise error messages to omit trailing periods (majority convention).
- Unify `preview()` across Prompt and Evaluation datasets via shared `build_preview()`.
- Evaluation helper tests updated to call shared functions from `_common` directly.
- Prompt test updated for normalised error type (`DatasetError` instead of `NotImplementedError` for unsupported extensions) and message wording.

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Updated `jsonschema/kedro-catalog-X.XX.json` if necessary
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
- [ ] Received approvals from at least half of the TSC (required for adding a new, non-experimental dataset)
