### PR TITLE
fix(telemetry): Correctly format selected tools sent to Heap

### DIFF
--- a/kedro-telemetry/RELEASE.md
+++ b/kedro-telemetry/RELEASE.md
@@ -1,5 +1,6 @@
 # Upcoming release
 * Added support for Python 3.14.
+* Fixed formatting of the `tools` property sent to Heap so it is a readable comma-separated string (e.g. `"Linting, Testing"`).
 
 # Release 0.7.0
 * Dropped support for Python 3.9 (EOL Oct 2025). Minimum supported version is now 3.10.

--- a/kedro-telemetry/kedro_telemetry/plugin.py
+++ b/kedro-telemetry/kedro_telemetry/plugin.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ast
 import hashlib
 import json
 import logging
@@ -133,13 +134,43 @@ def _add_tool_properties(
         try:
             tool_kedro = pyproject_data["tool"]["kedro"]
             if "tools" in tool_kedro:
-                properties["tools"] = ", ".join(tool_kedro["tools"])
+                tools_property = _format_tools(tool_kedro["tools"])
+                if tools_property is not None:
+                    properties["tools"] = tools_property
             if "example_pipeline" in tool_kedro:
                 properties["example_pipeline"] = tool_kedro["example_pipeline"]
         except KeyError:
             pass
 
     return properties
+
+
+def _format_tools(tools_value: Any) -> str | None:
+    """Normalise the `[tool.kedro] tools` value to a comma-separated string.
+
+    Kedro's project template writes `tools` as a TOML string containing the
+    `str()` of a Python list (e.g. ``tools = "['Linting', 'Testing']"``), so
+    `tomllib` returns a string here, not a list. The previous implementation
+    assumed a list and called ``", ".join(...)`` directly, which iterated over
+    the string character-by-character and produced unusable output in Heap.
+
+    This function accepts either form (the real Kedro string, or a TOML array
+    in case the file was hand-edited) and returns ``None`` when there's no
+    usable value to send.
+    """
+    if isinstance(tools_value, str):
+        try:
+            parsed = ast.literal_eval(tools_value)
+        except (ValueError, SyntaxError):
+            parsed = None
+        if isinstance(parsed, (list, tuple)):
+            tools_value = parsed
+
+    if isinstance(tools_value, (list, tuple)):
+        return ", ".join(str(t) for t in tools_value) or None
+    if isinstance(tools_value, str) and tools_value:
+        return tools_value
+    return None
 
 
 def _generate_new_uuid(full_path: str) -> str:

--- a/kedro-telemetry/tests/test_masking.py
+++ b/kedro-telemetry/tests/test_masking.py
@@ -27,6 +27,7 @@ DEFAULT_KEDRO_COMMANDS = [
     "pipeline",
     "registry",
     "run",
+    "server",
     "starter",
     "--version",
     "-V",

--- a/kedro-telemetry/tests/test_plugin.py
+++ b/kedro-telemetry/tests/test_plugin.py
@@ -21,6 +21,7 @@ from kedro_telemetry.plugin import (
     KedroTelemetryHook,
     _check_for_telemetry_consent,
     _format_project_statistics_data,
+    _format_tools,
     _is_known_ci_env,
 )
 
@@ -44,7 +45,7 @@ new-proj = "spaceflights.__main__:main"
 package_name = "spaceflights"
 project_name = "spaceflights"
 kedro_init_version = "0.18.14"
-tools = ["Linting", "Testing", "Custom Logging", "Documentation", "Data Structure", "PySpark"]
+tools = "['Linting', 'Testing', 'Custom Logging', 'Documentation', 'Data Structure', 'PySpark']"
 example_pipeline = "True"
 
 [project.entry-points."kedro.hooks"]
@@ -793,3 +794,48 @@ class TestKedroTelemetryHook:
         assert result["number_of_pipelines"] == ds_nodes_pipes_cnt
         # Ensure dataset types are counted for the new catalog + doesn't count parameters
         assert result["dataset_types"] == {"kedro.io.memory_dataset.MemoryDataset": 2}
+
+
+class TestFormatTools:
+    """Tests for `_format_tools`, which normalises the ``[tool.kedro] tools``
+    value (which Kedro writes as a TOML string containing ``str(list)``) into
+    a comma-separated string suitable for Heap."""
+
+    @mark.parametrize(
+        "tools_value, expected",
+        [
+            # Real Kedro starter format: TOML string containing str(list)
+            (
+                "['Linting', 'Testing', 'Documentation']",
+                "Linting, Testing, Documentation",
+            ),
+            # Default "no tools selected" written by the starter
+            ("['None']", "None"),
+            # Hand-edited / legacy TOML array form
+            (["Linting", "Testing"], "Linting, Testing"),
+            (("Linting", "Testing"), "Linting, Testing"),
+            # Plain comma-separated string (already in the desired shape)
+            ("Linting, Testing", "Linting, Testing"),
+        ],
+    )
+    def test_supported_inputs(self, tools_value, expected):
+        assert _format_tools(tools_value) == expected
+
+    @mark.parametrize(
+        "tools_value",
+        [
+            "",
+            [],
+            (),
+            "[]",
+            None,
+            123,
+        ],
+    )
+    def test_empty_or_unsupported_inputs_return_none(self, tools_value):
+        assert _format_tools(tools_value) is None
+
+    def test_malformed_string_falls_back_to_string_value(self):
+        # Not valid Python literal, but a non-empty string -> sent verbatim
+        # so we still get _something_ in Heap rather than dropping the field.
+        assert _format_tools("Linting; Testing") == "Linting; Testing"


### PR DESCRIPTION
## Description
The `tools` property in the `Kedro Project Statistics` event was being sent to Heap as a per-character soup, e.g. `"[, ', L, i, n, t, i, n, g, ', ,,  , ', T, e, s, t, i, n, g, ', ]"`, instead of the intended `"Linting, Testing"`.

Root cause: Kedro's project template writes `[tool.kedro] tools` as a TOML **string** containing the `str()` of a Python list (e.g. `tools = "['Linting', 'Testing']"`), but the plugin assumed it was a list and called `", ".join(tool_kedro["tools"])` on it — `str.join` then iterated over the string character-by-character.

The bug went unnoticed because both test fixtures (`MOCK_PYPROJECT_TOOLS` and `tests/integration/dummy-project/pyproject.toml`) used a TOML array form that doesn't match what Kedro actually generates.
## Development notes
- Added `_format_tools` in `kedro_telemetry/plugin.py` that parses the value with `ast.literal_eval` and returns a comma-separated string. Handles all of:
  - Real Kedro form: `"['Linting', 'Testing']"` → `"Linting, Testing"`
  - Hand-edited TOML array: `["Linting", "Testing"]` → `"Linting, Testing"`
  - Plain CSV string: `"Linting, Testing"` → passed through
  - Empty / `None` / malformed → property is not sent
- Updated `MOCK_PYPROJECT_TOOLS` to use the real Kedro form so the two existing `*with_tools` tests now exercise the production code path. Existing assertions are unchanged.
- Added a focused `TestFormatTools` class (12 parametrised cases) covering all input shapes.
- Added a `RELEASE.md` entry under "Upcoming release".

Tested locally on Python 3.11 + Kedro 1.3.1.

## Payload change
Before — produced by real Kedro projects today:
```json
"tools": "[, ', L, i, n, t, i, n, g, ', ,,  , ', T, e, s, t, i, n, g, ', ,,  , ', D, o, c, u, m, e, n, t, a, t, i, o, n, ', ]"
```


Screenshot from heap:
<img width="451" height="106" alt="Screenshot 2026-05-08 at 15 41 14" src="https://github.com/user-attachments/assets/9b86908e-7228-421f-9086-7e590cd377d0" />


After:
```json
"tools": "Linting, Testing, Documentation"
```

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Updated `jsonschema/kedro-catalog-X.XX.json` if necessary
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
- [ ] Received approvals from at least half of the TSC (required for adding a new, non-experimental dataset)
