### PR TITLE
fix(datasets): Add path validation to IncrementalDataset

### DIFF
--- a/kedro-datasets/RELEASE.md
+++ b/kedro-datasets/RELEASE.md
@@ -32,6 +32,7 @@
 - Refactored shared validation and utility logic from the three Opik experimental datasets (`PromptDataset`, `EvaluationDataset`, `TraceDataset`) into a common `opik._common` module.
 - Refactored shared validation and utility logic from the three Langfuse experimental datasets (`PromptDataset`, `EvaluationDataset`, `TraceDataset`) into a common `langfuse._common` module.
 - Added `os.PathLike` support for `plotly` datasets.
+- Added `checkpoint.filepath` validation for IncrementalDataset.
 
 ## Community contributions
 Many thanks to the following Kedroids for contributing PRs to this release:

--- a/kedro-datasets/kedro_datasets/partitions/incremental_dataset.py
+++ b/kedro-datasets/kedro_datasets/partitions/incremental_dataset.py
@@ -9,6 +9,7 @@ new partitions past the checkpoint.It also uses `fsspec` for filesystem level op
 from __future__ import annotations
 
 import operator
+import posixpath
 from collections.abc import Callable
 from copy import deepcopy
 from typing import Any
@@ -22,6 +23,8 @@ from kedro.io.core import (
     parse_dataset_definition,
 )
 from kedro.utils import load_obj
+
+from kedro_datasets._utils import validate_sub_path
 
 from .partitioned_dataset import (
     KEY_PROPAGATION_WARNING,
@@ -175,7 +178,32 @@ class IncrementalDataset(PartitionedDataset):
                 {"keys": CREDENTIALS_KEY, "target": "checkpoint"},
             )
 
-        return {**default_config, **checkpoint_config}
+        merged = {**default_config, **checkpoint_config}
+
+        if self._filepath_arg in checkpoint_config:
+            user_filepath = str(checkpoint_config[self._filepath_arg])
+            dir_path = self._filesystem._strip_protocol(self._normalized_path).rstrip(
+                self._sep
+            )
+            stripped = self._filesystem._strip_protocol(user_filepath).replace(
+                "\\", "/"
+            )
+            if posixpath.isabs(stripped):
+                normalized = posixpath.normpath(stripped)
+                normalized_base = posixpath.normpath(dir_path)
+                if not (
+                    normalized == normalized_base
+                    or normalized.startswith(normalized_base + "/")
+                ):
+                    raise DatasetError(
+                        f"Checkpoint filepath '{user_filepath}' resolves to "
+                        f"'{normalized}' which is outside the dataset "
+                        f"directory '{dir_path}'."
+                    )
+            else:
+                validate_sub_path(stripped.lstrip("/"), dir_path)
+
+        return merged
 
     def _list_partitions(self) -> list[str]:
         if self._cached_partitions is not None:

--- a/kedro-datasets/kedro_datasets/partitions/incremental_dataset.py
+++ b/kedro-datasets/kedro_datasets/partitions/incremental_dataset.py
@@ -205,9 +205,9 @@ class IncrementalDataset(PartitionedDataset):
                 dir_path = self._filesystem._strip_protocol(
                     self._normalized_path
                 ).rstrip(self._sep)
