### PR TITLE
fix: exclude `.secrets.baseline` from CI workflow triggers

### DIFF
--- a/.github/workflows/docs-linkcheck.yml
+++ b/.github/workflows/docs-linkcheck.yml
@@ -5,10 +5,14 @@ on:
     branches:
       - main
       - develop
+    paths-ignore:
+      - ".secrets.baseline"
   pull_request:
     branches:
       - main
       - develop
+    paths-ignore:
+      - ".secrets.baseline"
 
 jobs:
   linkcheck:

--- a/.github/workflows/kedro-airflow.yml
+++ b/.github/workflows/kedro-airflow.yml
@@ -9,6 +9,7 @@ on:
       - "kedro-datasets/**"
       - "kedro-docker/**"
       - "kedro-telemetry/**"
+      - ".secrets.baseline"
   pull_request:
     branches:
       - main
@@ -16,6 +17,7 @@ on:
       - "kedro-datasets/**"
       - "kedro-docker/**"
       - "kedro-telemetry/**"
+      - ".secrets.baseline"
 
 permissions:
   contents: read

--- a/.github/workflows/kedro-datasets.yml
+++ b/.github/workflows/kedro-datasets.yml
@@ -9,6 +9,7 @@ on:
       - "kedro-airflow/**"
       - "kedro-docker/**"
       - "kedro-telemetry/**"
+      - ".secrets.baseline"
   pull_request:
     branches:
       - main
@@ -16,6 +17,7 @@ on:
       - "kedro-airflow/**"
       - "kedro-docker/**"
       - "kedro-telemetry/**"
+      - ".secrets.baseline"
 
 permissions:
   contents: read

--- a/.github/workflows/kedro-docker.yml
+++ b/.github/workflows/kedro-docker.yml
@@ -9,6 +9,7 @@ on:
       - "kedro-airflow/**"
       - "kedro-datasets/**"
       - "kedro-telemetry/**"
+      - ".secrets.baseline"
   pull_request:
     branches:
       - main
@@ -16,6 +17,7 @@ on:
       - "kedro-airflow/**"
       - "kedro-datasets/**"
       - "kedro-telemetry/**"
+      - ".secrets.baseline"
 
 permissions:
   contents: read

--- a/.github/workflows/kedro-telemetry.yml
+++ b/.github/workflows/kedro-telemetry.yml
@@ -9,6 +9,7 @@ on:
       - "kedro-airflow/**"
       - "kedro-datasets/**"
       - "kedro-docker/**"
+      - ".secrets.baseline"
   pull_request:
     branches:
       - main
@@ -16,6 +17,7 @@ on:
       - "kedro-airflow/**"
       - "kedro-datasets/**"
       - "kedro-docker/**"
+      - ".secrets.baseline"
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Closes #1338

- Adds \`.secrets.baseline\` to \`paths-ignore\` in all GitHub Actions workflows that trigger on \`push\` or \`pull_request\` events
- Prevents CI builds from being triggered unnecessarily when only the secrets baseline file changes

## Workflows updated

- \`docs-linkcheck.yml\`
- \`kedro-airflow.yml\`
- \`kedro-datasets.yml\`
- \`kedro-docker.yml\`
- \`kedro-telemetry.yml\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)