### PR TITLE
feat(datasets): support creds across Ibis datasets

### DIFF
--- a/kedro-datasets/RELEASE.md
+++ b/kedro-datasets/RELEASE.md
@@ -3,16 +3,23 @@
 ## Major features and improvements
 
 - Kedro-Datasets is now compatible with Python 3.14, except for `tensorflow.TensorFlowModelDataset` and `geopandas.GenericDataset`.
+- Added credentials support to `ibis.FileDataset`.
 - Added the following new **experimental** datasets:
 
-| Type                                 | Description                                          | Location                               |
-| ------------------------------------ | ---------------------------------------------------- | -------------------------------------- |
-| `opik.EvaluationDataset`             | A dataset for managing Opik evaluation datasets.     | `kedro_datasets_experimental.opik`     |
+| Type                     | Description                                      | Location                           |
+| ------------------------ | ------------------------------------------------ | ---------------------------------- |
+| `opik.EvaluationDataset` | A dataset for managing Opik evaluation datasets. | `kedro_datasets_experimental.opik` |
 
 ## Bug fixes and other changes
-- Restructured the `README.md` file for Opik experimental datasets and added information on `OpikTraceDataset`.
+
+- Refactored shared validation and utility logic from the three Opik experimental datasets (`PromptDataset`, `EvaluationDataset`, `TraceDataset`) into a common `opik._common` module.
+- Refactored shared validation and utility logic from the three Langfuse experimental datasets (`PromptDataset`, `EvaluationDataset`, `TraceDataset`) into a common `langfuse._common` module.
+- Added `os.PathLike` support for `plotly` datasets.
+- Added `checkpoint.filepath` validation for IncrementalDataset.
+- Restructured the `README.md` file for Opik experimental datasets and added information on `opik.TraceDataset`.
 
 ## Breaking changes to experimental datasets
+
 - Renamed dataset classes and shortened `pyproject.toml` extra names for `langfuse`, `opik`, and `langchain` experimental datasets. The redundant package-family prefix has been dropped:
   - Classes:
     - `langfuse.LangfusePromptDataset` → `langfuse.PromptDataset`
@@ -27,14 +34,8 @@
     - `langchain-langchainpromptdataset` → `langchain-promptdataset`
     - etc.
 
-## Bug fixes and other changes
-
-- Refactored shared validation and utility logic from the three Opik experimental datasets (`PromptDataset`, `EvaluationDataset`, `TraceDataset`) into a common `opik._common` module.
-- Refactored shared validation and utility logic from the three Langfuse experimental datasets (`PromptDataset`, `EvaluationDataset`, `TraceDataset`) into a common `langfuse._common` module.
-- Added `os.PathLike` support for `plotly` datasets.
-- Added `checkpoint.filepath` validation for IncrementalDataset.
-
 ## Community contributions
