### PR TITLE
fix(datasets): bump opencv-python to ~=4.13.0.92 for Python 3.14

### DIFF
--- a/.github/workflows/kedro-datasets-experimental.yml
+++ b/.github/workflows/kedro-datasets-experimental.yml
@@ -14,6 +14,7 @@ on:
       - main
     paths:
       - "kedro-datasets/kedro_datasets_experimental/**"
+      - ".github/workflows/kedro-datasets-experimental.yml"
 
 jobs:
   unit-tests-experimental:

--- a/kedro-datasets/RELEASE.md
+++ b/kedro-datasets/RELEASE.md
@@ -34,6 +34,7 @@
 - Refactored shared validation and utility logic from the three Langfuse experimental datasets (`PromptDataset`, `EvaluationDataset`, `TraceDataset`) into a common `langfuse._common` module.
 - Added `os.PathLike` support for `plotly` datasets.
 - Added `checkpoint.filepath` validation for IncrementalDataset.
+- Bumped `opencv-python` to `~=4.13.0.92` so `experimental_test` resolves on Python 3.14 (the old `~=4.12.0.88` capped `numpy<2.3.0`, which has no Windows cp314 wheel).
 
 ## Community contributions
 Many thanks to the following Kedroids for contributing PRs to this release:

--- a/kedro-datasets/RELEASE.md
+++ b/kedro-datasets/RELEASE.md
@@ -45,7 +45,7 @@ Many thanks to the following Kedroids for contributing PRs to this release:
 - [iwhalen](https://github.com/iwhalen)
 - [Sai Asish Y](https://github.com/SAY-5)
 - [Kaushal Dhungel](https://github.com/Kaushal-Dhungel)
-- [Anton Nikshin](https://github.com/nikanton)
+- [Anton Nikishin](https://github.com/nikanton)
 
 # Release 9.3.0
 

--- a/kedro-datasets/pyproject.toml
+++ b/kedro-datasets/pyproject.toml
@@ -251,7 +251,7 @@ rioxarray = ["kedro-datasets[rioxarray-geotiffdataset]"]
 safetensors-safetensorsdataset = ["safetensors", "numpy"]
 safetensors = ["kedro-datasets[safetensors-safetensorsdataset]"]
 
-video-videodataset = ["opencv-python~=4.12.0.88"]
+video-videodataset = ["opencv-python~=4.13.0.92"]
 video = ["kedro-datasets[video-videodataset]"]
 
 # Docs requirements
@@ -383,7 +383,7 @@ experimental = [
     "xarray>=2023.1.0",
     "rioxarray",
     "torch",
-    "opencv-python~=4.12.0.88",
+    "opencv-python~=4.13.0.92",
     "prophet>=1.1.5",
     "opik",
     "optuna",
@@ -406,7 +406,7 @@ experimental_test = [
     "xarray>=2023.1.0",
     "rioxarray",
     "torch",
-    "opencv-python~=4.12.0.88",
+    "opencv-python~=4.13.0.92",
     "prophet>=1.1.5",
     "opik",
     "optuna",


### PR DESCRIPTION
## Summary
- `unit-tests-experimental (windows-latest, 3.14)` has been failing because `opencv-python~=4.12.0.88` (transitive dep of the video dataset, included in the `experimental_test` extras) pins `numpy>=2,<2.3.0`. NumPy <2.3.0 has no cp314 Windows wheel, so `uv` falls back to a MINGW-W64 source build of NumPy that aborts mid-build.
- This matrix entry has never run green: Python 3.14 was added to the experimental matrix in #1387, but the workflow's `paths:` filter means it only fires for PRs touching `kedro-datasets/kedro_datasets_experimental/**`. #1400 was the first such PR after #1387 and is what surfaced the latent failure.
- `opencv-python==4.13.0.92` is the current latest release. It drops the `numpy<2.3.0` cap (now only requires `numpy>=2` on Python ≥3.9) and ships abi3 wheels including `win_amd64`, so it installs cleanly on Python 3.14 with `numpy>=2.3.x`.
- Bumps the pin in all three places it appears: the standalone `video-videodataset` extra and both `experimental` / `experimental_test` extras.

## Test plan
- [x] CI: `unit-tests-experimental (windows-latest, 3.14)` resolves and goes green.
- [x] CI: the rest of the experimental matrix (ubuntu/windows × 3.10–3.14) stays green.
- [x] CI: `unit-tests` (non-experimental, which also reads the bumped `video-videodataset` pin) stays green.