### PR TITLE
feat(datasets): Add `os.PathLike` support for Spark datasets

### DIFF
--- a/kedro-datasets/RELEASE.md
+++ b/kedro-datasets/RELEASE.md
@@ -6,10 +6,12 @@
 - Fixed the `darts-torch-model-dataset` optional dependency to point at the real PyPI package `u8darts[all]`.
 - Repaired `polars.PolarsDatabaseDataset` end-to-end and added a full test suite for it.
 - Fixed `opik.TraceDataset` so `credentials.project_name` is now passed to `configure()` and persisted to Opik's session configuration.
+- Added `os.PathLike` support for `Spark` datasets.
 
 ## Community contributions
 - [@PragnyaKhandelwal](https://github.com/PragnyaKhandelwal)
 - [Anton Nikishin](https://github.com/nikanton)
+- [@GDaamn](https://github.com/GDaamn)
 
 # Release 9.4.0
 

--- a/kedro-datasets/kedro_datasets/spark/deltatable_dataset.py
+++ b/kedro-datasets/kedro_datasets/spark/deltatable_dataset.py
@@ -3,6 +3,7 @@
 """
 from __future__ import annotations
 
+import os
 from pathlib import PurePosixPath
 from typing import Any, NoReturn
 
@@ -60,12 +61,13 @@ class DeltaTableDataset(AbstractDataset[None, DeltaTable]):
     _SINGLE_PROCESS = True
 
     def __init__(
-        self, *, filepath: str, metadata: dict[str, Any] | None = None
+        self, *, filepath: str | os.PathLike, metadata: dict[str, Any] | None = None
     ) -> None:
         """Creates a new instance of ``DeltaTableDataset``.
 
         Args:
-            filepath: Filepath in POSIX format to a Spark dataframe. When using Databricks
+            filepath: Filepath in POSIX format to a Spark dataframe. This can be a
+                string or an ``os.PathLike`` object. When using Databricks
                 and working with data written to mount path points,
                 specify ``filepath``s for (versioned) ``SparkDataset``s
                 starting with ``/dbfs/mnt``.

--- a/kedro-datasets/kedro_datasets/spark/spark_dataset.py
+++ b/kedro-datasets/kedro_datasets/spark/spark_dataset.py
@@ -1,6 +1,7 @@
 """``AbstractVersionedDataset`` implementation to access Spark dataframes using
 ``pyspark``.
 """
+
 from __future__ import annotations
 
 import json

--- a/kedro-datasets/kedro_datasets/spark/spark_dataset.py
+++ b/kedro-datasets/kedro_datasets/spark/spark_dataset.py
@@ -1,11 +1,11 @@
 """``AbstractVersionedDataset`` implementation to access Spark dataframes using
 ``pyspark``.
 """
-
 from __future__ import annotations
 
 import json
 import logging
+import os
 from copy import deepcopy
 from fnmatch import fnmatch
 from functools import partial
@@ -150,7 +150,7 @@ class SparkDataset(AbstractVersionedDataset[DataFrame, DataFrame]):
     def __init__(  # noqa: PLR0913
         self,
         *,
-        filepath: str,
+        filepath: str | os.PathLike,
         file_format: str = "parquet",
         load_args: dict[str, Any] | None = None,
         save_args: dict[str, Any] | None = None,
@@ -161,7 +161,8 @@ class SparkDataset(AbstractVersionedDataset[DataFrame, DataFrame]):
         """Creates a new instance of ``SparkDataset``.
 
         Args:
-            filepath: Filepath in POSIX format to a Spark dataframe. When using Databricks
+            filepath: Filepath in POSIX format to a Spark dataframe. This can be a
+                string or an ``os.PathLike`` object. When using Databricks
                 specify ``filepath``s starting with ``/dbfs/``.
             file_format: File format used during load and save
                 operations. These are formats supported by the running

--- a/kedro-datasets/kedro_datasets/spark/spark_streaming_dataset.py
+++ b/kedro-datasets/kedro_datasets/spark/spark_streaming_dataset.py
@@ -1,6 +1,7 @@
 """SparkStreamingDataset to load and save a PySpark Streaming DataFrame."""
 from __future__ import annotations
 
+import os
 from pathlib import PurePosixPath
 from typing import Any
 
@@ -41,7 +42,7 @@ class SparkStreamingDataset(AbstractDataset):
     def __init__(  # noqa: PLR0913
         self,
         *,
-        filepath: str = "",
+        filepath: str | os.PathLike = "",
         file_format: str = "",
         save_args: dict[str, Any] | None = None,
         load_args: dict[str, Any] | None = None,
@@ -50,7 +51,8 @@ class SparkStreamingDataset(AbstractDataset):
         """Creates a new instance of SparkStreamingDataset.
 
         Args:
-            filepath: Filepath in POSIX format to a Spark dataframe. When using Databricks
+            filepath: Filepath in POSIX format to a Spark dataframe. This can be a
+                string or an ``os.PathLike`` object. When using Databricks
                 specify ``filepath``s starting with ``/dbfs/``. For message brokers such as
                 Kafka and all filepath is not required.
             file_format: File format used during load and save operations.

--- a/kedro-datasets/tests/spark/test_deltatable_dataset.py
+++ b/kedro-datasets/tests/spark/test_deltatable_dataset.py
@@ -1,3 +1,5 @@
+from pathlib import PurePosixPath
+
 import pytest
 from delta import DeltaTable
 from kedro.io.core import DatasetError
@@ -55,6 +57,20 @@ class TestDeltaTableDataset:
 
         # check that indeed nothing is written
         assert not delta_ds.exists()
+
+    def test_pathlike_filepath(self, tmp_path, sample_spark_df):
+        filepath = tmp_path / "test_data"
+        delta_ds = DeltaTableDataset(filepath=filepath)
+
+        assert isinstance(delta_ds._filepath, PurePosixPath)
+        assert str(delta_ds._filepath) == filepath.as_posix()
+        assert not delta_ds.exists()
+
+        spark_delta_ds = SparkDataset(filepath=filepath, file_format="delta")
+        spark_delta_ds.save(sample_spark_df)
+
+        assert delta_ds.exists()
+        assert isinstance(delta_ds.load(), DeltaTable)
 
     def test_exists(self, tmp_path, sample_spark_df):
         filepath = (tmp_path / "test_data").as_posix()

--- a/kedro-datasets/tests/spark/test_spark_dataset.py
+++ b/kedro-datasets/tests/spark/test_spark_dataset.py
@@ -179,6 +179,18 @@ class TestSparkDataset:
         spark_df = spark_dataset.load()
         assert spark_df.count() == 4
 
+    def test_pathlike_filepath(self, tmp_path, sample_pandas_df):
+        filepath = tmp_path / "data"
+        local_parquet_set = ParquetDataset(filepath=filepath.as_posix())
+        local_parquet_set.save(sample_pandas_df)
+
+        spark_dataset = SparkDataset(filepath=filepath)
+        spark_df = spark_dataset.load()
+
+        assert spark_df.count() == 4
+        assert isinstance(spark_dataset._filepath, PurePosixPath)
+        assert str(spark_dataset._filepath) == filepath.as_posix()
+
     def test_save_parquet(self, tmp_path, sample_spark_df):
         # To cross check the correct Spark save operation we save to
         # a single spark partition and retrieve it with Kedro

--- a/kedro-datasets/tests/spark/test_spark_streaming_dataset.py
+++ b/kedro-datasets/tests/spark/test_spark_streaming_dataset.py
@@ -107,6 +107,27 @@ class TestSparkStreamingDataset:
         schema = sample_schema(schema_path)
         assert streaming_ds.schema == schema
 
+    def test_pathlike_filepath(self, tmp_path, sample_spark_streaming_df):
+        filepath = tmp_path / "test_streams"
+        schema_path = tmp_path / SCHEMA_FILE_NAME
+
+        spark_json_ds = SparkDataset(
+            filepath=filepath,
+            file_format="json",
+            save_args={"mode": "overwrite"},
+        )
+        spark_json_ds.save(sample_spark_streaming_df)
+
+        streaming_ds = SparkStreamingDataset(
+            filepath=filepath,
+            file_format="json",
+            load_args={"schema": {"filepath": schema_path.as_posix()}},
+        )
+
+        loaded = streaming_ds.load()
+        assert loaded.isStreaming
+        assert loaded.schema == sample_schema(schema_path.as_posix())
+
     @pytest.mark.usefixtures("mocked_s3_schema")
     def test_load_options_schema_path_with_credentials(
         self, tmp_path, sample_spark_streaming_df


### PR DESCRIPTION
## Description
This PR closes part of issues #1316 #1317 by adding support for `os.PathLike` objects as the filepath argument to the Spark datasets, in addition to strings. The PR also adds related tests for this change.

## Development notes
- Updated the filepath parameter type from str to str | os.PathLike for:
    * `SparkDataset`
    * `SparkStreamingDataset`
    * `DeltaTableDataset`
- Updated the corresponding docstrings to document that filepath can be either a `str` or an `os.PathLike` object.
- Added tests verifying that pathlib.Path objects can be used successfully:
    * `test_pathlike_filepath` for SparkDataset
    * `test_pathlike_filepath` for SparkStreamingDataset
    * `test_pathlike_filepath` for DeltaTableDataset

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Updated `jsonschema/kedro-catalog-X.XX.json` if necessary
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ x] Added tests to cover my changes
- [ ] Received approvals from at least half of the TSC (required for adding a new, non-experimental dataset)
