### PR TITLE
docs: clarify MatplotlibDataset filepath type is str | os.PathLike

### DIFF
--- a/kedro-datasets/RELEASE.md
+++ b/kedro-datasets/RELEASE.md
@@ -16,6 +16,7 @@
 - Refactored shared validation and utility logic from the three Opik experimental datasets (`PromptDataset`, `EvaluationDataset`, `TraceDataset`) into a common `opik._common` module.
 - Refactored shared validation and utility logic from the three Langfuse experimental datasets (`PromptDataset`, `EvaluationDataset`, `TraceDataset`) into a common `langfuse._common` module.
 - Added `os.PathLike` support for `plotly` datasets.
+- Added `os.PathLike` support for `matplotlib.MatplotlibDataset`.
 - Added `checkpoint.filepath` validation for IncrementalDataset.
 - Restructured the `README.md` file for Opik experimental datasets and added information on `opik.TraceDataset`.
 
@@ -42,6 +43,7 @@ Many thanks to the following Kedroids for contributing PRs to this release:
 - [Datascienceio](https://github.com/datascienceio)
 - [Guillaume Tauzin](https://github.com/gtauzin)
 - [iwhalen](https://github.com/iwhalen)
+- [Sai Asish Y](https://github.com/SAY-5)
 
 # Release 9.3.0
 

--- a/kedro-datasets/kedro_datasets/matplotlib/matplotlib_dataset.py
+++ b/kedro-datasets/kedro_datasets/matplotlib/matplotlib_dataset.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import base64
 import io
+import os
 from copy import deepcopy
 from pathlib import PurePosixPath
 from typing import Any, NoReturn
@@ -91,7 +92,7 @@ class MatplotlibDataset(
     def __init__(  # noqa: PLR0913
         self,
         *,
-        filepath: str,
+        filepath: str | os.PathLike,
         fs_args: dict[str, Any] | None = None,
         credentials: dict[str, Any] | None = None,
         save_args: dict[str, Any] | None = None,

--- a/kedro-datasets/tests/matplotlib/test_matplotlib_dataset.py
+++ b/kedro-datasets/tests/matplotlib/test_matplotlib_dataset.py
@@ -149,6 +149,13 @@ class TestMatplotlibDataset:
         for key, value in save_args.items():
             assert plot_dataset._save_args[key] == value
 
+    def test_pathlike_filepath(self, tmp_path, mock_single_plot):
+        """Test that os.PathLike filepaths are supported."""
+        filepath = tmp_path / "matplotlib.png"
+        dataset = MatplotlibDataset(filepath=filepath)
+        dataset.save(mock_single_plot)
+        assert filepath.read_bytes()
+
     def test_list_save(self, tmp_path, mock_list_plot, plot_dataset, mocked_s3_bucket):
         """Test saving list of plots to S3."""
 


### PR DESCRIPTION
## Description
Completes the Matplotlib sub-task of #1317, which asks to "Update docstrings to point out that `filepath` type is `str | os.PathLike`, not just `str`".

## Development notes
Updates the `MatplotlibDataset.__init__` type annotation to `str | os.PathLike` (matching merged sub-task PR #1324) and adds a `test_pathlike_filepath` test confirming an `os.PathLike` filepath round-trips.

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [ ] Updated `jsonschema/kedro-catalog-X.XX.json` if necessary
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [x] Added tests to cover my changes
- [ ] Received approvals from at least half of the TSC (required for adding a new, non-experimental dataset)