### PR TITLE
fix(datasets): Conform OpikDatasets to Tolerate extra credentials

### DIFF
--- a/kedro-datasets/kedro_datasets_experimental/opik/_common.py
+++ b/kedro-datasets/kedro_datasets_experimental/opik/_common.py
@@ -28,9 +28,9 @@ OPIK_CLIENT_KEYS = frozenset({
 def build_opik_client_kwargs(credentials: dict[str, Any]) -> dict[str, Any]:
     """Pick only credential keys accepted by `Opik()`.
 
-    Filters out keys used elsewhere in the same credentials block — e.g.
+    Filters out keys used elsewhere in the same credentials block e.g.
     `endpoint` (consumed by `TraceDataset` autogen mode) or an `openai`
-    sub-block (consumed by `TraceDataset` openai mode) — so they don't
+    sub-block (consumed by `TraceDataset` openai mode) so they don't
     reach the Opik client constructor and raise `TypeError`. This lets a
     single `opik_credentials` block serve all three datasets.
 

--- a/kedro-datasets/kedro_datasets_experimental/opik/_common.py
+++ b/kedro-datasets/kedro_datasets_experimental/opik/_common.py
@@ -26,19 +26,19 @@ OPIK_CLIENT_KEYS = frozenset({
 
 
 def build_opik_client_kwargs(credentials: dict[str, Any]) -> dict[str, Any]:
-    """Pick only credential keys accepted by ``Opik()``.
+    """Pick only credential keys accepted by `Opik()`.
 
     Filters out keys used elsewhere in the same credentials block — e.g.
-    ``endpoint`` (consumed by ``TraceDataset`` autogen mode) or an ``openai``
-    sub-block (consumed by ``TraceDataset`` openai mode) — so they don't
-    reach the Opik client constructor and raise ``TypeError``. This lets a
-    single ``opik_credentials`` block serve all three datasets.
+    `endpoint` (consumed by `TraceDataset` autogen mode) or an `openai`
+    sub-block (consumed by `TraceDataset` openai mode) — so they don't
+    reach the Opik client constructor and raise `TypeError`. This lets a
+    single `opik_credentials` block serve all three datasets.
 
     Args:
         credentials: Raw credentials dict from the catalog.
 
     Returns:
-        A dict containing only keys recognised by ``Opik()``.
+        A dict containing only keys recognised by `Opik()`.
     """
     return {k: v for k, v in credentials.items() if k in OPIK_CLIENT_KEYS}
 

--- a/kedro-datasets/kedro_datasets_experimental/opik/_common.py
+++ b/kedro-datasets/kedro_datasets_experimental/opik/_common.py
@@ -16,6 +16,32 @@ if TYPE_CHECKING:
 
 SUPPORTED_FILE_EXTENSIONS = {".json", ".yaml", ".yml"}
 
+OPIK_CLIENT_KEYS = frozenset({
+    "api_key",
+    "workspace",
+    "host",
+    "url_override",
+    "project_name",
+})
+
+
+def build_opik_client_kwargs(credentials: dict[str, Any]) -> dict[str, Any]:
+    """Pick only credential keys accepted by ``Opik()``.
+
+    Filters out keys used elsewhere in the same credentials block — e.g.
+    ``endpoint`` (consumed by ``TraceDataset`` autogen mode) or an ``openai``
+    sub-block (consumed by ``TraceDataset`` openai mode) — so they don't
+    reach the Opik client constructor and raise ``TypeError``. This lets a
+    single ``opik_credentials`` block serve all three datasets.
+
+    Args:
+        credentials: Raw credentials dict from the catalog.
+
+    Returns:
+        A dict containing only keys recognised by ``Opik()``.
+    """
+    return {k: v for k, v in credentials.items() if k in OPIK_CLIENT_KEYS}
+
 
 def validate_credentials(
     credentials: dict[str, Any],

--- a/kedro-datasets/kedro_datasets_experimental/opik/_common.py
+++ b/kedro-datasets/kedro_datasets_experimental/opik/_common.py
@@ -28,11 +28,13 @@ OPIK_CLIENT_KEYS = frozenset({
 def build_opik_client_kwargs(credentials: dict[str, Any]) -> dict[str, Any]:
     """Pick only credential keys accepted by `Opik()`.
 
-    Filters out keys used elsewhere in the same credentials block e.g.
-    `endpoint` (consumed by `TraceDataset` autogen mode) or an `openai`
-    sub-block (consumed by `TraceDataset` openai mode) so they don't
-    reach the Opik client constructor and raise `TypeError`. This lets a
-    single `opik_credentials` block serve all three datasets.
+    `PromptDataset` and `EvaluationDataset` pass credentials straight into
+    the `Opik()` constructor, so any unrecognised key raises `TypeError`.
+    A shared `opik_credentials` block may legitimately carry such keys for
+    `TraceDataset` — e.g. `endpoint` (autogen mode) or an `openai` sub-block
+    (openai mode). This helper filters those out before the splat.
+    `TraceDataset` itself does not use this helper: it never splats
+    credentials and already picks its keys explicitly.
 
     Args:
         credentials: Raw credentials dict from the catalog.

--- a/kedro-datasets/kedro_datasets_experimental/opik/evaluation_dataset.py
+++ b/kedro-datasets/kedro_datasets_experimental/opik/evaluation_dataset.py
@@ -11,6 +11,7 @@ from opik.rest_api.core.api_error import ApiError
 from kedro_datasets._typing import JSONPreview
 
 from ._common import (
+    build_opik_client_kwargs,
     build_preview,
     create_file_dataset,
     validate_credentials,
@@ -206,7 +207,7 @@ class EvaluationDataset(AbstractDataset):
         self._file_dataset = None
 
         try:
-            self._client = Opik(**credentials)
+            self._client = Opik(**build_opik_client_kwargs(credentials))
         except Exception as e:
             raise DatasetError(f"Failed to initialise Opik client: {e}") from e
 

--- a/kedro-datasets/kedro_datasets_experimental/opik/prompt_dataset.py
+++ b/kedro-datasets/kedro_datasets_experimental/opik/prompt_dataset.py
@@ -19,6 +19,7 @@ from opik import Opik, Prompt
 from kedro_datasets._typing import JSONPreview
 
 from ._common import (
+    build_opik_client_kwargs,
     build_preview,
     create_file_dataset,
     validate_file_extension,
@@ -173,7 +174,7 @@ class PromptDataset(AbstractDataset):
 
         # Initialise Opik client
         try:
-            self._opik_client = Opik(**credentials, **opik_kwargs)
+            self._opik_client = Opik(**build_opik_client_kwargs(credentials), **opik_kwargs)
         except Exception as e:
             raise DatasetError(f"Failed to initialise Opik client: {e}")
 

--- a/kedro-datasets/kedro_datasets_experimental/tests/opik/test_evaluation_dataset.py
+++ b/kedro-datasets/kedro_datasets_experimental/tests/opik/test_evaluation_dataset.py
@@ -235,7 +235,7 @@ class TestEvaluationDatasetInit:
             "workspace": "w",
             "project_name": "p",
             "endpoint": "https://example.com/otlp",   # TraceDataset autogen only
-            "openai": {"api_key": "sk-x"},            # TraceDataset openai mode only
+            "openai": {"api_key": "sk-x"},            # pragma: allowlist secret
         }
 
         with patch("kedro_datasets_experimental.opik.evaluation_dataset.Opik") as mock_class:

--- a/kedro-datasets/kedro_datasets_experimental/tests/opik/test_evaluation_dataset.py
+++ b/kedro-datasets/kedro_datasets_experimental/tests/opik/test_evaluation_dataset.py
@@ -226,10 +226,10 @@ class TestEvaluationDatasetInit:
                 )
 
     def test_init_filters_unknown_credentials(self):
-        """Extra credential keys (e.g. autogen-only ``endpoint``, openai sub-block)
-        are filtered out before reaching ``Opik()`` — so one ``opik_credentials``
+        """Extra credential keys (e.g. autogen-only `endpoint`, openai sub-block)
+        are filtered out before reaching `Opik()` so one `opik_credentials`
         block can serve EvaluationDataset, PromptDataset, and TraceDataset
-        (autogen mode) without raising ``TypeError``."""
+        (autogen mode) without raising `TypeError`."""
         credentials = {
             "api_key": "k", # pragma: allowlist secret
             "workspace": "w",

--- a/kedro-datasets/kedro_datasets_experimental/tests/opik/test_evaluation_dataset.py
+++ b/kedro-datasets/kedro_datasets_experimental/tests/opik/test_evaluation_dataset.py
@@ -225,6 +225,26 @@ class TestEvaluationDatasetInit:
                     credentials=mock_credentials,
                 )
 
+    def test_init_filters_unknown_credentials(self):
+        """Extra credential keys (e.g. autogen-only ``endpoint``, openai sub-block)
+        are filtered out before reaching ``Opik()`` — so one ``opik_credentials``
+        block can serve EvaluationDataset, PromptDataset, and TraceDataset
+        (autogen mode) without raising ``TypeError``."""
+        credentials = {
+            "api_key": "k", # pragma: allowlist secret
+            "workspace": "w",
+            "project_name": "p",
+            "endpoint": "https://example.com/otlp",   # TraceDataset autogen only
+            "openai": {"api_key": "sk-x"},            # TraceDataset openai mode only
+        }
+
+        with patch("kedro_datasets_experimental.opik.evaluation_dataset.Opik") as mock_class:
+            mock_class.return_value = Mock()
+            EvaluationDataset(dataset_name="ds", credentials=credentials)
+
+        _, kwargs = mock_class.call_args
+        assert set(kwargs) == {"api_key", "workspace", "project_name"}
+
 
 class TestFiledatasetProperty:
     """Test the file_dataset lazy property."""

--- a/kedro-datasets/kedro_datasets_experimental/tests/opik/test_prompt_dataset.py
+++ b/kedro-datasets/kedro_datasets_experimental/tests/opik/test_prompt_dataset.py
@@ -221,10 +221,10 @@ class TestPromptDatasetInit:
                     )
 
     def test_init_filters_unknown_credentials(self, filepath_json_chat):
-        """Extra credential keys (e.g. autogen-only ``endpoint``, openai sub-block)
-        are filtered out before reaching ``Opik()`` — so one ``opik_credentials``
+        """Extra credential keys (e.g. autogen-only `endpoint`, openai sub-block)
+        are filtered out before reaching `Opik()` — so one `opik_credentials`
         block can serve PromptDataset, EvaluationDataset, and TraceDataset
-        (autogen mode) without raising ``TypeError``."""
+        (autogen mode) without raising `TypeError`."""
         credentials = {
             "api_key": "k", # pragma: allowlist secret
             "workspace": "w",

--- a/kedro-datasets/kedro_datasets_experimental/tests/opik/test_prompt_dataset.py
+++ b/kedro-datasets/kedro_datasets_experimental/tests/opik/test_prompt_dataset.py
@@ -222,7 +222,7 @@ class TestPromptDatasetInit:
 
     def test_init_filters_unknown_credentials(self, filepath_json_chat):
         """Extra credential keys (e.g. autogen-only `endpoint`, openai sub-block)
-        are filtered out before reaching `Opik()` — so one `opik_credentials`
+        are filtered out before reaching `Opik()` so one `opik_credentials`
         block can serve PromptDataset, EvaluationDataset, and TraceDataset
         (autogen mode) without raising `TypeError`."""
         credentials = {

--- a/kedro-datasets/kedro_datasets_experimental/tests/opik/test_prompt_dataset.py
+++ b/kedro-datasets/kedro_datasets_experimental/tests/opik/test_prompt_dataset.py
@@ -230,7 +230,7 @@ class TestPromptDatasetInit:
             "workspace": "w",
             "project_name": "p",
             "endpoint": "https://example.com/otlp",   # TraceDataset autogen only
-            "openai": {"api_key": "sk-x"},            # TraceDataset openai mode only
+            "openai": {"api_key": "sk-x"},            # pragma: allowlist secret
         }
 
         with patch("kedro_datasets_experimental.opik.prompt_dataset.Opik") as mock_opik_class:

--- a/kedro-datasets/kedro_datasets_experimental/tests/opik/test_prompt_dataset.py
+++ b/kedro-datasets/kedro_datasets_experimental/tests/opik/test_prompt_dataset.py
@@ -220,6 +220,31 @@ class TestPromptDatasetInit:
                         credentials=mock_credentials
                     )
 
+    def test_init_filters_unknown_credentials(self, filepath_json_chat):
+        """Extra credential keys (e.g. autogen-only ``endpoint``, openai sub-block)
+        are filtered out before reaching ``Opik()`` — so one ``opik_credentials``
+        block can serve PromptDataset, EvaluationDataset, and TraceDataset
+        (autogen mode) without raising ``TypeError``."""
+        credentials = {
+            "api_key": "k", # pragma: allowlist secret
+            "workspace": "w",
+            "project_name": "p",
+            "endpoint": "https://example.com/otlp",   # TraceDataset autogen only
+            "openai": {"api_key": "sk-x"},            # TraceDataset openai mode only
+        }
+
+        with patch("kedro_datasets_experimental.opik.prompt_dataset.Opik") as mock_opik_class:
+            mock_opik_class.return_value = Mock()
+            PromptDataset(
+                filepath=filepath_json_chat,
+                prompt_name="test-prompt",
+                prompt_type="chat",
+                credentials=credentials,
+            )
+
+        _, kwargs = mock_opik_class.call_args
+        assert set(kwargs) == {"api_key", "workspace", "project_name"}
+
 
 class TestPromptDatasetSave:
     """Test PromptDataset save functionality."""


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->

`opik.PromptDataset` and `opik.EvaluationDataset` splat the entire `credentials` dict into `Opik(**credentials)`. 

Any key the Opik client doesn't recognise raises:
```TypeError: Opik.__init__() got an unexpected keyword argument 'endpoint'```

This effects users who want a single `opik_credentials` block to serve all three datasets: `opik.TraceDataset` in `mode: autogen` requires `endpoint` in credentials (for the OTLP exporter), but adding it then breaks the Prompt and Evaluation datasets sharing the same block.

`langfuse.PromptDataset` already avoids this by picking specific keys
(`public_key`, `secret_key`) explicitly. This PR mirrors that pattern for Opik.

## Development notes
<!-- What have you changed, and how has this been tested? -->

A new helper in `opik/_common.py` filters credentials down to the keys `Opik()` actually accepts:

```
    OPIK_CLIENT_KEYS = frozenset({
        "api_key", "workspace", "host", "url_override", "project_name",
    })
```

Both `PromptDataset` and `EvaluationDataset` now route credentials through it. `TraceDataset` needs no change as it already picks keys explicitly via `configure(api_key=..., workspace=..., url=credentials.get("url_override"))` and reads `endpoint` directly only inside `_build_autogen_tracer`.

- Credentials containing only valid keys: unchanged (happy path).
- Credentials containing extras like `endpoint` or an `openai` sub-block:
  previously raised `TypeError`; now silently ignored by Prompt/Evaluation.
- Forward-compatible: if the Opik client gains a kwarg, add it to
  `OPIK_CLIENT_KEYS`.
- Added `test_init_filters_unknown_credentials` to both `test_prompt_dataset.py` and `test_evaluation_dataset.py`, asserting that extra credential keys are filtered out of the `Opik(...)` call.

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Updated `jsonschema/kedro-catalog-X.XX.json` if necessary
- [x] Added a description of this change in the relevant `RELEASE.md` file
- [x] Added tests to cover my changes
- [ ] Received approvals from at least half of the TSC (required for adding a new, non-experimental dataset)
