### PR TITLE
fix(telemetry): Send dataset type counts in a Heap-compliant flat format

### DIFF
--- a/kedro-telemetry/RELEASE.md
+++ b/kedro-telemetry/RELEASE.md
@@ -1,5 +1,6 @@
 # Upcoming release
 * Added support for Python 3.14.
+* Fixed `Kedro Project Statistics` event so dataset-type counts are accepted by Heap. Counts are now sent as individual scalar properties named `dataset_type_count.<dataset-class-FQN>` instead of a single nested `dataset_types` object, which Heap's API rejects.
 
 # Release 0.7.0
 * Dropped support for Python 3.9 (EOL Oct 2025). Minimum supported version is now 3.10.

--- a/kedro-telemetry/kedro_telemetry/plugin.py
+++ b/kedro-telemetry/kedro_telemetry/plugin.py
@@ -302,28 +302,28 @@ def _format_project_statistics_data(
     catalog: DataCatalog,
     default_pipeline: Pipeline,
     project_pipelines: dict,
-):
+) -> dict[str, Any]:
     """Add project statistics to send to Heap."""
     # Support both catalog.list() for `kedro < 1.0` and catalog.keys() for `kedro >= 1.0`
-    dataset_types: dict[str | None, int] = {}
+    dataset_type_counts: dict[str, int] = {}
     if hasattr(catalog, "keys") and callable(catalog.keys):
         # Only collect dataset types for kedro >= 1.0 because `get_type` method is not available in earlier versions
         dataset_names = catalog.keys()
         for ds_name in dataset_names:
-            if not ds_name.startswith(("parameters", "params:")):
-                ds_type = catalog.get_type(ds_name) or ""
-                if (
-                    ds_type.startswith("kedro_datasets.")
-                    or ds_type.startswith("kedro.io.")
-                    or ds_type.startswith("kedro_datasets_experimental.")
-                ):
-                    dataset_types[ds_type] = dataset_types.get(ds_type, 0) + 1
-                else:
-                    dataset_types["custom"] = dataset_types.get("custom", 0) + 1
+            if ds_name.startswith(("parameters", "params:")):
+                continue
+            ds_type = catalog.get_type(ds_name) or ""
+            if ds_type.startswith(
+                ("kedro_datasets.", "kedro.io.", "kedro_datasets_experimental.")
+            ):
+                key = ds_type
+            else:
+                key = "custom"
+            dataset_type_counts[key] = dataset_type_counts.get(key, 0) + 1
     else:
         dataset_names = catalog.list()  # type: ignore
 
-    return {
+    properties: dict[str, Any] = {
         "number_of_datasets": sum(
             1
             for c in dataset_names
@@ -331,8 +331,13 @@ def _format_project_statistics_data(
         ),
         "number_of_nodes": len(default_pipeline.nodes) if default_pipeline else None,  # type: ignore
         "number_of_pipelines": len(project_pipelines.keys()),
-        "dataset_types": dataset_types,
     }
+    # Flatten per-type counts into individual scalar properties so they are
+    # accepted by Heap (which only allows string/number property values) and
+    # can be aggregated/grouped in Heap dashboards.
+    for type_name, count in dataset_type_counts.items():
+        properties[f"dataset_type_count.{type_name}"] = count
+    return properties
 
 
 def _get_heap_app_id() -> str:

--- a/kedro-telemetry/tests/test_plugin.py
+++ b/kedro-telemetry/tests/test_plugin.py
@@ -580,7 +580,8 @@ class TestKedroTelemetryHook:
             "number_of_datasets": 4,
             "number_of_nodes": 2,
             "number_of_pipelines": 2,
-            "dataset_types": {"custom": 1, "kedro.io.memory_dataset.MemoryDataset": 3},
+            "dataset_type_count.custom": 1,
+            "dataset_type_count.kedro.io.memory_dataset.MemoryDataset": 3,
         }
         expected_properties = {**project_properties, **project_statistics}
         expected_call = mocker.call(
@@ -644,7 +645,8 @@ class TestKedroTelemetryHook:
             "number_of_datasets": 4,
             "number_of_nodes": 2,
             "number_of_pipelines": 2,
-            "dataset_types": {"custom": 1, "kedro.io.memory_dataset.MemoryDataset": 3},
+            "dataset_type_count.custom": 1,
+            "dataset_type_count.kedro.io.memory_dataset.MemoryDataset": 3,
         }
         expected_properties = {**project_properties, **project_statistics}
 
@@ -714,7 +716,8 @@ class TestKedroTelemetryHook:
             "number_of_datasets": 4,
             "number_of_nodes": 2,
             "number_of_pipelines": 2,
-            "dataset_types": {"kedro.io.memory_dataset.MemoryDataset": 3, "custom": 1},
+            "dataset_type_count.kedro.io.memory_dataset.MemoryDataset": 3,
+            "dataset_type_count.custom": 1,
         }
         expected_properties = {**project_properties, **project_statistics}
 
