### PR TITLE
refactor(datasets): Refactor shared `Opik` helpers

### DIFF
--- a/kedro-datasets/RELEASE.md
+++ b/kedro-datasets/RELEASE.md
@@ -8,6 +8,8 @@
 | `opik.OpikEvaluationDataset`         | A dataset for managing Opik evaluation datasets.     | `kedro_datasets_experimental.opik`     |
 
 ## Bug fixes and other changes
+- Refactored shared validation and utility logic from the three Opik experimental datasets (`OpikPromptDataset`, `OpikEvaluationDataset`, `OpikTraceDataset`) into a common `opik._common` module.
+
 ## Community contributions
 
 # Release 9.3.0

--- a/kedro-datasets/kedro_datasets_experimental/opik/README.md
+++ b/kedro-datasets/kedro_datasets_experimental/opik/README.md
@@ -224,11 +224,7 @@ dataset = OpikPromptDataset(
         "project_name": "customer-support",
     },
     save_args={
-        "metadata": {
-            "environment": "production",
-            "team": "ml-ops",
-            "version": "2.0.0"
-        }
+        "metadata": {"environment": "production", "team": "ml-ops", "version": "2.0.0"}
     },
 )
 ```
@@ -261,7 +257,7 @@ template = support_dataset.load()
 response = template.format(
     customer_name="Alice",
     issue="billing inquiry",
-    context="Previous interaction: password reset"
+    context="Previous interaction: password reset",
 )
 ```
 
