### PR TITLE
fix(datasets): Bump litellm version on Python 3.14 for chromadb compatibility

### DIFF
--- a/kedro-datasets/pyproject.toml
+++ b/kedro-datasets/pyproject.toml
@@ -420,6 +420,7 @@ experimental_test = [
     "s3fs>=2021.04",
     "reportlab>=3.6.0",
     "chromadb>=1.0.0",
+    "litellm<1.80.12; python_version >= '3.14'",  # For compatibility with chromadb's opentelemetry-proto
     "dask[complete]>=2021.10",
 ]
 


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->

#### Why was this breaking?

The `experimental_tes`t extra installs all experimental dataset dependencies into a single shared environment. On Python 3.14, this creates a dependency conflict that prevents chromadb from importing.

  1. `opik` requires `litellm>=1.79.2`
  2. `litellm>=1.80.12` introduced a Python 3.14-specific requirement: `grpcio>=1.75.0`
  3. `grpcio>=1.75.0` pulls in `grpcio-status>=1.75.0`, which requires `protobuf>=6.31.1`
  4. All versions of `opentelemetry-proto` with correctly-generated `protobuf` bindings (1.12.x–1.34.x) require
  `protobuf<5.0`, which is incompatible with the >=6.31.1 floor
  5. The only `opentelemetry-proto` version compatible with `protobuf>=6` is 1.11.1, which has no upper bound, but its
  _pb2.py files were generated with an old protoc and use a descriptor API removed in `protobuf>=4.0`
  6. chromadb imports `opentelemetry-exporter-otlp-proto-grpc` at module level, so the resolver gets stuck with
  `opentelemetry-proto==1.11.1` and the test collection fails with TypeError: Descriptors cannot be created directly

<img width="963" height="128" alt="image" src="https://github.com/user-attachments/assets/de17de2e-0607-43dc-a4ce-a25d790865a3" />

ChromaDBDataset is the only dataset affected. The langfuse and opik datasets also use opentelemetry, but via the HTTP exporter (no grpcio-status dependency) and with lazy imports, so they are not impacted.

Pinning  `litellm<1.80.12` in  experimental_test on Python 3.14 keeps `litellm` below the version that introduced the `grpcio` bump, allowing the resolver to pick a `grpcio-status` version with looser `protobuf constraints`.

## Development notes
<!-- What have you changed, and how has this been tested? -->

This constraint will need revisiting if opik raises its litellm minimum above 1.80.11. The long-term fix would be for chromadb to upgrade to opentelemetry-exporter-otlp-proto-grpc>=1.35.0, whose opentelemetry-proto dependency supports protobuf>=5.0,<7.0, but that is out of our control.


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Updated `jsonschema/kedro-catalog-X.XX.json` if necessary
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
- [ ] Received approvals from at least half of the TSC (required for adding a new, non-experimental dataset)
