### PR TITLE
fix(datasets): Forward project_name in Opik langchain-mode tracer

### DIFF
--- a/kedro-datasets/RELEASE.md
+++ b/kedro-datasets/RELEASE.md
@@ -2,6 +2,9 @@
 
 ## Major features and improvements
 ## Bug fixes and other changes
+
+- Fixed `opik.TraceDataset` so `credentials.project_name` is now passed to `configure()` and persisted to Opik's session configuration.
+
 ## Community contributions
 
 # Release 9.4.0

--- a/kedro-datasets/kedro_datasets_experimental/opik/trace_dataset.py
+++ b/kedro-datasets/kedro_datasets_experimental/opik/trace_dataset.py
@@ -13,6 +13,12 @@ REQUIRED_OPIK_CREDENTIALS = {"api_key", "workspace"}
 REQUIRED_OPIK_CREDENTIALS_AUTOGEN = {"endpoint"}
 OPTIONAL_OPIK_CREDENTIALS = {"project_name", "url_override"}
 
+# Opik configuration is global per process: the first project configured wins
+# once a client has been created. This tracks the project configured so far (a
+# mutable holder, to avoid a module-level `global` rebind) so we can warn if a
+# later TraceDataset configures a different one.
+_session_project_state: dict[str, str | None] = {"project_name": None}
+
 
 class TraceDataset(AbstractDataset):
     """Kedro dataset for managing Opik tracing clients and callbacks.
@@ -179,15 +185,36 @@ class TraceDataset(AbstractDataset):
         Note: Opik configuration is global within a process, so the project
         cannot be changed once a client has been created. Using multiple
         `TraceDataset` instances with different projects in the same session
-        will log all traces to the first configured project.
+        will log all traces to the first configured project; a warning is
+        emitted in that case.
         """
+        project_name = self._credentials.get("project_name")
+        configured_project = _session_project_state["project_name"]
+
+        if (
+            configured_project is not None
+            and project_name is not None
+            and project_name != configured_project
+        ):
+            logger.warning(
+                "Opik is already configured for project '%s' in this session. "
+                "Opik configuration is global per process, so configuring project "
+                "'%s' may not take effect for all traces — run pipelines targeting "
+                "different projects in separate processes.",
+                configured_project,
+                project_name,
+            )
+
         configure(
             api_key=self._credentials["api_key"],
             workspace=self._credentials["workspace"],
             url=self._credentials.get("url_override"),
-            project_name=self._credentials.get("project_name"),
+            project_name=project_name,
             force=True,
         )
+
+        if configured_project is None and project_name is not None:
+            _session_project_state["project_name"] = project_name
 
     def _validate_openai_client_params(self) -> None:
         """Validate OpenAI credentials in the 'openai' section.

--- a/kedro-datasets/kedro_datasets_experimental/opik/trace_dataset.py
+++ b/kedro-datasets/kedro_datasets_experimental/opik/trace_dataset.py
@@ -167,35 +167,25 @@ class TraceDataset(AbstractDataset):
                     )
 
     def _configure_opik(self) -> None:
-        """Initialize Opik global configuration with awareness of project switching.
+        """Configure the Opik SDK from the provided credentials.
 
-        This function ensures that the Opik SDK is configured using the provided credentials.
-        If an existing configuration is detected (from a prior dataset instance),
-        a warning is emitted since the active project cannot be changed dynamically.
+        `project_name` is passed to `configure()` so it is persisted to
+        Opik's session configuration and picked up by the auto-created client.
+        This is what routes traces to the right project for both `langchain`
+        mode (the `OpikTracer` inherits the configured project) and `sdk`
+        mode (the `@track` decorator resolves the same way). `configure()`
+        gained the `project_name` parameter in opik 1.11.0.
+
+        Note: Opik configuration is global within a process, so the project
+        cannot be changed once a client has been created. Using multiple
+        `TraceDataset` instances with different projects in the same session
+        will log all traces to the first configured project.
         """