@@ -383,7 +379,7 @@ credentials = {
 
 #### Unsupported File Extension
 ```
-NotImplementedError: Unsupported file extension '.txt'
+DatasetError: Unsupported file extension '.txt'
 ```
 
 ##### Solution: Use supported formats: `.json`, `.yaml`, or `.yml`
@@ -710,7 +706,9 @@ from opik.evaluation.metrics import base_metric, score_result
 
 
 class MyScorer(base_metric.BaseMetric):
-    def score(self, dataset_item: dict, task_outputs: dict, **kwargs) -> score_result.ScoreResult:
+    def score(
+        self, dataset_item: dict, task_outputs: dict, **kwargs
+    ) -> score_result.ScoreResult:
         expected = dataset_item.get("expected_output", "")
         actual = task_outputs.get("output", "")
         value = float(actual == expected)

--- a/kedro-datasets/kedro_datasets_experimental/opik/_common.py
+++ b/kedro-datasets/kedro_datasets_experimental/opik/_common.py
@@ -1,0 +1,134 @@
+"""Shared helpers for Opik datasets."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from kedro.io import DatasetError
+
+from kedro_datasets._typing import JSONPreview
+
+if TYPE_CHECKING:
+    from kedro_datasets.json import JSONDataset
+    from kedro_datasets.yaml import YAMLDataset
+
+SUPPORTED_FILE_EXTENSIONS = {".json", ".yaml", ".yml"}
+
+
+def validate_credentials(
+    credentials: dict[str, Any],
+    required: set[str],
+    optional: set[str],
+) -> None:
+    """Validate Opik credentials.
+
+    Args:
+        credentials: Credentials dictionary to validate.
+        required: Set of required credential keys.
+        optional: Set of optional credential keys (must be non-empty
+            if provided).
+
+    Raises:
+        DatasetError: If required credentials are missing or empty.
+    """
+    for key in required:
+        if key not in credentials:
+            raise DatasetError(f"Missing required Opik credential: '{key}'.")
+        if not credentials[key] or not str(credentials[key]).strip():
+            raise DatasetError(f"Opik credential '{key}' cannot be empty.")
+
+    for key in optional:
+        if key in credentials and (
+            not credentials[key] or not str(credentials[key]).strip()
+        ):
+            raise DatasetError(
+                f"Opik credential '{key}' cannot be empty if provided."
+            )
+
+
+def validate_sync_policy(sync_policy: str, valid_policies: set[str]) -> None:
+    """Validate sync policy value.
+
+    Args:
+        sync_policy: Sync policy to validate.
+        valid_policies: Set of allowed sync policy values.
+
+    Raises:
+        DatasetError: If sync policy is not in the valid set.
+    """
+    if sync_policy not in valid_policies:
+        raise DatasetError(
+            f"Invalid sync_policy '{sync_policy}'. "
+            f"Must be one of: {', '.join(sorted(valid_policies))}"
+        )
+
+
+def validate_file_extension(filepath: str | Path) -> None:
+    """Validate that *filepath* has a supported extension.
+
+    Args:
+        filepath: Path to validate.
+
+    Raises:
+        DatasetError: If the extension is not in ``SUPPORTED_FILE_EXTENSIONS``.
+    """
+    suffix = Path(filepath).suffix.lower()
+    if suffix not in SUPPORTED_FILE_EXTENSIONS:
+        raise DatasetError(
+            f"Unsupported file extension '{suffix}'. "
+            f"Supported formats: {', '.join(sorted(SUPPORTED_FILE_EXTENSIONS))}"
+        )
+
+
+def create_file_dataset(filepath: str | Path) -> JSONDataset | YAMLDataset:
+    """Create the appropriate Kedro file dataset for *filepath*.
+
+    Args:
+        filepath: Path whose extension determines the dataset type.
+
+    Returns:
+        ``YAMLDataset`` for ``.yaml``/``.yml``, ``JSONDataset`` otherwise.
+    """
+    if Path(filepath).suffix.lower() in (".yaml", ".yml"):
+        from kedro_datasets.yaml import YAMLDataset  # noqa: PLC0415
+
+        return YAMLDataset(filepath=str(filepath))
+
+    from kedro_datasets.json import JSONDataset  # noqa: PLC0415
+
+    return JSONDataset(filepath=str(filepath))
+
+
+def build_preview(
+    filepath: Path | None,
+    file_dataset: JSONDataset | YAMLDataset | None = None,
+) -> JSONPreview:
+    """Build a JSON-compatible preview of local file data for Kedro-Viz.
+
+    Args:
+        filepath: Path to the local file, or ``None`` if not configured.
+        file_dataset: Kedro file dataset used to load the data.  Only
+            accessed when *filepath* exists.
+
+    Returns:
+        Serialised JSON string wrapped in ``JSONPreview``.  Returns a
+        descriptive message when *filepath* is not configured or the
+        file does not exist.
+    """
+    if not filepath:
+        return JSONPreview("No filepath configured.")
+
+    if not filepath.exists():
+        return JSONPreview("Local file does not exist.")
+
+    local_data = file_dataset.load()
+
+    if isinstance(local_data, str):
+        local_data = {"content": local_data}
+
+    try:
+        return JSONPreview(json.dumps(local_data))
+    except (TypeError, ValueError) as e:
+        return JSONPreview(f"Could not serialise local data to JSON: {e}")

--- a/kedro-datasets/kedro_datasets_experimental/opik/opik_evaluation_dataset.py
+++ b/kedro-datasets/kedro_datasets_experimental/opik/opik_evaluation_dataset.py
@@ -11,13 +11,20 @@ from opik.rest_api.core.api_error import ApiError
 
 from kedro_datasets._typing import JSONPreview
 
+from ._common import (
+    build_preview,
+    create_file_dataset,
+    validate_credentials,
+    validate_file_extension,
+    validate_sync_policy,
+)
+
 if TYPE_CHECKING:
     from kedro_datasets.json import JSONDataset
     from kedro_datasets.yaml import YAMLDataset
 
 logger = logging.getLogger(__name__)
 
-SUPPORTED_FILE_EXTENSIONS = {".json", ".yaml", ".yml"}
 REQUIRED_OPIK_CREDENTIALS = {"api_key"}
 OPTIONAL_OPIK_CREDENTIALS = {"workspace", "host", "project_name"}
 VALID_SYNC_POLICIES = {"local", "remote"}
@@ -210,47 +217,10 @@ class OpikEvaluationDataset(AbstractDataset):
         filepath: str | None,
         sync_policy: str,
     ) -> None:
-        OpikEvaluationDataset._validate_credentials(credentials)
-        OpikEvaluationDataset._validate_sync_policy(sync_policy)
-        OpikEvaluationDataset._validate_filepath(filepath)
-
-    @staticmethod
-    def _validate_credentials(credentials: dict[str, str]) -> None:
-        for key in REQUIRED_OPIK_CREDENTIALS:
-            if key not in credentials:
-                raise DatasetError(
-                    f"Missing required Opik credential: '{key}'."
-                )
-            if not credentials[key] or not str(credentials[key]).strip():
-                raise DatasetError(
-                    f"Opik credential '{key}' cannot be empty."
-                )
-        for key in OPTIONAL_OPIK_CREDENTIALS:
-            if key in credentials and (
-                not credentials[key] or not str(credentials[key]).strip()
-            ):
-                raise DatasetError(
-                    f"Opik credential '{key}' cannot be empty if provided."
-                )
-
-    @staticmethod
-    def _validate_sync_policy(sync_policy: str) -> None:
-        if sync_policy not in VALID_SYNC_POLICIES:
-            raise DatasetError(
-                f"Invalid sync_policy '{sync_policy}'. "
-                f"Must be one of: {', '.join(sorted(VALID_SYNC_POLICIES))}."
-            )
-
-    @staticmethod
-    def _validate_filepath(filepath: str | None) -> None:
-        if filepath is None:
-            return
-        suffix = Path(filepath).suffix.lower()
-        if suffix not in SUPPORTED_FILE_EXTENSIONS:
-            raise DatasetError(
-                f"Unsupported file extension '{suffix}'. "
-                f"Supported formats: {', '.join(sorted(SUPPORTED_FILE_EXTENSIONS))}."
-            )
+        validate_credentials(credentials, REQUIRED_OPIK_CREDENTIALS, OPTIONAL_OPIK_CREDENTIALS)
+        validate_sync_policy(sync_policy, VALID_SYNC_POLICIES)
+        if filepath is not None:
+            validate_file_extension(filepath)
 
     @property
     def file_dataset(self) -> "JSONDataset | YAMLDataset":
@@ -258,13 +228,7 @@ class OpikEvaluationDataset(AbstractDataset):
         if not self._filepath:
             raise DatasetError("filepath must be provided for file dataset operations.")
         if self._file_dataset is None:
-            suffix = self._filepath.suffix.lower()
-            if suffix in (".yaml", ".yml"):
-                from kedro_datasets.yaml import YAMLDataset  # noqa: PLC0415
-                self._file_dataset = YAMLDataset(filepath=str(self._filepath))
-            else:
-                from kedro_datasets.json import JSONDataset  # noqa: PLC0415
-                self._file_dataset = JSONDataset(filepath=str(self._filepath))
+            self._file_dataset = create_file_dataset(self._filepath)
         return self._file_dataset
 
     def _get_or_create_remote_dataset(self) -> Dataset:
@@ -587,18 +551,4 @@ class OpikEvaluationDataset(AbstractDataset):
             JSONPreview: A Kedro-Viz-compatible object containing a serialized JSON string.
                 Returns a descriptive message if filepath is not configured or does not exist.
         """
-        if not self._filepath:
-            return JSONPreview("No filepath configured.")
-
-        if not self._filepath.exists():
-            return JSONPreview("Local evaluation dataset does not exist.")
-
-        local_data = self.file_dataset.load()
-
-        if isinstance(local_data, str):
-            local_data = {"content": local_data}
-
-        try:
-            return JSONPreview(json.dumps(local_data))
-        except (TypeError, ValueError) as e:
-            return JSONPreview(f"Could not serialise local data to JSON: {e}")
+        return build_preview(self._filepath, self.file_dataset if self._filepath else None)

--- a/kedro-datasets/kedro_datasets_experimental/opik/opik_evaluation_dataset.py
+++ b/kedro-datasets/kedro_datasets_experimental/opik/opik_evaluation_dataset.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import uuid
 from pathlib import Path

--- a/kedro-datasets/kedro_datasets_experimental/opik/opik_prompt_dataset.py
+++ b/kedro-datasets/kedro_datasets_experimental/opik/opik_prompt_dataset.py
@@ -18,15 +18,17 @@ from opik import Opik, Prompt
 
 from kedro_datasets._typing import JSONPreview
 
-# Supported file extensions for prompt storage
-SUPPORTED_FILE_EXTENSIONS = {".json", ".yaml", ".yml"}
+from ._common import (
+    build_preview,
+    create_file_dataset,
+    validate_file_extension,
+    validate_sync_policy,
+)
 
-# Valid parameter values
 VALID_PROMPT_TYPES = {"chat", "text"}
 VALID_SYNC_POLICIES = {"local", "remote", "strict"}
 VALID_MODES = {"langchain", "sdk"}
 
-# Logger for this module
 logger = logging.getLogger(__name__)
 
 
@@ -155,7 +157,6 @@ class OpikPromptDataset(AbstractDataset):
 
         Raises:
             DatasetError: If required parameters are missing or invalid.
-            NotImplementedError: If filepath has unsupported extension.
             ImportError: If langchain is required but not installed.
         """
         # Validate parameters
@@ -196,34 +197,22 @@ class OpikPromptDataset(AbstractDataset):
 
         Raises:
             DatasetError: If parameters are invalid.
-            NotImplementedError: If filepath has unsupported extension.
             ImportError: If required packages are missing.
         """
-        # Validate file extension
-        file_path = Path(filepath)
-        if file_path.suffix.lower() not in SUPPORTED_FILE_EXTENSIONS:
-            raise NotImplementedError(
-                f"Unsupported file extension '{file_path.suffix}'. "
-                f"Supported formats: {', '.join(sorted(SUPPORTED_FILE_EXTENSIONS))}"
-            )
+        validate_file_extension(filepath)
 
-        # Validate enum parameters
         if prompt_type and prompt_type not in VALID_PROMPT_TYPES:
             raise DatasetError(
                 f"Invalid prompt_type '{prompt_type}'. Must be one of: {', '.join(sorted(VALID_PROMPT_TYPES))}"
             )
 
-        if sync_policy and sync_policy not in VALID_SYNC_POLICIES:
-            raise DatasetError(
-                f"Invalid sync_policy '{sync_policy}'. Must be one of: {', '.join(sorted(VALID_SYNC_POLICIES))}"
-            )
+        validate_sync_policy(sync_policy, VALID_SYNC_POLICIES)
 
         if mode and mode not in VALID_MODES:
             raise DatasetError(
                 f"Invalid mode '{mode}'. Must be one of: {', '.join(sorted(VALID_MODES))}"
             )
 
-        # Validate mode-specific requirements
         if mode == "langchain":
             try:
                 from langchain_core.prompts import ChatPromptTemplate  # noqa: PLC0415
@@ -253,22 +242,9 @@ class OpikPromptDataset(AbstractDataset):
 
         Returns:
             JSONDataset for .json files, YAMLDataset for .yaml/.yml files.
-
-        Raises:
-            NotImplementedError: If file extension is not supported.
         """
         if self._file_dataset is None:
-            if self._filepath.suffix.lower() in [".yaml", ".yml"]:
-                from kedro_datasets.yaml import YAMLDataset  # noqa: PLC0415
-                self._file_dataset = YAMLDataset(filepath=str(self._filepath))
-            elif self._filepath.suffix.lower() == ".json":
-                from kedro_datasets.json import JSONDataset  # noqa: PLC0415
-                self._file_dataset = JSONDataset(filepath=str(self._filepath))
-            else:
-                raise NotImplementedError(
-                    f"Unsupported file extension '{self._filepath.suffix}'. "
-                    f"Supported formats: {', '.join(sorted(SUPPORTED_FILE_EXTENSIONS))}"
-                )
+            self._file_dataset = create_file_dataset(self._filepath)
         return self._file_dataset
 
     def _describe(self) -> dict[str, Any]:
@@ -599,13 +575,4 @@ class OpikPromptDataset(AbstractDataset):
         Returns:
             JSONPreview: A Kedro-Viz-compatible preview of the prompt.
         """
-        if self._filepath.exists():
-            local_data = self.file_dataset.load()
-
-            # Wrap string content in JSON object for Kedro-Viz compatibility
-            if isinstance(local_data, str):
-                local_data = {"content": local_data}
-
-            return JSONPreview(json.dumps(local_data))
-
-        return JSONPreview("Local prompt file does not exist.")
+        return build_preview(self._filepath, self.file_dataset)

--- a/kedro-datasets/kedro_datasets_experimental/opik/opik_trace_dataset.py
+++ b/kedro-datasets/kedro_datasets_experimental/opik/opik_trace_dataset.py
@@ -5,6 +5,8 @@ from typing import Any, Literal
 from kedro.io import AbstractDataset, DatasetError
 from opik import configure, track
 
+from ._common import validate_credentials
+
 logger = logging.getLogger(__name__)
 
 REQUIRED_OPIK_CREDENTIALS = {"api_key", "workspace"}
@@ -153,15 +155,8 @@ class OpikTraceDataset(AbstractDataset):
 
     def _validate_opik_credentials(self) -> None:
         """Validate Opik credentials before configuring the environment."""
-        for key in REQUIRED_OPIK_CREDENTIALS:
-            if key not in self._credentials or not str(self._credentials[key]).strip():
-                raise DatasetError(f"Missing required Opik credential: '{key}'")
+        validate_credentials(self._credentials, REQUIRED_OPIK_CREDENTIALS, OPTIONAL_OPIK_CREDENTIALS)
 
-        for key in OPTIONAL_OPIK_CREDENTIALS:
-            if key in self._credentials and not str(self._credentials[key]).strip():
-                raise DatasetError(f"Optional Opik credential '{key}' cannot be empty if provided")
-
-        # AutoGen mode has additional required credentials
         if self._mode == "autogen":
             for key in REQUIRED_OPIK_CREDENTIALS_AUTOGEN:
                 if not self._credentials.get(key):

--- a/kedro-datasets/kedro_datasets_experimental/tests/opik/test_opik_prompt_dataset.py
+++ b/kedro-datasets/kedro_datasets_experimental/tests/opik/test_opik_prompt_dataset.py
@@ -181,11 +181,11 @@ class TestOpikPromptDatasetInit:
             )
 
     def test_init_unsupported_file_extension(self, tmp_path, mock_opik):
