### PR TITLE
feat(datasets): Add CMP script to Kedro datasets docs

### DIFF
--- a/kedro-datasets/docs/overrides/partials/copyright-legal-socials.html
+++ b/kedro-datasets/docs/overrides/partials/copyright-legal-socials.html
@@ -2,6 +2,15 @@
     <div class="copyright">
         <span class="copyright-first-line">Copyright © Kedro, a Series of LF Projects, LLC</span>
     </div>
+    <div class="legal-links">
+        <button
+            type="button"
+            class="cookie-settings-btn"
+            onclick="window.CookieConsent && window.CookieConsent.showPreferences && window.CookieConsent.showPreferences()"
+        >
+            Cookie Settings
+        </button>
+    </div>
     <div class="social-links">
         <a href="https://kedro-org.slack.com" target="_blank" rel="noopener" aria-label="Slack">
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20">

--- a/kedro-datasets/docs/stylesheets/footer.css
+++ b/kedro-datasets/docs/stylesheets/footer.css
@@ -36,6 +36,9 @@
   display: flex;
   gap: 16px;
   font-size: 14px;
+  margin-left: auto;
+  padding-right: 16px;
+  border-right: 1px solid var(--footer-text-color);
 }
 
 .legal-links a {
@@ -47,10 +50,23 @@
   text-decoration: underline;
 }
 
+.legal-links button.cookie-settings-btn {
+  background: none;
+  border: 0;
+  padding: 0;
+  font: inherit;
+  cursor: pointer;
+  color: var(--footer-text-color);
+}
+
+.legal-links button.cookie-settings-btn:hover {
+  text-decoration: underline;
+}
+
 .social-links {
   display: flex;
   gap: 1rem;
-  margin-left: auto;
+  margin-left: 16px;
 }
 
 .social-links a {
@@ -165,6 +181,9 @@
   .legal-links {
      flex-wrap: wrap;
     gap: 16px;
+    margin-left: 0;
+    padding-right: 0;
+    border-right: 0;
   }
 
   .social-links {

--- a/kedro-datasets/mkdocs.yml
+++ b/kedro-datasets/mkdocs.yml
@@ -235,6 +235,7 @@ extra_css:
   - stylesheets/code-select.css
 
 extra_javascript:
+  - https://kedro.org/consent/kedro-consent.js
   - javascript/readthedocs.js
   - javascript/deindex-old-docs.js
   - javascript/code-select.js


### PR DESCRIPTION
Similar to https://github.com/kedro-org/kedro/pull/5510

## Description

  This pull request makes an update to the `kedro-datasets` documentation configuration by adding a new JavaScript file for consent management and updating the documentation site footer to add a "Cookie Settings" button. It mirrors the same change made for the main Kedro docs in
  https://github.com/kedro-org/kedro/pull/5510, so the consent banner and analytics behaviour are consistent across `docs.kedro.org` and `docs.kedro.org/projects/kedro-datasets`.

  ## Development notes

  * Included the external `kedro-consent.js` script from `kedro.org` to enable cookie consent functionality. (`kedro-datasets/mkdocs.yml`)
  * Added a "Cookie Settings" button to the footer, allowing users to manage their cookie preferences via the CookieConsent library. (`kedro-datasets/docs/overrides/partials/copyright-legal-socials.html`)
  * Styled the new button and adjusted the footer layout so it sits between the copyright line and the social icons with a vertical divider; mobile media query resets the divider/margin. (`kedro-datasets/docs/stylesheets/footer.css`)

  The script is the same one served from `https://kedro.org/consent/kedro-consent.js` (introduced in https://github.com/kedro-org/kedro-website/pull/216), so consent state is shared across `*.kedro.org` subdomains and Heap Analytics only loads after the user opts in.

  ## Test plan

  ### Prerequisites

  ```bash
  cd kedro-datasets
  uv pip install -e ".[docs]"
  ```

  ### 1. Strict build

  ```bash
  mkdocs build --strict
  ```

  Expected: build succeeds with no warnings/errors.

  ```bash
  grep -c "kedro.org/consent/kedro-consent.js" site/index.html
  ```

  Expected output: `1`.

  Also confirm the script propagates to deeper pages:

  ```bash
  grep -c "kedro.org/consent/kedro-consent.js" site/api/kedro_datasets/pandas.CSVDataset/index.html
  ```

  Expected output: `1`.

  ### 2. Local dev server

  ```bash
  mkdocs serve
  ```

  Open http://127.0.0.1:8000/.

  ### 3. Consent script is requested

  DevTools → **Network** tab → reload the page.

  - A request to `https://kedro.org/consent/kedro-consent.js` appears.
  - If it 404s or is blocked (expected until the script is deployed on `kedro.org`), no Heap scripts are requested and no `_hp*` cookies are set — this is the fail-safe behaviour from kedro-org/kedro#5361.

  ### 4. Footer button renders

  Scroll to the page footer.

  - `Cookie Settings` button sits on the right side of the footer, between the copyright line and the social icons, separated by a vertical divider.
  - Hovering the button shows an underline.
  - Once the consent script is live on `kedro.org`, clicking the button re-opens the preferences modal; until then the click is a safe no-op (guarded by `window.CookieConsent && window.CookieConsent.showPreferences`).

  ## Developer Certificate of Origin

  We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for 
  guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

  If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

  ## Checklist

  - [ ] Read the [contributing](https://github.com/kedro-org/kedro-plugins/blob/main/CONTRIBUTING.md) guidelines
  - [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
  - [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
  - [ ] Updated the documentation to reflect the code changes
  - [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro-plugins/blob/main/kedro-datasets/RELEASE.md) file
  - [ ] Added tests to cover my changes
  - [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team