### PR TITLE
fix(datasets): pin `scipy>=1.16` on Python 3.14 in experimental_test extra

### DIFF
--- a/kedro-datasets/pyproject.toml
+++ b/kedro-datasets/pyproject.toml
@@ -426,6 +426,9 @@ experimental_test = [
     "chromadb>=1.0.0",
     "litellm<1.80.12; python_version >= '3.14'",  # For compatibility with chromadb's opentelemetry-proto
     "dask[complete]>=2021.10",
+    # scipy is pulled transitively which has no cp314 wheel and
+    # fails to build from source in CI 1.16.0 is the first release with cp314 wheels.
+    "scipy>=1.16.0; python_version >= '3.14'",
 ]
 
 # All requirements


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->

The `kedro-datasets-experimental` CI fails on the Python 3.14 while installing the `experimental_test` extra:

scipy is pulled transitively scipy 1.15.3 is pulled which has no cp314 wheel so uv builds it from source, and the build fails as scipy 1.16.0 is the first release with cp314 wheels.


## Development notes
<!-- What have you changed, and how has this been tested? -->

Add a 3.14 pin in the `experimental_test`

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Updated `jsonschema/kedro-catalog-X.XX.json` if necessary
- [x] Added a description of this change in the relevant `RELEASE.md` file
- [x] Added tests to cover my changes
- [ ] Received approvals from at least half of the TSC (required for adding a new, non-experimental dataset)
