### PR TITLE
fix(datasets): skip network doctest in HFTransformerPipelineDataset to fix nightly failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ dataset-doctest%:
 	  exit 2; \
 	fi; \
     \
-	# The ignored datasets below require complicated setup with cloud/database clients or network model downloads which is overkill for the doctest examples.
+	# The ignored datasets below require complicated setup with cloud/database clients or network model download which is overkill for the doctest examples.
 	cd kedro-datasets && pytest kedro_datasets --doctest-modules --doctest-continue-on-failure --no-cov \
 	  --ignore kedro_datasets/huggingface/transformer_pipeline_dataset.py \
 	  --ignore kedro_datasets/pandas/gbq_dataset.py \

--- a/Makefile
+++ b/Makefile
@@ -76,8 +76,9 @@ dataset-doctest%:
 	  exit 2; \
 	fi; \
     \
-	# The ignored datasets below require complicated setup with cloud/database clients which is overkill for the doctest examples.
+	# The ignored datasets below require complicated setup with cloud/database clients or network model downloads which is overkill for the doctest examples.
 	cd kedro-datasets && pytest kedro_datasets --doctest-modules --doctest-continue-on-failure --no-cov \
+	  --ignore kedro_datasets/huggingface/transformer_pipeline_dataset.py \
 	  --ignore kedro_datasets/pandas/gbq_dataset.py \
 	  --ignore kedro_datasets/partitions/partitioned_dataset.py \
 	  --ignore kedro_datasets/redis/redis_dataset.py \

--- a/kedro-datasets/kedro_datasets/huggingface/transformer_pipeline_dataset.py
+++ b/kedro-datasets/kedro_datasets/huggingface/transformer_pipeline_dataset.py
@@ -32,8 +32,8 @@ class HFTransformerPipelineDataset(AbstractDataset):
         >>> dataset = HFTransformerPipelineDataset(
         ...     task="text-classification", model_name="prajjwal1/bert-tiny"
         ... )
-        >>> model = dataset.load()  # doctest: +SKIP
-        >>> assert model("Hello world")[0]["label"].startswith("LABEL_")  # doctest: +SKIP
+        >>> model = dataset.load()
+        >>> assert model("Hello world")[0]["label"].startswith("LABEL_")
 
     """
 

--- a/kedro-datasets/kedro_datasets/huggingface/transformer_pipeline_dataset.py
+++ b/kedro-datasets/kedro_datasets/huggingface/transformer_pipeline_dataset.py
@@ -32,8 +32,8 @@ class HFTransformerPipelineDataset(AbstractDataset):
         >>> dataset = HFTransformerPipelineDataset(
         ...     task="text-classification", model_name="prajjwal1/bert-tiny"
         ... )
-        >>> model = dataset.load()
-        >>> assert model("Hello world")[0]["label"].startswith("LABEL_")
+        >>> model = dataset.load()  # doctest: +SKIP
+        >>> assert model("Hello world")[0]["label"].startswith("LABEL_")  # doctest: +SKIP
 
     """
 


### PR DESCRIPTION
Fixes #1420

# Description

Adds `kedro_datasets/huggingface/transformer_pipeline_dataset.py` to the existing doctest `--ignore` list in the `dataset-doctest%` target of the `Makefile`, so its network-dependent example is no longer executed in CI. This keeps consistent with how other datasets that need external setup are already skipped.

```makefile
--ignore kedro_datasets/huggingface/transformer_pipeline_dataset.py \
```

## Why?

The nightly build (#1420) has been failing every night. All failures share the **same root cause**: the doctest called `dataset.load()`, which downloads the `prajjwal1/bert-tiny` model from the Hugging Face Hub at test time. The Hub now returns **HTTP 429 (Too Many Requests)** to the shared CI runners, which makes the doctest fail.

```
429 Client Error: Too Many Requests for url:
https://huggingface.co/prajjwal1/bert-tiny/resolve/main/config.json
```

This is not a code regression, it is an external service rate-limiting CI. The failing matrix cell changed each night (different OS/Python), but the error was identical in every run (#1022–#1026).



## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Updated `jsonschema/kedro-catalog-X.XX.json` if necessary
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
- [ ] Received approvals from at least half of the TSC (required for adding a new, non-experimental dataset)
