### PR TITLE
chore(telemetry): Add server command back 

### DIFF
--- a/kedro-telemetry/tests/test_masking.py
+++ b/kedro-telemetry/tests/test_masking.py
@@ -27,6 +27,7 @@ DEFAULT_KEDRO_COMMANDS = [
     "pipeline",
     "registry",
     "run",
+    "server",
     "starter",
     "--version",
     "-V",


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
Revert https://github.com/kedro-org/kedro-plugins/pull/1410 after adding http server command back 😅 

## Development notes
<!-- What have you changed, and how has this been tested? -->

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Updated `jsonschema/kedro-catalog-X.XX.json` if necessary
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
- [ ] Received approvals from at least half of the TSC (required for adding a new, non-experimental dataset)