-                fp_stripped = self._filesystem._strip_protocol(
-                    user_filepath
-                ).replace("\\", "/")
+                fp_stripped = self._filesystem._strip_protocol(user_filepath).replace(
+                    "\\", "/"
+                )
                 normalized_dir = posixpath.normpath(dir_path)
                 normalized_fp = posixpath.normpath(fp_stripped)
                 if not (

--- a/kedro-datasets/kedro_datasets/partitions/incremental_dataset.py
+++ b/kedro-datasets/kedro_datasets/partitions/incremental_dataset.py
@@ -205,9 +205,9 @@ class IncrementalDataset(PartitionedDataset):
                 dir_path = self._filesystem._strip_protocol(
                     self._normalized_path
                 ).rstrip(self._sep)
-                fp_stripped = self._filesystem._strip_protocol(
-                    user_filepath
-                ).replace("\\", "/")
+                fp_stripped = self._filesystem._strip_protocol(user_filepath).replace(
+                    "\\", "/"
+                )
                 validate_sub_path(fp_stripped.lstrip("/"), dir_path)
 
         return merged

--- a/kedro-datasets/kedro_datasets/partitions/incremental_dataset.py
+++ b/kedro-datasets/kedro_datasets/partitions/incremental_dataset.py
@@ -9,6 +9,7 @@ new partitions past the checkpoint.It also uses `fsspec` for filesystem level op
 from __future__ import annotations
 
 import operator
+import os
 import posixpath
 from collections.abc import Callable
 from copy import deepcopy
@@ -182,26 +183,32 @@ class IncrementalDataset(PartitionedDataset):
 
         if self._filepath_arg in checkpoint_config:
             user_filepath = str(checkpoint_config[self._filepath_arg])
-            dir_path = self._filesystem._strip_protocol(self._normalized_path).rstrip(
-                self._sep
-            )
-            stripped = self._filesystem._strip_protocol(user_filepath).replace(
-                "\\", "/"
-            )
-            if posixpath.isabs(stripped):
-                normalized = posixpath.normpath(stripped)
-                normalized_base = posixpath.normpath(dir_path)
-                if not (
-                    normalized == normalized_base
-                    or normalized.startswith(normalized_base + "/")
-                ):
+            if self._protocol == "file":
+                # Local filesystem: use os.path directly so Windows drive
+                # letters are handled correctly across all fsspec versions.
+                base = os.path.normcase(os.path.normpath(self._normalized_path))
+                if os.path.isabs(user_filepath):
+                    resolved = os.path.normcase(os.path.normpath(user_filepath))
+                else:
+                    resolved = os.path.normcase(
+                        os.path.normpath(os.path.join(base, user_filepath))
+                    )
+                if not (resolved == base or resolved.startswith(base + os.sep)):
                     raise DatasetError(
                         f"Checkpoint filepath '{user_filepath}' resolves to "
-                        f"'{normalized}' which is outside the dataset "
-                        f"directory '{dir_path}'."
+                        f"'{resolved}' which is outside the dataset "
+                        f"directory '{base}'."
                     )
             else:
-                validate_sub_path(stripped.lstrip("/"), dir_path)
+                # Cloud filesystem (S3, GCS, Azure, …): strip protocol and
+                # use validate_sub_path which handles cloud path traversal.
+                dir_path = self._filesystem._strip_protocol(
+                    self._normalized_path
+                ).rstrip(self._sep)
+                fp_stripped = self._filesystem._strip_protocol(
+                    user_filepath
+                ).replace("\\", "/")
+                validate_sub_path(fp_stripped.lstrip("/"), dir_path)
 
         return merged
 

--- a/kedro-datasets/kedro_datasets/partitions/incremental_dataset.py
+++ b/kedro-datasets/kedro_datasets/partitions/incremental_dataset.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import operator
 import os
-import posixpath
 from collections.abc import Callable
 from copy import deepcopy
 from typing import Any

--- a/kedro-datasets/kedro_datasets/partitions/incremental_dataset.py
+++ b/kedro-datasets/kedro_datasets/partitions/incremental_dataset.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import operator
 import os
+import posixpath
 from collections.abc import Callable
 from copy import deepcopy
 from typing import Any
@@ -23,8 +24,6 @@ from kedro.io.core import (
     parse_dataset_definition,
 )
 from kedro.utils import load_obj
-
-from kedro_datasets._utils import validate_sub_path
 
 from .partitioned_dataset import (
     KEY_PROPAGATION_WARNING,
@@ -199,15 +198,27 @@ class IncrementalDataset(PartitionedDataset):
                         f"directory '{base}'."
                     )
             else:
-                # Cloud filesystem (S3, GCS, Azure, …): strip protocol and
-                # use validate_sub_path which handles cloud path traversal.
+                # Cloud filesystem (S3, GCS, Azure, …): strip protocol from
+                # both paths, then do a direct normpath prefix check — the same
+                # pattern as the local branch — so same-bucket traversal (../)
+                # and cross-bucket paths are both caught without path joining.
                 dir_path = self._filesystem._strip_protocol(
                     self._normalized_path
                 ).rstrip(self._sep)
-                fp_stripped = self._filesystem._strip_protocol(user_filepath).replace(
-                    "\\", "/"
-                )
-                validate_sub_path(fp_stripped.lstrip("/"), dir_path)
+                fp_stripped = self._filesystem._strip_protocol(
+                    user_filepath
+                ).replace("\\", "/")
+                normalized_dir = posixpath.normpath(dir_path)
+                normalized_fp = posixpath.normpath(fp_stripped)
+                if not (
+                    normalized_fp == normalized_dir
+                    or normalized_fp.startswith(normalized_dir + "/")
+                ):
+                    raise DatasetError(
+                        f"Checkpoint filepath '{user_filepath}' resolves to "
+                        f"'{normalized_fp}' which is outside the dataset "
+                        f"directory '{normalized_dir}'."
+                    )
 
         return merged
 

--- a/kedro-datasets/tests/partitions/test_incremental_dataset.py
+++ b/kedro-datasets/tests/partitions/test_incremental_dataset.py
@@ -591,36 +591,23 @@ class TestIncrementalDatasetS3:
 class TestIncrementalDatasetCheckpointValidation:
     """Tests for path traversal protection in checkpoint filepath validation."""
 
-    @pytest.mark.parametrize(
-        "checkpoint_filepath",
-        [
-            "/tmp/bad_checkpoint",
-            "/etc/passwd",
-        ],
-    )
-    def test_absolute_path_traversal_blocked(self, tmp_path, checkpoint_filepath):
-        """Absolute checkpoint filepaths outside the dataset directory are rejected."""
+    def test_absolute_path_traversal_blocked(self, tmp_path):
+        """Absolute checkpoint filepath outside the dataset directory is rejected."""
+        outside = str(tmp_path.parent / "bad_checkpoint")
         with pytest.raises(DatasetError, match="outside the dataset directory"):
             IncrementalDataset(
                 path=str(tmp_path),
                 dataset=DATASET,
-                checkpoint={"filepath": checkpoint_filepath},
+                checkpoint={"filepath": outside},
             )
 
-    @pytest.mark.parametrize(
-        "checkpoint_filepath",
-        [
-            "../../bad_checkpoint",
-            "../sibling/checkpoint",
-        ],
-    )
-    def test_relative_traversal_blocked(self, tmp_path, checkpoint_filepath):
-        """Relative checkpoint filepaths that escape the dataset directory via .. are rejected."""
+    def test_relative_traversal_blocked(self, tmp_path):
+        """Relative checkpoint filepath that escapes the dataset directory via .. is rejected."""
         with pytest.raises(DatasetError, match="outside the dataset directory"):
             IncrementalDataset(
                 path=str(tmp_path),
                 dataset=DATASET,
-                checkpoint={"filepath": checkpoint_filepath},
+                checkpoint={"filepath": "../bad_checkpoint"},
             )
 
     def test_filepath_within_base_allowed(self, tmp_path, partitioned_data_pandas):

--- a/kedro-datasets/tests/partitions/test_incremental_dataset.py
+++ b/kedro-datasets/tests/partitions/test_incremental_dataset.py
@@ -278,6 +278,56 @@ class TestIncrementalDatasetLocal:
                 path=str(tmp_path), dataset=DATASET, checkpoint=checkpoint_config
             )
 