-        """Test initialisation with unsupported file extension raises NotImplementedError."""
+        """Test initialisation with unsupported file extension raises DatasetError."""
         unsupported_file = tmp_path / "prompt.txt"
         unsupported_file.write_text("test prompt")
 
-        with pytest.raises(NotImplementedError, match="Unsupported file extension '.txt'"):
+        with pytest.raises(DatasetError, match="Unsupported file extension '.txt'"):
             OpikPromptDataset(
                 filepath=str(unsupported_file),
                 prompt_name="test-prompt",
@@ -592,7 +592,7 @@ class TestOpikPromptDatasetUtilityMethods:
         )
 
         preview = dataset.preview()
-        assert "Local prompt file does not exist" in str(preview)
+        assert "Local file does not exist" in str(preview)
 
     def test_ensure_dataset_exists_creates_new(self, filepath_json_chat, mock_credentials, mock_opik):
         """Test that _ensure_dataset_exists creates dataset if it doesn't exist."""


### PR DESCRIPTION
## Description
Resolves #1370.

- Introduce `kedro_datasets_experimental/opik/_common.py` with shared helpers extracted from the three `Opik` datasets: `validate_credentials()`, `validate_sync_policy()`, `validate_file_extension()`, `create_file_dataset()` and `build_preview()`.
- Update `OpikPromptDataset`, `OpikEvaluationDataset`, and `OpikTraceDataset` to import from `_common` instead of duplicating logic.
- Normalise error types — `OpikPromptDataset` now raises `DatasetError` instead of `NotImplementedError` for unsupported file extensions.
- Unify `preview()` across `Prompt` and `Evaluation` datasets via shared `build_preview()`.
- Prompt test updated for normalised error type (`DatasetError` instead of `NotImplementedError` for unsupported extensions) and message wording.
- Updated `README.md` troubleshooting section to reflect `DatasetError`.

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Updated `jsonschema/kedro-catalog-X.XX.json` if necessary
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
- [ ] Received approvals from at least half of the TSC (required for adding a new, non-experimental dataset)
