### PR TITLE
fix(datasets): Fix for nightly build failure

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -36,8 +36,8 @@ jobs:
       - name: Run unit tests for kedro-airflow, kedro-docker, kedro-telemetry
         if: inputs.plugin != 'kedro-datasets'
         run: make plugin=${{ inputs.plugin }} test
-      - name: Reinstall CPU-only PyTorch to avoid triton/CUDA segfault
-        if: inputs.plugin == 'kedro-datasets'
+      - name: Reinstall CPU-only PyTorch to avoid triton/CUDA segfault on Linux
+        if: inputs.os != 'windows-latest' && inputs.plugin == 'kedro-datasets'
         run: |
           uv pip install --force-reinstall torch --index-url https://download.pytorch.org/whl/cpu
           uv pip uninstall -y triton || true

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -36,11 +36,11 @@ jobs:
       - name: Run unit tests for kedro-airflow, kedro-docker, kedro-telemetry
         if: inputs.plugin != 'kedro-datasets'
         run: make plugin=${{ inputs.plugin }} test
-      # - name: Reinstall CPU-only PyTorch to avoid triton/CUDA segfault on Linux
-      #   if: inputs.plugin == 'kedro-datasets'
-      #   run: |
-      #     uv pip install --force-reinstall torch --index-url https://download.pytorch.org/whl/cpu
-      #     uv pip uninstall -y triton || true
+      - name: Reinstall CPU-only PyTorch to avoid triton/CUDA segfault on Linux
+        if: inputs.plugin == 'kedro-datasets'
+        run: |
+          uv pip install --force-reinstall torch --index-url https://download.pytorch.org/whl/cpu
+          uv pip uninstall -y triton || true
       - name: Run unit tests for Linux / kedro-datasets
         if: inputs.os != 'windows-latest' && inputs.plugin == 'kedro-datasets'
         run: make dataset-tests

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Run unit tests for kedro-airflow, kedro-docker, kedro-telemetry
         if: inputs.plugin != 'kedro-datasets'
         run: make plugin=${{ inputs.plugin }} test
-      - name: Reinstall CPU-only PyTorch to avoid triton/CUDA segfault on Linux
+      - name: Reinstall CPU-only PyTorch to avoid triton/CUDA segfault
         if: inputs.plugin == 'kedro-datasets'
         run: |
           uv pip install --force-reinstall torch --index-url https://download.pytorch.org/whl/cpu

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -36,11 +36,11 @@ jobs:
       - name: Run unit tests for kedro-airflow, kedro-docker, kedro-telemetry
         if: inputs.plugin != 'kedro-datasets'
         run: make plugin=${{ inputs.plugin }} test
-      - name: Reinstall CPU-only PyTorch to avoid triton/CUDA segfault on Linux
-        if: inputs.plugin == 'kedro-datasets'
-        run: |
-          uv pip install --force-reinstall torch --index-url https://download.pytorch.org/whl/cpu
-          uv pip uninstall -y triton || true
+      # - name: Reinstall CPU-only PyTorch to avoid triton/CUDA segfault on Linux
+      #   if: inputs.plugin == 'kedro-datasets'
+      #   run: |
+      #     uv pip install --force-reinstall torch --index-url https://download.pytorch.org/whl/cpu
+      #     uv pip uninstall -y triton || true
       - name: Run unit tests for Linux / kedro-datasets
         if: inputs.os != 'windows-latest' && inputs.plugin == 'kedro-datasets'
         run: make dataset-tests

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -36,6 +36,11 @@ jobs:
       - name: Run unit tests for kedro-airflow, kedro-docker, kedro-telemetry
         if: inputs.plugin != 'kedro-datasets'
         run: make plugin=${{ inputs.plugin }} test
+      - name: Reinstall CPU-only PyTorch to avoid triton/CUDA segfault on Linux
+        if: inputs.plugin == 'kedro-datasets'
+        run: |
+          uv pip install --force-reinstall torch --index-url https://download.pytorch.org/whl/cpu
+          uv pip uninstall -y triton || true
       - name: Run unit tests for Linux / kedro-datasets
         if: inputs.os != 'windows-latest' && inputs.plugin == 'kedro-datasets'
         run: make dataset-tests

--- a/kedro-datasets/tests/networkx/test_json_dataset.py
+++ b/kedro-datasets/tests/networkx/test_json_dataset.py
@@ -16,7 +16,7 @@ ATTRS = {
     "target": "to",
     "name": "fake_id",
     "key": "fake_key",
-    "link": "fake_link",
+    "edges": "fake_link",
 }
 
 
@@ -74,7 +74,7 @@ class TestJSONDataset:
             target="to",
             name="fake_id",
             key="fake_key",
-            link="fake_link",
+            edges="fake_link",
         )
 
         patched_load = mocker.patch(
@@ -100,7 +100,7 @@ class TestJSONDataset:
             target="to",
             name="fake_id",
             key="fake_key",
-            link="fake_link",
+            edges="fake_link",
         )
         assert dummy_graph_data.nodes(data=True) == reloaded.nodes(data=True)
 


### PR DESCRIPTION
## Description

Fix for nightly build [failure](https://github.com/kedro-org/kedro-plugins/actions/runs/25884616437/job/76072917415)

## Development notes

The fault is not in Kedro’s Python code. It happens while importing native code: Something in the doctest run imports transformers (Hugging Face). That import path pulls in `torch._dynamo`. Dynamo calls `torch.utils._triton.has_triton_package`, which imports triton. `triton/knobs.py` (line 15) loads a C extension (create_module in importlib). That extension `segfaults → Fatal Python error: Segmentation fault`.

So the crash is Triton’s extension (pulled in via PyTorch + Transformers) on the GitHub Actions Linux image, not a failed doctest assertion. That matches a CPU-only / headless CI box where CUDA PyTorch + Triton wheels can be fragile or mismatched with the runner’s drivers/libs.

So the fix is to use CPU PyTorch (narrower stack) Install CPU-only torch for that workflow (official index / +cpu wheels) so you don’t load the CUDA stack that often sits next to Triton on Linux nightlies.

Because of the fix above, there is a change in `NetworkX` dependencies (now installs NetworkX 3.6). NetworkX >3.4 [renamed](https://github.com/networkx/networkx/pull/7565) the link keyword to edges in both `node_link_data()` and `node_link_graph()` . This required the change to `kedro-datasets/tests/networkx/test_json_dataset.py` in current PR.

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Updated `jsonschema/kedro-catalog-X.XX.json` if necessary
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
- [ ] Received approvals from at least half of the TSC (required for adding a new, non-experimental dataset)