+    @pytest.mark.parametrize(
+        "checkpoint_filepath",
+        [
+            "/tmp/evil_checkpoint",
+            "/etc/passwd",
+        ],
+    )
+    def test_checkpoint_filepath_absolute_path_traversal_blocked(
+        self, tmp_path, checkpoint_filepath
+    ):
+        """Absolute checkpoint filepaths outside the dataset directory are rejected."""
+        with pytest.raises(DatasetError, match="outside the dataset directory"):
+            IncrementalDataset(
+                path=str(tmp_path),
+                dataset=DATASET,
+                checkpoint={"filepath": checkpoint_filepath},
+            )
+
+    @pytest.mark.parametrize(
+        "checkpoint_filepath",
+        [
+            "../../evil_checkpoint",
+            "../sibling/checkpoint",
+        ],
+    )
+    def test_checkpoint_filepath_relative_traversal_blocked(
+        self, tmp_path, checkpoint_filepath
+    ):
+        """Relative checkpoint filepaths that escape the dataset directory via .. are rejected."""
+        with pytest.raises(DatasetError, match="outside the dataset directory"):
+            IncrementalDataset(
+                path=str(tmp_path),
+                dataset=DATASET,
+                checkpoint={"filepath": checkpoint_filepath},
+            )
+
+    def test_checkpoint_filepath_within_base_allowed(
+        self, tmp_path, partitioned_data_pandas
+    ):
+        """A checkpoint filepath inside the dataset directory is accepted."""
+        checkpoint_path = str(tmp_path / "my_checkpoint")
+        pds = IncrementalDataset(
+            path=str(tmp_path),
+            dataset=DATASET,
+            checkpoint={"filepath": checkpoint_path},
+        )
+        pds.save(partitioned_data_pandas)
+        pds.confirm()
+        assert Path(checkpoint_path).is_file()
+
     @pytest.mark.parametrize("dataset_config", [{"type": DATASET, "versioned": True}])
     @pytest.mark.parametrize(
         "suffix,expected_num_parts", [("", 5), (".csv", 5), ("bad", 0)]

--- a/kedro-datasets/tests/partitions/test_incremental_dataset.py
+++ b/kedro-datasets/tests/partitions/test_incremental_dataset.py
@@ -623,11 +623,31 @@ class TestIncrementalDatasetCheckpointValidation:
         assert Path(checkpoint_path).is_file()
 
     def test_s3_traversal_blocked(self, mocked_csvs_in_s3):
-        """S3 checkpoint filepaths with .. traversal are rejected via validate_sub_path."""
+        """S3 checkpoint filepaths with .. traversal are rejected."""
         traversal_path = f"s3://{BUCKET_NAME}/csvs/../../../bad_checkpoint"
         with pytest.raises(DatasetError, match="outside the dataset directory"):
             IncrementalDataset(
                 path=mocked_csvs_in_s3,
                 dataset=DATASET,
                 checkpoint={"filepath": traversal_path},
+            )
+
+    def test_s3_same_bucket_traversal_blocked(self, mocked_csvs_in_s3):
+        """Same-bucket .. traversal that stays within the bucket is rejected."""
+        traversal_path = f"s3://{BUCKET_NAME}/csvs/../outside"
+        with pytest.raises(DatasetError, match="outside the dataset directory"):
+            IncrementalDataset(
+                path=mocked_csvs_in_s3,
+                dataset=DATASET,
+                checkpoint={"filepath": traversal_path},
+            )
+
+    def test_s3_cross_bucket_blocked(self, mocked_csvs_in_s3):
+        """A checkpoint filepath pointing to a different S3 bucket is rejected."""
+        cross_bucket_path = "s3://other-bucket/evil"
+        with pytest.raises(DatasetError, match="outside the dataset directory"):
+            IncrementalDataset(
+                path=mocked_csvs_in_s3,
+                dataset=DATASET,
+                checkpoint={"filepath": cross_bucket_path},
             )

--- a/kedro-datasets/tests/partitions/test_incremental_dataset.py
+++ b/kedro-datasets/tests/partitions/test_incremental_dataset.py
@@ -278,56 +278,6 @@ class TestIncrementalDatasetLocal:
                 path=str(tmp_path), dataset=DATASET, checkpoint=checkpoint_config
             )
 
