### PR TITLE
fix(datasets): support PathLike in pandas datasets

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -142,14 +142,14 @@
         "filename": "kedro-datasets/kedro_datasets/pandas/sql_dataset.py",
         "hashed_secret": "46e3d772a1888eadff26c7ada47fd7502d796e07",
         "is_verified": false,
-        "line_number": 128
+        "line_number": 129
       },
       {
         "type": "Secret Keyword",
         "filename": "kedro-datasets/kedro_datasets/pandas/sql_dataset.py",
         "hashed_secret": "e026e197bb77b12d16ab6986e068751f016d0ea5",
         "is_verified": false,
-        "line_number": 369
+        "line_number": 370
       }
     ],
     "kedro-datasets/kedro_datasets/snowflake/snowpark_dataset.py": [
@@ -460,5 +460,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-12T22:31:44Z"
+  "generated_at": "2026-05-14T13:15:43Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -249,7 +249,7 @@
         "filename": "kedro-datasets/tests/pandas/test_csv_dataset.py",
         "hashed_secret": "adb5fabe51f5b45e83fdd91b71c92156fec4a63e",
         "is_verified": false,
-        "line_number": 409
+        "line_number": 416
       }
     ],
     "kedro-datasets/tests/pandas/test_generic_dataset.py": [
@@ -460,5 +460,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-28T15:02:26Z"
+  "generated_at": "2026-05-12T22:31:44Z"
 }

--- a/kedro-datasets/RELEASE.md
+++ b/kedro-datasets/RELEASE.md
@@ -15,7 +15,7 @@
 
 - Refactored shared validation and utility logic from the three Opik experimental datasets (`PromptDataset`, `EvaluationDataset`, `TraceDataset`) into a common `opik._common` module.
 - Refactored shared validation and utility logic from the three Langfuse experimental datasets (`PromptDataset`, `EvaluationDataset`, `TraceDataset`) into a common `langfuse._common` module.
-- Added `os.PathLike` support for `plotly` datasets.
+- Added `os.PathLike` support for `plotly` and `pandas` datasets.
 - Added `checkpoint.filepath` validation for IncrementalDataset.
 - Restructured the `README.md` file for Opik experimental datasets and added information on `opik.TraceDataset`.
 

