### PR TITLE
fix(datasets): correct darts extra to `u8darts[all]` to close dependency-confusion gap

### DIFF
--- a/kedro-datasets/RELEASE.md
+++ b/kedro-datasets/RELEASE.md
@@ -3,7 +3,7 @@
 ## Major features and improvements
 ## Bug fixes and other changes
 
-- Fixed the `darts-torch-model-dataset` optional dependency to point at the real PyPI package `u8darts[all]` instead of the non-existent `u8darts-all`, removing a dependency-confusion risk on `pip install "kedro-datasets[darts-torch-model-dataset]"`.
+- Fixed the `darts-torch-model-dataset` optional dependency to point at the real PyPI package `u8darts[all]`.
 
 ## Community contributions
 

--- a/kedro-datasets/RELEASE.md
+++ b/kedro-datasets/RELEASE.md
@@ -2,6 +2,9 @@
 
 ## Major features and improvements
 ## Bug fixes and other changes
+
+- Fixed the `darts-torch-model-dataset` optional dependency to point at the real PyPI package `u8darts[all]` instead of the non-existent `u8darts-all`, removing a dependency-confusion risk on `pip install "kedro-datasets[darts-torch-model-dataset]"`.
+
 ## Community contributions
 
 # Release 9.4.0

--- a/kedro-datasets/pyproject.toml
+++ b/kedro-datasets/pyproject.toml
@@ -217,7 +217,7 @@ yaml = ["kedro-datasets[yaml-yamldataset]"]
 chromadb-chromadbdataset = ["chromadb>=1.0.0"]
 chromadb = ["kedro-datasets[chromadb-chromadbdataset]"]
 
-darts-torch-model-dataset = ["u8darts-all"]
+darts-torch-model-dataset = ["u8darts[all]"]
 darts = ["kedro-datasets[darts-torch-model-dataset]"]
 databricks-externaltabledataset = ["kedro-datasets[hdfs-base,s3fs-base]"]
 langchain-promptdataset = ["langchain>=0.3.0"]


### PR DESCRIPTION
## Description

The `darts-torch-model-dataset` optional dependency in `kedro-datasets` referenced `u8darts-all`. This typo was added in this [PR](https://github.com/kedro-org/kedro-plugins/pull/1048). This is a **conda** package name, not a PyPI distribution, on PyPI it resolves to no real package (the simple index lists zero files). As a result the extra pointed at an unclaimed PyPI namespace that any third party could register, which is a classic dependency-confusion vector: anyone running

```
pip install "kedro-datasets[darts-torch-model-dataset]"
```

(or the `[darts]` alias) would have pip fetch `u8darts-all` from PyPI, and whoever owns that name controls the code that gets installed.

This was reported by an external security researcher.

## Development notes

- Changed `kedro-datasets/pyproject.toml` line 220 from `["u8darts-all"]` to `["u8darts[all]"]`, the real Unit8 PyPI package with its `all` extra. This matches the form already used in the `experimental` and `experimental_test` dependency groups (lines 390 / 420), which is why CI tests passed despite the broken extra: CI installs darts through those groups and never exercised the typo'd extra.
- The dataset code imports `from darts import ...`; `u8darts[all]` provides that module including the torch models. (`u8darts` is deprecated upstream in favour of `darts`, but `u8darts[all]` still resolves and keeps this change minimal.)

## Checklist

- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes (RELEASE.md)
- [x] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes (N/A — dependency metadata only)