-        project_name = self._credentials.get("project_name")
-
-        # Detect an existing configuration and warn if switching projects
-        existing_project = os.getenv("OPIK_PROJECT_NAME")
-        if existing_project and project_name and project_name != existing_project:
-            logger.warning(
-                f"Opik is already configured for project '{existing_project}', "
-                f"as defined by the environment variable OPIK_PROJECT_NAME. "
-                f"The active project cannot be changed dynamically — the new project "
-                f"'{project_name}' will be ignored, and all traces will continue "
-                f"to be logged under '{existing_project}'.\n"
-                f"To log traces to a different project, unset the environment variable "
-                f"`OPIK_PROJECT_NAME` before running your pipeline or in the interactive session."
-            )
-        # Set or update the environment variable (used by Opik SDK)
-        elif project_name:
-            os.environ["OPIK_PROJECT_NAME"] = project_name
-
-        # Configure Opik (repeated calls are safe but project name won't change)
         configure(
             api_key=self._credentials["api_key"],
             workspace=self._credentials["workspace"],
             url=self._credentials.get("url_override"),
+            project_name=self._credentials.get("project_name"),
             force=True,
         )
 
@@ -350,23 +340,19 @@ class TraceDataset(AbstractDataset):
         return track_openai(client, project_name=project_name) if project_name else track_openai(client)
 
     def _load_langchain_tracer(self) -> Any:
-        """Return an OpikTracer callback for LangChain integration."""
+        """Return an OpikTracer callback for LangChain integration.
+
+        The project is set by ``_configure_opik`` (via ``configure``), so the
+        tracer inherits it from the configured client. An explicit
+        ``project_name`` catalog kwarg still flows through ``trace_kwargs`` and
+        takes precedence for this tracer.
+        """
         try:
             from opik.integrations.langchain import OpikTracer  # noqa: PLC0415
         except ImportError as e:
             raise DatasetError("Opik LangChain integration not available.") from e
 
-        # Forward project_name from credentials when not explicitly overridden
-        # in catalog trace_kwargs. Without this, OpikTracer logs to the
-        # "Default Project" regardless of credentials.project_name, because
-        # _configure_opik calls configure(force=True), which writes
-        # ~/.opik.config without project_name and overrides OPIK_PROJECT_NAME.
-        project_name = self._credentials.get("project_name")
-        kwargs = {**self._trace_kwargs}
-        if project_name and "project_name" not in kwargs:
-            kwargs["project_name"] = project_name
-
-        return OpikTracer(**kwargs)
+        return OpikTracer(**self._trace_kwargs)
 
     def save(self, data: Any) -> None:
         """Saving traces manually is not supported; TraceDataset is read-only."""

--- a/kedro-datasets/kedro_datasets_experimental/opik/trace_dataset.py
+++ b/kedro-datasets/kedro_datasets_experimental/opik/trace_dataset.py
@@ -356,7 +356,17 @@ class TraceDataset(AbstractDataset):
         except ImportError as e:
             raise DatasetError("Opik LangChain integration not available.") from e
 
-        return OpikTracer(**self._trace_kwargs)
+        # Forward project_name from credentials when not explicitly overridden
+        # in catalog trace_kwargs. Without this, OpikTracer logs to the
+        # "Default Project" regardless of credentials.project_name, because
+        # _configure_opik calls configure(force=True), which writes
+        # ~/.opik.config without project_name and overrides OPIK_PROJECT_NAME.
+        project_name = self._credentials.get("project_name")
+        kwargs = {**self._trace_kwargs}
+        if project_name and "project_name" not in kwargs:
+            kwargs["project_name"] = project_name
+
+        return OpikTracer(**kwargs)
 
     def save(self, data: Any) -> None:
         """Saving traces manually is not supported; TraceDataset is read-only."""

--- a/kedro-datasets/kedro_datasets_experimental/opik/trace_dataset.py
+++ b/kedro-datasets/kedro_datasets_experimental/opik/trace_dataset.py
@@ -342,9 +342,9 @@ class TraceDataset(AbstractDataset):
     def _load_langchain_tracer(self) -> Any:
         """Return an OpikTracer callback for LangChain integration.
 
-        The project is set by ``_configure_opik`` (via ``configure``), so the
+        The project is set by `_configure_opik` (via `configure`), so the
         tracer inherits it from the configured client. An explicit
-        ``project_name`` catalog kwarg still flows through ``trace_kwargs`` and
+        `project_name` catalog kwarg still flows through `trace_kwargs` and
         takes precedence for this tracer.
         """
         try:

--- a/kedro-datasets/kedro_datasets_experimental/tests/opik/test_trace_dataset.py
+++ b/kedro-datasets/kedro_datasets_experimental/tests/opik/test_trace_dataset.py
@@ -158,6 +158,44 @@ def test_load_langchain_tracer(opik_tracer_mock, configure_mock, base_credential
 
 
 @patch("kedro_datasets_experimental.opik.trace_dataset.configure")
+@patch("opik.integrations.langchain.OpikTracer")
+def test_load_langchain_tracer_forwards_project_name_from_credentials(
+    opik_tracer_mock, configure_mock, base_credentials
+):
+    """project_name in credentials should reach OpikTracer.
+
+    Regression test for traces landing in "Default Project" — _configure_opik
+    calls configure(force=True), which writes ~/.opik.config without
+    project_name and overrides OPIK_PROJECT_NAME, so OpikTracer must receive
+    the project explicitly.
+    """
+    creds = base_credentials | {"project_name": "my-project"}
+    TraceDataset(creds, mode="langchain").load()
+    opik_tracer_mock.assert_called_once_with(project_name="my-project")
+
+
+@patch("kedro_datasets_experimental.opik.trace_dataset.configure")
+@patch("opik.integrations.langchain.OpikTracer")
+def test_load_langchain_tracer_trace_kwarg_overrides_credentials(
+    opik_tracer_mock, configure_mock, base_credentials
+):
+    """An explicit project_name catalog kwarg overrides the credentials value."""
+    creds = base_credentials | {"project_name": "from-creds"}
+    TraceDataset(creds, mode="langchain", project_name="from-kwargs").load()
+    opik_tracer_mock.assert_called_once_with(project_name="from-kwargs")
+
+
+@patch("kedro_datasets_experimental.opik.trace_dataset.configure")
+@patch("opik.integrations.langchain.OpikTracer")
+def test_load_langchain_tracer_no_project_name_passes_no_kwarg(
+    opik_tracer_mock, configure_mock, base_credentials
+):
+    """Without project_name anywhere, OpikTracer is called with no extra kwargs."""
+    TraceDataset(base_credentials, mode="langchain").load()
+    opik_tracer_mock.assert_called_once_with()
+
+
+@patch("kedro_datasets_experimental.opik.trace_dataset.configure")
 def test_langchain_import_error_raises(configure_mock, base_credentials, monkeypatch):
     """Test that ImportError in LangChain integration raises DatasetError."""
     monkeypatch.setitem(sys.modules, "opik.integrations.langchain", None)

--- a/kedro-datasets/kedro_datasets_experimental/tests/opik/test_trace_dataset.py
+++ b/kedro-datasets/kedro_datasets_experimental/tests/opik/test_trace_dataset.py
@@ -42,22 +42,22 @@ def test_empty_optional_credential_raises(base_credentials):
 
 
 @patch("kedro_datasets_experimental.opik.trace_dataset.configure")
-def test_configure_opik_sets_project_name(configure_mock, base_credentials):
-    """Test that configuring Opik sets the project name environment variable."""
+def test_configure_opik_forwards_project_name(configure_mock, base_credentials):
+    """project_name from credentials is passed to configure() so the configured
+    client (and any tracer derived from it) logs to the right project."""
     creds = base_credentials | {"project_name": "test-proj"}
     TraceDataset(creds)
-    assert os.getenv("OPIK_PROJECT_NAME") == "test-proj"
     configure_mock.assert_called_once()
+    assert configure_mock.call_args.kwargs["project_name"] == "test-proj"
 
 
 @patch("kedro_datasets_experimental.opik.trace_dataset.configure")
-def test_configure_opik_warns_on_project_switch(configure_mock, base_credentials, caplog):
-    """Test that configuring Opik warns when switching to a different project."""
-    os.environ["OPIK_PROJECT_NAME"] = "existing-proj"
-    creds = base_credentials | {"project_name": "new-proj"}
-    TraceDataset(creds)
-    assert "will be ignored" in caplog.text
-    assert os.getenv("OPIK_PROJECT_NAME") == "existing-proj"
+def test_configure_opik_project_name_none_when_absent(configure_mock, base_credentials):
+    """No project_name in credentials -> configure() receives project_name=None
+    (Opik falls back to its own default)."""
+    TraceDataset(base_credentials)
+    configure_mock.assert_called_once()
+    assert configure_mock.call_args.kwargs["project_name"] is None
 
 
 @patch("kedro_datasets_experimental.opik.trace_dataset.configure")
@@ -159,27 +159,25 @@ def test_load_langchain_tracer(opik_tracer_mock, configure_mock, base_credential
 
 @patch("kedro_datasets_experimental.opik.trace_dataset.configure")
 @patch("opik.integrations.langchain.OpikTracer")
-def test_load_langchain_tracer_forwards_project_name_from_credentials(
+def test_load_langchain_tracer_routes_project_via_configure(
     opik_tracer_mock, configure_mock, base_credentials
 ):
-    """project_name in credentials should reach OpikTracer.
-
-    Regression test for traces landing in "Default Project" — _configure_opik
-    calls configure(force=True), which writes ~/.opik.config without
-    project_name and overrides OPIK_PROJECT_NAME, so OpikTracer must receive
-    the project explicitly.
-    """
+    """Regression for traces landing in "Default Project": project_name from
+    credentials reaches the Opik client via configure(), so the langchain
+    tracer (created without an explicit project) inherits it."""
     creds = base_credentials | {"project_name": "my-project"}
     TraceDataset(creds, mode="langchain").load()
-    opik_tracer_mock.assert_called_once_with(project_name="my-project")
+    assert configure_mock.call_args.kwargs["project_name"] == "my-project"
+    opik_tracer_mock.assert_called_once_with()
 
 
 @patch("kedro_datasets_experimental.opik.trace_dataset.configure")
 @patch("opik.integrations.langchain.OpikTracer")
-def test_load_langchain_tracer_trace_kwarg_overrides_credentials(
+def test_load_langchain_tracer_trace_kwarg_passed_through(
     opik_tracer_mock, configure_mock, base_credentials
 ):
-    """An explicit project_name catalog kwarg overrides the credentials value."""
+    """An explicit project_name catalog kwarg is passed straight to OpikTracer,
+    taking precedence over the configured client project for that tracer."""
     creds = base_credentials | {"project_name": "from-creds"}
     TraceDataset(creds, mode="langchain", project_name="from-kwargs").load()
     opik_tracer_mock.assert_called_once_with(project_name="from-kwargs")
@@ -190,7 +188,7 @@ def test_load_langchain_tracer_trace_kwarg_overrides_credentials(
 def test_load_langchain_tracer_no_project_name_passes_no_kwarg(
     opik_tracer_mock, configure_mock, base_credentials
 ):
-    """Without project_name anywhere, OpikTracer is called with no extra kwargs."""
+    """Without a catalog project_name kwarg, OpikTracer is called with no kwargs."""
     TraceDataset(base_credentials, mode="langchain").load()
     opik_tracer_mock.assert_called_once_with()
 

--- a/kedro-datasets/kedro_datasets_experimental/tests/opik/test_trace_dataset.py
+++ b/kedro-datasets/kedro_datasets_experimental/tests/opik/test_trace_dataset.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from kedro.io import DatasetError
 
+from kedro_datasets_experimental.opik import trace_dataset as trace_dataset_module
 from kedro_datasets_experimental.opik.trace_dataset import TraceDataset
 
 OPIK_AUTOGEN_ENDPOINT = "https://www.comet.com/opik/api/v1/private/otel/v1/traces"
@@ -58,6 +59,23 @@ def test_configure_opik_project_name_none_when_absent(configure_mock, base_crede
     TraceDataset(base_credentials)
     configure_mock.assert_called_once()
     assert configure_mock.call_args.kwargs["project_name"] is None
+
+
+@patch("kedro_datasets_experimental.opik.trace_dataset.configure")
+def test_configure_opik_warns_on_project_switch_in_session(
+    configure_mock, base_credentials, caplog
+):
+    """Configuring a second, different project in the same process warns, since
+    Opik configuration is global per process. Same project does not warn."""
+    TraceDataset(base_credentials | {"project_name": "proj-a"})
+
+    caplog.clear()
+    TraceDataset(base_credentials | {"project_name": "proj-a"})
+    assert "already configured" not in caplog.text
+
+    caplog.clear()
+    TraceDataset(base_credentials | {"project_name": "proj-b"})
+    assert "already configured for project 'proj-a'" in caplog.text
 
 
 @patch("kedro_datasets_experimental.opik.trace_dataset.configure")
@@ -331,7 +349,8 @@ class TestTraceDatasetAutogenMode:
 
 @pytest.fixture(autouse=True)
 def clean_env():
-    """Clean up environment variables after each test."""
+    """Reset env vars and the per-process project guard after each test."""
     yield
     if "OPIK_PROJECT_NAME" in os.environ:
         del os.environ["OPIK_PROJECT_NAME"]
+    trace_dataset_module._session_project_state["project_name"] = None

--- a/kedro-datasets/pyproject.toml
+++ b/kedro-datasets/pyproject.toml
@@ -230,8 +230,8 @@ langfuse = ["kedro-datasets[langfuse-evaluationdataset,langfuse-promptdataset,la
 mlrun = ["mlrun>=1.10.0"]
 opik-evaluationdataset = ["opik>=1.8.0"]
 opik-promptdataset = ["opik>=1.8.0"]
-opik-tracedataset = ["opik>=1.8.0"]
-opik-tracedataset-autogen = ["opik>=1.8.0", "opentelemetry-sdk", "opentelemetry-exporter-otlp-proto-http"]
+opik-tracedataset = ["opik>=1.11.0"]
+opik-tracedataset-autogen = ["opik>=1.11.0", "opentelemetry-sdk", "opentelemetry-exporter-otlp-proto-http"]
 opik = ["kedro-datasets[opik-evaluationdataset, opik-promptdataset, opik-tracedataset, opik-tracedataset-autogen]", "openai>=2.3.0", "langchain>=0.2.0"]
 
 netcdf-netcdfdataset = ["h5netcdf>=1.2.0","netcdf4>=1.6.4","xarray>=2023.1.0"]

--- a/kedro-datasets/pyproject.toml
+++ b/kedro-datasets/pyproject.toml
@@ -426,6 +426,9 @@ experimental_test = [
     "chromadb>=1.0.0",
     "litellm<1.80.12; python_version >= '3.14'",  # For compatibility with chromadb's opentelemetry-proto
     "dask[complete]>=2021.10",
+    # scipy is pulled transitively which has no cp314 wheel and
+    # fails to build from source in CI 1.16.0 is the first release with cp314 wheels.
+    "scipy>=1.16.0; python_version >= '3.14'",
 ]
 
 # All requirements


### PR DESCRIPTION
## Description

In `langchain` mode, `opik.TraceDataset` ignores `credentials.project_name`, so every LangChain trace lands in Opik's **"Default Project"** regardless of what's configured. This PR forwards `project_name` from credentials to `OpikTracer`, mirroring the existing `_load_openai_client` pattern in the same file.

Sibling of #1416 same theme of "make the Opik datasets consistent in how they handle credentials." Together, both PRs unblock removal of two workarounds in `kedro-academy/kedro-academy#168`


## Development notes
In `_load_langchain_tracer`, pull `project_name` from credentials when not explicitly overridden in catalog `trace_kwargs`:

```
project_name = self._credentials.get("project_name")
kwargs = {**self._trace_kwargs}
if project_name and "project_name" not in kwargs:
    kwargs["project_name"] = project_name

return OpikTracer(**kwargs)
```

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [ ] Updated `jsonschema/kedro-catalog-X.XX.json` if necessary
- [x] Added a description of this change in the relevant `RELEASE.md` file
- [x] Added tests to cover my changes
- [ ] Received approvals from at least half of the TSC (required for adding a new, non-experimental dataset)