-    @pytest.mark.parametrize(
-        "checkpoint_filepath",
-        [
-            "/tmp/bad_checkpoint",
-            "/etc/passwd",
-        ],
-    )
-    def test_checkpoint_filepath_absolute_path_traversal_blocked(
-        self, tmp_path, checkpoint_filepath
-    ):
-        """Absolute checkpoint filepaths outside the dataset directory are rejected."""
-        with pytest.raises(DatasetError, match="outside the dataset directory"):
-            IncrementalDataset(
-                path=str(tmp_path),
-                dataset=DATASET,
-                checkpoint={"filepath": checkpoint_filepath},
-            )
-
-    @pytest.mark.parametrize(
-        "checkpoint_filepath",
-        [
-            "../../bad_checkpoint",
-            "../sibling/checkpoint",
-        ],
-    )
-    def test_checkpoint_filepath_relative_traversal_blocked(
-        self, tmp_path, checkpoint_filepath
-    ):
-        """Relative checkpoint filepaths that escape the dataset directory via .. are rejected."""
-        with pytest.raises(DatasetError, match="outside the dataset directory"):
-            IncrementalDataset(
-                path=str(tmp_path),
-                dataset=DATASET,
-                checkpoint={"filepath": checkpoint_filepath},
-            )
-
-    def test_checkpoint_filepath_within_base_allowed(
-        self, tmp_path, partitioned_data_pandas
-    ):
-        """A checkpoint filepath inside the dataset directory is accepted."""
-        checkpoint_path = str(tmp_path / "my_checkpoint")
-        pds = IncrementalDataset(
-            path=str(tmp_path),
-            dataset=DATASET,
-            checkpoint={"filepath": checkpoint_path},
-        )
-        pds.save(partitioned_data_pandas)
-        pds.confirm()
-        assert Path(checkpoint_path).is_file()
-
     @pytest.mark.parametrize("dataset_config", [{"type": DATASET, "versioned": True}])
     @pytest.mark.parametrize(
         "suffix,expected_num_parts", [("", 5), (".csv", 5), ("bad", 0)]
@@ -637,7 +587,55 @@ class TestIncrementalDatasetS3:
         # confirming with no partitions available must have no effect
         assert not pds._checkpoint.exists()
 
-    def test_checkpoint_filepath_s3_traversal_blocked(self, mocked_csvs_in_s3):
+
+class TestIncrementalDatasetCheckpointSecurity:
+    """Tests for path traversal protection in checkpoint filepath validation."""
+
+    @pytest.mark.parametrize(
+        "checkpoint_filepath",
+        [
+            "/tmp/bad_checkpoint",
+            "/etc/passwd",
+        ],
+    )
+    def test_absolute_path_traversal_blocked(self, tmp_path, checkpoint_filepath):
+        """Absolute checkpoint filepaths outside the dataset directory are rejected."""
+        with pytest.raises(DatasetError, match="outside the dataset directory"):
+            IncrementalDataset(
+                path=str(tmp_path),
+                dataset=DATASET,
+                checkpoint={"filepath": checkpoint_filepath},
+            )
+
+    @pytest.mark.parametrize(
+        "checkpoint_filepath",
+        [
+            "../../bad_checkpoint",
+            "../sibling/checkpoint",
+        ],
+    )
+    def test_relative_traversal_blocked(self, tmp_path, checkpoint_filepath):
+        """Relative checkpoint filepaths that escape the dataset directory via .. are rejected."""
+        with pytest.raises(DatasetError, match="outside the dataset directory"):
+            IncrementalDataset(
+                path=str(tmp_path),
+                dataset=DATASET,
+                checkpoint={"filepath": checkpoint_filepath},
+            )
+
+    def test_filepath_within_base_allowed(self, tmp_path, partitioned_data_pandas):
+        """A checkpoint filepath inside the dataset directory is accepted."""
+        checkpoint_path = str(tmp_path / "my_checkpoint")
+        pds = IncrementalDataset(
+            path=str(tmp_path),
+            dataset=DATASET,
+            checkpoint={"filepath": checkpoint_path},
+        )
+        pds.save(partitioned_data_pandas)
+        pds.confirm()
+        assert Path(checkpoint_path).is_file()
+
+    def test_s3_traversal_blocked(self, mocked_csvs_in_s3):
         """S3 checkpoint filepaths with .. traversal are rejected via validate_sub_path."""
         traversal_path = f"s3://{BUCKET_NAME}/csvs/../../../bad_checkpoint"
         with pytest.raises(DatasetError, match="outside the dataset directory"):

--- a/kedro-datasets/tests/partitions/test_incremental_dataset.py
+++ b/kedro-datasets/tests/partitions/test_incremental_dataset.py
@@ -588,7 +588,7 @@ class TestIncrementalDatasetS3:
         assert not pds._checkpoint.exists()
 
 
-class TestIncrementalDatasetCheckpointSecurity:
+class TestIncrementalDatasetCheckpointValidation:
     """Tests for path traversal protection in checkpoint filepath validation."""
 
     @pytest.mark.parametrize(

--- a/kedro-datasets/tests/partitions/test_incremental_dataset.py
+++ b/kedro-datasets/tests/partitions/test_incremental_dataset.py
@@ -281,7 +281,7 @@ class TestIncrementalDatasetLocal:
     @pytest.mark.parametrize(
         "checkpoint_filepath",
         [
-            "/tmp/evil_checkpoint",
+            "/tmp/bad_checkpoint",
             "/etc/passwd",
         ],
     )
@@ -299,7 +299,7 @@ class TestIncrementalDatasetLocal:
     @pytest.mark.parametrize(
         "checkpoint_filepath",
         [
-            "../../evil_checkpoint",
+            "../../bad_checkpoint",
             "../sibling/checkpoint",
         ],
     )
@@ -636,3 +636,13 @@ class TestIncrementalDatasetS3:
         pds.confirm()
         # confirming with no partitions available must have no effect
         assert not pds._checkpoint.exists()
+
+    def test_checkpoint_filepath_s3_traversal_blocked(self, mocked_csvs_in_s3):
+        """S3 checkpoint filepaths with .. traversal are rejected via validate_sub_path."""
+        traversal_path = f"s3://{BUCKET_NAME}/csvs/../../../bad_checkpoint"
+        with pytest.raises(DatasetError, match="outside the dataset directory"):
+            IncrementalDataset(
+                path=mocked_csvs_in_s3,
+                dataset=DATASET,
+                checkpoint={"filepath": traversal_path},
+            )


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->

`IncrementalDataset._parse_checkpoint_config()` accepted any user-supplied `checkpoint.filepath` without validation. Via Kedro's runtime parameter interpolation (`${runtime_params:...}`), it would be possible to point the checkpoint to a file outside the dataset directory and `confirm()` would write there.

With the changes made on this PR, this is now validated against the dataset's base directory in two modes:
- Absolute paths (e.g. /tmp/file.txt): checked directly, must start with the dataset directory
- Relative paths (e.g. ../../etc/passwd): delegated to the existing validate_sub_path() utility, which normalizes `..` components and rejects escapes

## Development notes
<!-- What have you changed, and how has this been tested? -->

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Updated `jsonschema/kedro-catalog-X.XX.json` if necessary
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
- [ ] Received approvals from at least half of the TSC (required for adding a new, non-experimental dataset)