--- a/kedro-datasets/RELEASE.md
+++ b/kedro-datasets/RELEASE.md
@@ -43,6 +43,7 @@ Many thanks to the following Kedroids for contributing PRs to this release:
 - [Guillaume Tauzin](https://github.com/gtauzin)
 - [iwhalen](https://github.com/iwhalen)
 - [Sai Asish Y](https://github.com/SAY-5)
+- [Kaushal Dhungel](https://github.com/Kaushal-Dhungel)
 
 # Release 9.3.0
 

--- a/kedro-datasets/kedro_datasets/pandas/csv_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/csv_dataset.py
@@ -4,6 +4,7 @@ filesystem (e.g.: local, S3, GCS). It uses pandas to handle the CSV file.
 from __future__ import annotations
 
 import logging
+import os
 from copy import deepcopy
 from pathlib import PurePosixPath
 from typing import Any
@@ -73,7 +74,7 @@ class CSVDataset(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
     def __init__(  # noqa: PLR0913
         self,
         *,
-        filepath: str,
+        filepath: str | os.PathLike,
         load_args: dict[str, Any] | None = None,
         save_args: dict[str, Any] | None = None,
         version: Version | None = None,
@@ -89,6 +90,7 @@ class CSVDataset(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
                 If prefix is not provided, `file` protocol (local filesystem) will be used.
                 The prefix should be any protocol supported by ``fsspec``.
                 Note: `http(s)` doesn't support versioning.
+                Can be a string or a PathLike object.
             load_args: Pandas options for loading CSV files.
                 Here you can find all available arguments:
                 https://pandas.pydata.org/pandas-docs/stable/generated/pandas.read_csv.html

--- a/kedro-datasets/kedro_datasets/pandas/deltatable_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/deltatable_dataset.py
@@ -5,6 +5,7 @@ load and save using a pandas dataframe.
 
 from __future__ import annotations
 
+import os
 from copy import deepcopy
 from typing import Any
 
@@ -84,7 +85,7 @@ class DeltaTableDataset(AbstractDataset):
     def __init__(  # noqa: PLR0913
         self,
         *,
-        filepath: str | None = None,
+        filepath: str | os.PathLike | None = None,
         catalog_type: str | None = None,
         catalog_name: str | None = None,
         database: str | None = None,

--- a/kedro-datasets/kedro_datasets/pandas/deltatable_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/deltatable_dataset.py
@@ -105,6 +105,7 @@ class DeltaTableDataset(AbstractDataset):
                 ``GCS``: `gs://<bucket>/<path>`
                 If any of the prefix above is not provided, `file` protocol (local filesystem)
                 will be used.
+                Can be a string or a PathLike object.
             catalog_type (DataCatalog, Optional): `AWS` or `UNITY` if filepath is not provided.
                 Defaults to None.
             catalog_name (str, Optional): the name of catalog in AWS Glue or Databricks Unity.

--- a/kedro-datasets/kedro_datasets/pandas/excel_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/excel_dataset.py
@@ -4,6 +4,7 @@ filesystem (e.g.: local, S3, GCS). It uses pandas to handle the Excel file.
 from __future__ import annotations
 
 import logging
+import os
 from copy import deepcopy
 from pathlib import PurePosixPath
 from typing import Any
@@ -102,7 +103,7 @@ class ExcelDataset(
     def __init__(  # noqa: PLR0913
         self,
         *,
-        filepath: str,
+        filepath: str | os.PathLike,
         engine: str = "openpyxl",
         load_args: dict[str, Any] | None = None,
         save_args: dict[str, Any] | None = None,
@@ -119,6 +120,7 @@ class ExcelDataset(
                 `s3://`. If prefix is not provided, `file` protocol (local filesystem) will be used.
                 The prefix should be any protocol supported by ``fsspec``.
                 Note: `http(s)` doesn't support versioning.
+                Can be a string or a PathLike object.
             engine: The engine used to write to Excel files. The default
                 engine is 'openpyxl'.
             load_args: Pandas options for loading Excel files.

--- a/kedro-datasets/kedro_datasets/pandas/feather_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/feather_dataset.py
@@ -5,6 +5,7 @@ is supported by pandas, so it supports all operations the pandas supports.
 from __future__ import annotations
 
 import logging
+import os
 from copy import deepcopy
 from pathlib import PurePosixPath
 from typing import Any
@@ -66,7 +67,7 @@ class FeatherDataset(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
     def __init__(  # noqa: PLR0913
         self,
         *,
-        filepath: str,
+        filepath: str | os.PathLike,
         load_args: dict[str, Any] | None = None,
         save_args: dict[str, Any] | None = None,
         version: Version | None = None,
@@ -82,6 +83,7 @@ class FeatherDataset(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
                 `s3://`. If prefix is not provided, `file` protocol (local filesystem) will be used.
                 The prefix should be any protocol supported by ``fsspec``.
                 Note: `http(s)` doesn't support versioning.
+                Can be a string or a PathLike object.
             load_args: Pandas options for loading feather files.
                 Here you can find all available arguments:
                 https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_feather.html

--- a/kedro-datasets/kedro_datasets/pandas/gbq_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/gbq_dataset.py
@@ -255,8 +255,7 @@ class GBQQueryDataset(AbstractDataset[None, pd.DataFrame]):
             fs_args: Extra arguments to pass into underlying filesystem class constructor
                 (e.g. `{"project": "my-project"}` for ``GCSFileSystem``) used for reading the
                 SQL query from filepath.
-            filepath: A path to a file with a sql query statement. Can be a string or
-            a PathLike object.
+            filepath: A path to a file with a sql query statement. Can be a string or a PathLike object.
             metadata: Any arbitrary metadata.
                 This is ignored by Kedro, but may be consumed by users or external plugins.
 

--- a/kedro-datasets/kedro_datasets/pandas/gbq_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/gbq_dataset.py
@@ -5,6 +5,7 @@ to read and write from/to BigQuery table.
 from __future__ import annotations
 
 import copy
+import os
 from pathlib import PurePosixPath
 from typing import Any, ClassVar, NoReturn
 
@@ -232,7 +233,7 @@ class GBQQueryDataset(AbstractDataset[None, pd.DataFrame]):
         credentials: dict[str, Any] | Credentials | None = None,
         load_args: dict[str, Any] | None = None,
         fs_args: dict[str, Any] | None = None,
-        filepath: str | None = None,
+        filepath: str | os.PathLike | None = None,
         metadata: dict[str, Any] | None = None,
     ) -> None:
         """Creates a new instance of ``GBQQueryDataset``.
@@ -254,7 +255,8 @@ class GBQQueryDataset(AbstractDataset[None, pd.DataFrame]):
             fs_args: Extra arguments to pass into underlying filesystem class constructor
                 (e.g. `{"project": "my-project"}` for ``GCSFileSystem``) used for reading the
                 SQL query from filepath.
-            filepath: A path to a file with a sql query statement.
+            filepath: A path to a file with a sql query statement. Can be a string or
+            a PathLike object.
             metadata: Any arbitrary metadata.
                 This is ignored by Kedro, but may be consumed by users or external plugins.
 

--- a/kedro-datasets/kedro_datasets/pandas/generic_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/generic_dataset.py
@@ -4,6 +4,7 @@ type of read/write target.
 """
 from __future__ import annotations
 
+import os
 from copy import deepcopy
 from pathlib import PurePosixPath
 from typing import Any
@@ -87,7 +88,7 @@ class GenericDataset(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
     def __init__(  # noqa: PLR0913
         self,
         *,
-        filepath: str,
+        filepath: str | os.PathLike,
         file_format: str,
         load_args: dict[str, Any] | None = None,
         save_args: dict[str, Any] | None = None,

--- a/kedro-datasets/kedro_datasets/pandas/generic_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/generic_dataset.py
@@ -105,6 +105,7 @@ class GenericDataset(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
             filepath: Filepath in POSIX format to a file prefixed with a protocol like `s3://`.
                 If prefix is not provided, `file` protocol (local filesystem) will be used.
                 The prefix should be any protocol supported by ``fsspec``.
+                Can be a string or a PathLike object.
                 Key assumption: The first argument of either load/save method points to a
                 filepath/buffer/io type location. There are some read/write targets such
                 as 'clipboard' or 'records' that will fail since they do not take a

--- a/kedro-datasets/kedro_datasets/pandas/hdf_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/hdf_dataset.py
@@ -3,6 +3,7 @@ filesystem (e.g.: local, S3, GCS). It uses pandas.HDFStore to handle the hdf fil
 """
 from __future__ import annotations
 
+import os
 from copy import deepcopy
 from pathlib import PurePosixPath
 from threading import Lock
@@ -60,7 +61,7 @@ class HDFDataset(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
     def __init__(  # noqa: PLR0913
         self,
         *,
-        filepath: str,
+        filepath: str | os.PathLike,
         key: str,
         load_args: dict[str, Any] | None = None,
         save_args: dict[str, Any] | None = None,
@@ -77,6 +78,7 @@ class HDFDataset(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
                 If prefix is not provided, `file` protocol (local filesystem) will be used.
                 The prefix should be any protocol supported by ``fsspec``.
                 Note: `http(s)` doesn't support versioning.
+                Can be a string or a PathLike object.
             key: Identifier to the group in the HDF store.
             load_args: PyTables options for loading hdf files.
                 You can find all available arguments at:

--- a/kedro-datasets/kedro_datasets/pandas/json_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/json_dataset.py
@@ -4,6 +4,7 @@ filesystem (e.g.: local, S3, GCS). It uses pandas to handle the JSON file.
 from __future__ import annotations
 
 import logging
+import os
 from copy import deepcopy
 from pathlib import PurePosixPath
 from typing import Any
@@ -65,7 +66,7 @@ class JSONDataset(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
     def __init__(  # noqa: PLR0913
         self,
         *,
-        filepath: str,
+        filepath: str | os.PathLike,
         load_args: dict[str, Any] | None = None,
         save_args: dict[str, Any] | None = None,
         version: Version | None = None,
@@ -81,6 +82,7 @@ class JSONDataset(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
                 If prefix is not provided `file` protocol (local filesystem) will be used.
                 The prefix should be any protocol supported by ``fsspec``.
                 Note: `http(s)` doesn't support versioning.
+                Can be a string or a PathLike object.
             load_args: Pandas options for loading JSON files.
                 Here you can find all available arguments:
                 https://pandas.pydata.org/pandas-docs/stable/generated/pandas.read_json.html

--- a/kedro-datasets/kedro_datasets/pandas/parquet_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/parquet_dataset.py
@@ -4,6 +4,7 @@ filesystem (e.g.: local, S3, GCS). It uses pandas to handle the Parquet file.
 from __future__ import annotations
 
 import logging
+import os
 from copy import deepcopy
 from pathlib import Path, PurePosixPath
 from typing import Any
@@ -75,7 +76,7 @@ class ParquetDataset(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
     def __init__(  # noqa: PLR0913
         self,
         *,
-        filepath: str,
+        filepath: str | os.PathLike,
         load_args: dict[str, Any] | None = None,
         save_args: dict[str, Any] | None = None,
         version: Version | None = None,

--- a/kedro-datasets/kedro_datasets/pandas/parquet_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/parquet_dataset.py
@@ -94,6 +94,7 @@ class ParquetDataset(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
                 It can also be a path to a directory. If the directory is
                 provided then it can be used for reading partitioned parquet files.
                 Note: `http(s)` doesn't support versioning.
+                Can be a string or a PathLike object.
             load_args: Additional options for loading Parquet file(s).
                 Here you can find all available arguments when reading single file:
                 https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_parquet.html

--- a/kedro-datasets/kedro_datasets/pandas/sql_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/sql_dataset.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import copy
 import datetime as dt
+import os
 import re
 from pathlib import PurePosixPath
 from typing import Any, NoReturn
@@ -420,7 +421,7 @@ class SQLQueryDataset(AbstractDataset[None, pd.DataFrame]):
         credentials: dict[str, Any] | None = None,
         load_args: dict[str, Any] | None = None,
         fs_args: dict[str, Any] | None = None,
-        filepath: str | None = None,
+        filepath: str | os.PathLike | None = None,
         execution_options: dict[str, Any] | None = None,
         metadata: dict[str, Any] | None = None,
         encoding: str | None = None,

--- a/kedro-datasets/kedro_datasets/pandas/sql_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/sql_dataset.py
@@ -451,7 +451,7 @@ class SQLQueryDataset(AbstractDataset[None, pd.DataFrame]):
                 Here you can find all available arguments for `open`:
                 https://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.spec.AbstractFileSystem.open
                 All defaults are preserved, except `mode`, which is set to `r` when loading.
-            filepath: A path to a file with a sql query statement.
+            filepath: A path to a file with a sql query statement. Can be a string or a PathLike object.
             execution_options: A dictionary with non-SQL advanced options for the connection to
                 be applied to the underlying engine. To find all supported execution
                 options, see here:

--- a/kedro-datasets/kedro_datasets/pandas/xml_dataset.py
+++ b/kedro-datasets/kedro_datasets/pandas/xml_dataset.py
@@ -4,6 +4,7 @@ filesystem (e.g.: local, S3, GCS). It uses pandas to handle the XML file.
 from __future__ import annotations
 
 import logging
+import os
 from copy import deepcopy
 from pathlib import PurePosixPath
 from typing import Any
@@ -48,7 +49,7 @@ class XMLDataset(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
     def __init__(  # noqa: PLR0913
         self,
         *,
-        filepath: str,
+        filepath: str | os.PathLike,
         load_args: dict[str, Any] | None = None,
         save_args: dict[str, Any] | None = None,
         version: Version | None = None,
@@ -64,6 +65,7 @@ class XMLDataset(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
                 If prefix is not provided, `file` protocol (local filesystem) will be used.
                 The prefix should be any protocol supported by ``fsspec``.
                 Note: `http(s)` doesn't support versioning.
+                Can be a string or a PathLike object.
             load_args: Pandas options for loading XML files.
                 Here you can find all available arguments:
                 https://pandas.pydata.org/docs/reference/api/pandas.read_xml.html

--- a/kedro-datasets/tests/pandas/test_csv_dataset.py
+++ b/kedro-datasets/tests/pandas/test_csv_dataset.py
@@ -235,6 +235,13 @@ class TestCSVDataset:
         assert dataset._cached_load_version is None
         assert dataset._cached_save_version is None
 
+    def test_pathlike_filepath(self, tmp_path, dummy_dataframe):
+        """Test that os.PathLike filepaths are supported."""
+        filepath = tmp_path / "test.csv"
+        dataset = CSVDataset(filepath=filepath)
+        dataset.save(dummy_dataframe)
+        assert_frame_equal(dataset.load(), dummy_dataframe)
+
 
 class TestCSVDatasetVersioned:
     def test_version_str_repr(self, load_version, save_version):

--- a/kedro-datasets/tests/pandas/test_deltatable_dataset.py
+++ b/kedro-datasets/tests/pandas/test_deltatable_dataset.py
@@ -166,3 +166,10 @@ class TestDeltaTableDataset:
         history = deltatable_dataset_from_path.history
         assert isinstance(history, list)
         assert history[0]["operation"] == "WRITE"
+
+    def test_pathlike_filepath(self, tmp_path, dummy_df):
+        """Test that os.PathLike filepaths are supported."""
+        filepath = tmp_path / "test-delta-table"
+        dataset = DeltaTableDataset(filepath=filepath)
+        dataset.save(dummy_df)
+        assert_frame_equal(dummy_df, dataset.load())

--- a/kedro-datasets/tests/pandas/test_excel_dataset.py
+++ b/kedro-datasets/tests/pandas/test_excel_dataset.py
@@ -208,6 +208,13 @@ class TestExcelDataset:
         dataset.release()
         fs_mock.invalidate_cache.assert_called_once_with(filepath)
 
+    def test_pathlike_filepath(self, tmp_path, dummy_dataframe):
+        """Test that os.PathLike filepaths are supported."""
+        filepath = tmp_path / "test.xlsx"
+        dataset = ExcelDataset(filepath=filepath)
+        dataset.save(dummy_dataframe)
+        assert_frame_equal(dataset.load(), dummy_dataframe)
+
 
 class TestExcelDatasetVersioned:
     def test_version_str_repr(self, load_version, save_version):

--- a/kedro-datasets/tests/pandas/test_feather_dataset.py
+++ b/kedro-datasets/tests/pandas/test_feather_dataset.py
@@ -131,6 +131,13 @@ class TestFeatherDataset:
         dataset.release()
         fs_mock.invalidate_cache.assert_called_once_with(filepath)
 
+    def test_pathlike_filepath(self, tmp_path, dummy_dataframe):
+        """Test that os.PathLike filepaths are supported."""
+        filepath = tmp_path / "test.feather"
+        dataset = FeatherDataset(filepath=filepath)
+        dataset.save(dummy_dataframe)
+        assert_frame_equal(dataset.load(), dummy_dataframe)
+
 
 class TestFeatherDatasetVersioned:
     def test_version_str_repr(self, load_version, save_version):

--- a/kedro-datasets/tests/pandas/test_gbq_dataset.py
+++ b/kedro-datasets/tests/pandas/test_gbq_dataset.py
@@ -361,3 +361,20 @@ class TestGBQQueryDataset:
         )
         with pytest.raises(DatasetError, match=pattern):
             GBQQueryDataset(sql=SQL_QUERY, filepath=sql_file)
+
+    def test_pathlike_filepath(self, mocker, tmp_path, dummy_dataframe):
+        """Test that os.PathLike filepaths are supported."""
+        filepath = tmp_path / "test.sql"
+        filepath.write_text(SQL_QUERY)
+        dataset = GBQQueryDataset(filepath=filepath, project=PROJECT, credentials=None)
+        mocked_read_gbq = mocker.patch(
+            "kedro_datasets.pandas.gbq_dataset.pd_gbq.read_gbq"
+        )
+        mocked_read_gbq.return_value = dummy_dataframe
+        loaded_data = dataset.load()
+        mocked_read_gbq.assert_called_once_with(
+            project_id=PROJECT,
+            credentials=None,
+            query_or_table=SQL_QUERY,
+        )
+        assert_frame_equal(dummy_dataframe, loaded_data)

--- a/kedro-datasets/tests/pandas/test_generic_dataset.py
+++ b/kedro-datasets/tests/pandas/test_generic_dataset.py
@@ -150,6 +150,16 @@ class TestGenericSASDataset:
         assert dataset._cached_load_version is None
         assert dataset._cached_save_version is None
 
+    def test_pathlike_filepath(self, tmp_path, sas_binary):
+        """Test that os.PathLike filepaths are supported."""
+        filepath = tmp_path / "test.sas7bdat"
+        filepath.write_bytes(sas_binary)
+        dataset = GenericDataset(
+            filepath=filepath, file_format="sas", load_args={"format": "sas7bdat"}
+        )
+        df = dataset.load()
+        assert df.shape == (32, 6)
+
 
 class TestGenericCSVDatasetVersioned:
     def test_version_str_repr(self, filepath_csv, load_version, save_version):

--- a/kedro-datasets/tests/pandas/test_hdf_dataset.py
+++ b/kedro-datasets/tests/pandas/test_hdf_dataset.py
@@ -116,6 +116,13 @@ class TestHDFDataset:
         dataset.release()
         fs_mock.invalidate_cache.assert_called_once_with(filepath)
 
+    def test_pathlike_filepath(self, tmp_path, dummy_dataframe):
+        """Test that os.PathLike filepaths are supported."""
+        filepath = tmp_path / "test.h5"
+        dataset = HDFDataset(filepath=filepath, key=HDF_KEY)
+        dataset.save(dummy_dataframe)
+        assert_frame_equal(dataset.load(), dummy_dataframe)
+
     def test_save_and_load_df_with_categorical_variables(self, hdf_dataset):
         """Test saving and reloading the dataset with categorical variables."""
         df = pd.DataFrame(

--- a/kedro-datasets/tests/pandas/test_json_dataset.py
+++ b/kedro-datasets/tests/pandas/test_json_dataset.py
@@ -165,6 +165,13 @@ class TestJSONDataset:
         dataset.release()
         fs_mock.invalidate_cache.assert_called_once_with(filepath)
 
+    def test_pathlike_filepath(self, tmp_path, dummy_dataframe):
+        """Test that os.PathLike filepaths are supported."""
+        filepath = tmp_path / "test.json"
+        dataset = JSONDataset(filepath=filepath)
+        dataset.save(dummy_dataframe)
+        assert_frame_equal(dummy_dataframe, dataset.load())
+
     def test_preview_json(self, json_lines_data):
         dataset = JSONDataset(filepath=json_lines_data, load_args={"lines": True})
         preview_data = dataset.preview(nrows=2)

--- a/kedro-datasets/tests/pandas/test_parquet_dataset.py
+++ b/kedro-datasets/tests/pandas/test_parquet_dataset.py
@@ -251,6 +251,13 @@ class TestParquetDataset:
             == "TablePreview"
         )
 
+    def test_pathlike_filepath(self, tmp_path, dummy_dataframe):
+        """Test that os.PathLike filepaths are supported."""
+        filepath = tmp_path / FILENAME
+        dataset = ParquetDataset(filepath=filepath)
+        dataset.save(dummy_dataframe)
+        assert_frame_equal(dummy_dataframe, dataset.load())
+
 
 class TestParquetDatasetVersioned:
     def test_version_str_repr(self, load_version, save_version):

--- a/kedro-datasets/tests/pandas/test_sql_dataset.py
+++ b/kedro-datasets/tests/pandas/test_sql_dataset.py
@@ -564,3 +564,12 @@ class TestSQLQueryDataset:
         kedro_datasets.pandas.sql_dataset.create_engine.assert_called_once_with(
             CONNECTION, **additional_params
         )
+
+    def test_pathlike_filepath(self, mocker, tmp_path):
+        """Test that os.PathLike filepaths are supported."""
+        filepath = tmp_path / "test.sql"
+        filepath.write_text(SQL_QUERY)
+        dataset = SQLQueryDataset(filepath=filepath, credentials={"con": CONNECTION})
+        mocker.patch("pandas.read_sql_query")
+        dataset.load()
+        pd.read_sql_query.assert_called_once_with(sql=SQL_QUERY, con=ANY)

--- a/kedro-datasets/tests/pandas/test_xml_dataset.py
+++ b/kedro-datasets/tests/pandas/test_xml_dataset.py
@@ -142,6 +142,13 @@ class TestXMLDataset:
         dataset.release()
         fs_mock.invalidate_cache.assert_called_once_with(filepath)
 
+    def test_pathlike_filepath(self, tmp_path, dummy_dataframe):
+        """Test that os.PathLike filepaths are supported."""
+        filepath = tmp_path / "test.xml"
+        dataset = XMLDataset(filepath=filepath)
+        dataset.save(dummy_dataframe)
+        assert_frame_equal(dummy_dataframe, dataset.load())
+
 
 class TestXMLDatasetVersioned:
     def test_version_str_repr(self, load_version, save_version):


### PR DESCRIPTION
## Description
Adds `os.PathLike` support for Pandas datasets in `kedro-datasets`. Solves part of #1316.

## Development notes

Covered Pandas datasets:
- CSV
- DeltaTable
- Excel
- Feather
- GBQ query filepath
- Generic
- HDF
- JSON
- Parquet
- SQL query filepath
- XML