+
 Many thanks to the following Kedroids for contributing PRs to this release:
 
 - [Datascienceio](https://github.com/datascienceio)

--- a/kedro-datasets/kedro_datasets/ibis/file_dataset.py
+++ b/kedro-datasets/kedro_datasets/ibis/file_dataset.py
@@ -80,6 +80,7 @@ class FileDataset(ConnectionMixin, AbstractVersionedDataset[ir.Table, ir.Table])
         *,
         table_name: str | None = None,
         connection: dict[str, Any] | None = None,
+        credentials: dict[str, Any] | None = None,
         load_args: dict[str, Any] | None = None,
         save_args: dict[str, Any] | None = None,
         version: Version | None = None,
@@ -110,6 +111,9 @@ class FileDataset(ConnectionMixin, AbstractVersionedDataset[ir.Table, ir.Table])
             table_name: The name to use for the created table (on load).
             connection: Configuration for connecting to an Ibis backend.
                 If not provided, connect to DuckDB in in-memory mode.
+            credentials: Credentials or additional configuration used to
+                connect (e.g. user, password, token, account). If given,
+                these values override the base connection configuration.
             load_args: Additional arguments passed to the Ibis backend's
                 `read_{file_format}` method.
             save_args: Additional arguments passed to the Ibis backend's
@@ -123,7 +127,9 @@ class FileDataset(ConnectionMixin, AbstractVersionedDataset[ir.Table, ir.Table])
         """
         self._file_format = file_format
         self._table_name = table_name
-        self._connection_config = connection or self.DEFAULT_CONNECTION_CONFIG
+        _connection_config = connection or self.DEFAULT_CONNECTION_CONFIG
+        _credentials = deepcopy(credentials) or {}
+        self._connection_config = {**_connection_config, **_credentials}
         self.metadata = metadata
 
         super().__init__(
@@ -154,13 +160,13 @@ class FileDataset(ConnectionMixin, AbstractVersionedDataset[ir.Table, ir.Table])
         return self._connection
 
     def load(self) -> ir.Table:
-        load_path = self._get_load_path()
+        load_path = Path(self._get_load_path())
         reader = getattr(self.connection, f"read_{self._file_format}")
         return reader(load_path, table_name=self._table_name, **self._load_args)
 
     def save(self, data: ir.Table) -> None:
-        save_path = self._get_save_path()
-        Path(save_path).parent.mkdir(parents=True, exist_ok=True)
+        save_path = Path(self._get_save_path())
+        save_path.parent.mkdir(parents=True, exist_ok=True)
         writer = getattr(self.connection, f"to_{self._file_format}")
         writer(data, save_path, **self._save_args)
 

--- a/kedro-datasets/kedro_datasets/ibis/file_dataset.py
+++ b/kedro-datasets/kedro_datasets/ibis/file_dataset.py
@@ -160,13 +160,13 @@ class FileDataset(ConnectionMixin, AbstractVersionedDataset[ir.Table, ir.Table])
         return self._connection
 
     def load(self) -> ir.Table:
-        load_path = Path(self._get_load_path())
+        load_path = self._get_load_path()
         reader = getattr(self.connection, f"read_{self._file_format}")
         return reader(load_path, table_name=self._table_name, **self._load_args)
 
     def save(self, data: ir.Table) -> None:
-        save_path = Path(self._get_save_path())
-        save_path.parent.mkdir(parents=True, exist_ok=True)
+        save_path = self._get_save_path()
+        Path(save_path).parent.mkdir(parents=True, exist_ok=True)
         writer = getattr(self.connection, f"to_{self._file_format}")
         writer(data, save_path, **self._save_args)
 

--- a/kedro-datasets/kedro_datasets/ibis/table_dataset.py
+++ b/kedro-datasets/kedro_datasets/ibis/table_dataset.py
@@ -139,9 +139,9 @@ class TableDataset(ConnectionMixin, AbstractDataset[ir.Table, ir.Table]):
                 in a multi-level table hierarchy.
             connection: Configuration for connecting to an Ibis backend.
                 If not provided, connect to DuckDB in in-memory mode.
-            credentials: Connection information (e.g.
-                user, password, token, account). If provided, these values
-                override the base `connection` configuration.
+            credentials: Credentials or additional configuration used to
+                connect (e.g. user, password, token, account). If given,
+                these values override the base connection configuration.
             load_args: Additional arguments passed to the Ibis backend's
                 `table` method.
             save_args: Additional arguments passed to the Ibis backend's

--- a/kedro-datasets/static/jsonschema/kedro-catalog-1.0.0.json
+++ b/kedro-datasets/static/jsonschema/kedro-catalog-1.0.0.json
@@ -472,9 +472,13 @@
                   "type": ["string", "null"],
                   "description": "The name to use for the created table (on load)."
                 },
+                "credentials": {
+                  "type": ["object", "null"],
+                  "description": "Credentials required to get access to the underlying database."
+                },
                 "connection": {
                   "type": "object",
-                  "description": "Configuration for connecting to an Ibis backend. E.g. {\"backend\": \"duckdb\", \"database\": \"company.db\"}."
+                  "description": "Configuration for connecting to an Ibis backend. E.g. {\"backend\": \"duckdb\", \"database\": \"company.db\"}. If not provided, defaults to DuckDB in in-memory mode."
                 },
                 "load_args": {
                   "type": "object",
@@ -518,7 +522,7 @@
                 },
                 "connection": {
                   "type": "object",
-                  "description": "Configuration for connecting to an Ibis backend. E.g. {\"backend\": \"duckdb\", \"database\": \"company.db\"}. If not provided, defaults to DuckDB in-memory."
+                  "description": "Configuration for connecting to an Ibis backend. E.g. {\"backend\": \"duckdb\", \"database\": \"company.db\"}. If not provided, defaults to DuckDB in in-memory mode."
                 },
                 "load_args": {
                   "type": "object",

--- a/kedro-datasets/tests/ibis/test_file_dataset.py
+++ b/kedro-datasets/tests/ibis/test_file_dataset.py
@@ -32,12 +32,24 @@ def connection_config(request, database):
     )
 
 
+@pytest.fixture(params=[_SENTINEL])
+def credentials_config(request, database):
+    return (
+        None
+        if request.param is _SENTINEL  # `None` is a valid value to test
+        else request.param
+    )
+
+
 @pytest.fixture
-def file_dataset(filepath_csv, connection_config, load_args, save_args):
+def file_dataset(
+    filepath_csv, connection_config, credentials_config, load_args, save_args
+):
     return FileDataset(
         filepath=filepath_csv,
         file_format="csv",
         connection=connection_config,
+        credentials=credentials_config,
         load_args=load_args,
         save_args=save_args,
     )
@@ -125,6 +137,61 @@ class TestFileDataset:
         backend = (
             connection_config["backend"] if connection_config is not None else "duckdb"
         )
+        mocker.patch(f"ibis.{backend}")
+        file_dataset.load()
+        assert ("ibis", key) in file_dataset._connections
+
+    @pytest.mark.parametrize(
+        ("connection_config", "credentials_config", "key"),
+        [
+            (
+                {"backend": "duckdb", "database": "file.db", "extensions": ["spatial"]},
+                {"user": "admin", "password": "secret"},  # pragma: allowlist secret
+                (
+                    ("backend", "duckdb"),
+                    ("database", "file.db"),
+                    ("extensions", ("spatial",)),
+                    ("password", "secret"),
+                    ("user", "admin"),
+                ),
+            ),
+            (
+                [],
+                {
+                    "host": "xxx.sql.azuresynapse.net",
+                    "database": "xxx",
+                    "query": {"driver": "ODBC Driver 17 for SQL Server"},
+                    "backend": "mssql",
+                },
+                (
+                    ("backend", "mssql"),
+                    ("database", "xxx"),
+                    ("host", "xxx.sql.azuresynapse.net"),
+                    ("query", (("driver", "ODBC Driver 17 for SQL Server"),)),
+                ),
+            ),
+            (
+                None,
+                None,
+                (
+                    ("backend", "duckdb"),
+                    ("database", ":memory:"),
+                ),
+            ),
+            (
+                {"backend": "duckdb", "database": "file.db"},
+                {"backend": "mssql", "password": "secret"},  # pragma: allowlist secret
+                (
+                    ("backend", "mssql"),
+                    ("database", "file.db"),
+                    ("password", "secret"),
+                ),
+            ),
+        ],
+        indirect=["connection_config", "credentials_config"],
+    )
+    def test_connection_config_with_credentials(self, mocker, file_dataset, key):
+        backend = file_dataset._connection_config["backend"]
         mocker.patch(f"ibis.{backend}")
         file_dataset.load()
         assert ("ibis", key) in file_dataset._connections


### PR DESCRIPTION
## Description
Support credentials for `ibis.FileDataset`.

## Development notes
Implementation is identical to `ibis.TableDataset`. Also testing on kedro-org/kedro-pycafe-data#1.

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Updated `jsonschema/kedro-catalog-X.XX.json` if necessary
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [x] Added tests to cover my changes
- [ ] Received approvals from at least half of the TSC (required for adding a new, non-experimental dataset)