@@ -761,9 +764,9 @@ class TestKedroTelemetryHook:
         assert result["number_of_datasets"] == ds_nodes_pipes_cnt
         assert result["number_of_nodes"] == ds_nodes_pipes_cnt
         assert result["number_of_pipelines"] == ds_nodes_pipes_cnt
-        assert (
-            result["dataset_types"] == {}
-        )  # dataset types are not available for old catalog
+        # dataset types are not available for the old catalog, so no
+        # dataset_type_count.* properties should be emitted at all.
+        assert not any(k.startswith("dataset_type_count.") for k in result)
 
     def test_new_catalog_with_keys_method(self, pipeline_fixture, project_pipelines):
         # catalog.list() was replaces with catalog.keys() in `kedro >= 1.0`
@@ -792,4 +795,7 @@ class TestKedroTelemetryHook:
         assert result["number_of_nodes"] == ds_nodes_pipes_cnt
         assert result["number_of_pipelines"] == ds_nodes_pipes_cnt
         # Ensure dataset types are counted for the new catalog + doesn't count parameters
-        assert result["dataset_types"] == {"kedro.io.memory_dataset.MemoryDataset": 2}
+        assert (
+            result["dataset_type_count.kedro.io.memory_dataset.MemoryDataset"]
+            == ds_nodes_pipes_cnt
+        )


### PR DESCRIPTION
## Description

Heap's `/api/track` `properties` field only accepts scalar (string/number) values, see https://developers.heap.io/reference/track-1.

So the nested `dataset_types` object the plugin was sending in the `Kedro Project Statistics` event was being silently rejected. As a result, dataset-type usage data never made it into Heap.

## Development notes

- Updated `_format_project_statistics_data` in `kedro_telemetry/plugin.py` to flatten dataset-type counts into one scalar property per type, named `dataset_type_count.<dataset-class-FQN>` (e.g. `dataset_type_count.kedro_datasets.pandas.csv_dataset.CSVDataset`).
- Updated all five affected assertions in `tests/test_plugin.py` to the new shape.
- Added a `RELEASE.md` entry under "Upcoming release".

Tested locally on Python 3.11 + Kedro 1.3.1

## Payload change

### Before — rejected by Heap

```json
"properties": {
  "...": "...",
  "number_of_datasets": 12,
  "number_of_nodes": 7,
  "number_of_pipelines": 3,
  "dataset_types": {
    "kedro_datasets.pandas.csv_dataset.CSVDataset": 5,
    "kedro_datasets.pandas.parquet_dataset.ParquetDataset": 2,
    "kedro.io.memory_dataset.MemoryDataset": 4,
    "custom": 1
  }
}
```

`dataset_types` is a nested object. Per the [Heap Track API](https://developers.heap.io/reference/track-1), each property value must be a string or number under 1024 chars, so this field is rejected/dropped on Heap's side.

### After — accepted by Heap

```json
"properties": {
  "...": "...",
  "number_of_datasets": 12,
  "number_of_nodes": 7,
  "number_of_pipelines": 3,
  "dataset_type_count.kedro_datasets.pandas.csv_dataset.CSVDataset": 5,
  "dataset_type_count.kedro_datasets.pandas.parquet_dataset.ParquetDataset": 2,
  "dataset_type_count.kedro.io.memory_dataset.MemoryDataset": 4,
  "dataset_type_count.custom": 1
}
```

Each dataset class becomes its own scalar (numeric) property under the `dataset_type_count.*` namespace. This keeps the same information, satisfies Heap's contract, preserves FQNs (so e.g. `kedro_datasets.pandas.csv_dataset.CSVDataset` and a hypothetical `kedro_datasets.polars.csv_dataset.CSVDataset` stay distinct), and makes each type filterable/groupable in Heap dashboards.

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Updated `jsonschema/kedro-catalog-X.XX.json` if necessary
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
- [ ] Received approvals from at least half of the TSC (required for adding a new, non-experimental dataset)
