### PR TITLE
fix(datasets): harden experimental PyTorchDataset against unsafe torch.load

### DIFF
--- a/kedro-datasets/RELEASE.md
+++ b/kedro-datasets/RELEASE.md
@@ -3,6 +3,7 @@
 ## Major features and improvements
 * Added `send_individually` option to `APIDataset` to send list items as individual requests instead of batched arrays.
 ## Bug fixes and other changes
+- Hardened experimental `pytorch.PyTorchDataset`: `weights_only=True` is now enforced by default on load to block arbitrary code execution from untrusted `.pt` files, user-supplied `load_args` are now correctly passed to `torch.load` (previously silently dropped), and the misleading "pickle-safe" docstring was corrected.
 - Fixed the `darts-torch-model-dataset` optional dependency to point at the real PyPI package `u8darts[all]`.
 - Repaired `polars.PolarsDatabaseDataset` end-to-end and added a full test suite for it.
 - Fixed `opik.TraceDataset` so `credentials.project_name` is now passed to `configure()` and persisted to Opik's session configuration.

--- a/kedro-datasets/RELEASE.md
+++ b/kedro-datasets/RELEASE.md
@@ -3,7 +3,7 @@
 ## Major features and improvements
 * Added `send_individually` option to `APIDataset` to send list items as individual requests instead of batched arrays.
 ## Bug fixes and other changes
-- Hardened experimental `pytorch.PyTorchDataset`: `weights_only=True` is now enforced by default on load to block arbitrary code execution from untrusted `.pt` files, user-supplied `load_args` are now correctly passed to `torch.load` (previously silently dropped), and the misleading "pickle-safe" docstring was corrected.
+- Hardened experimental `pytorch.PyTorchDataset`: `weights_only=True` is now enforced by default on load to block arbitrary code execution from untrusted `.pt` files, user-supplied `load_args` and `save_args` are now correctly passed to `torch.load` and `torch.save` (previously silently dropped), and the misleading "pickle-safe" docstring was corrected.
 - Fixed the `darts-torch-model-dataset` optional dependency to point at the real PyPI package `u8darts[all]`.
 - Repaired `polars.PolarsDatabaseDataset` end-to-end and added a full test suite for it.
 - Fixed `opik.TraceDataset` so `credentials.project_name` is now passed to `configure()` and persisted to Opik's session configuration.

--- a/kedro-datasets/kedro_datasets_experimental/pytorch/pytorch_dataset.py
+++ b/kedro-datasets/kedro_datasets_experimental/pytorch/pytorch_dataset.py
@@ -16,7 +16,19 @@ from kedro.io.core import (
 
 
 class PyTorchDataset(AbstractVersionedDataset[Any, Any]):
-    """`PyTorchDataset` loads and saves PyTorch models' `state_dict` using PyTorch's recommended zipfile serialization protocol to avoid security issues with Pickle.
+    """`PyTorchDataset` loads and saves PyTorch models' `state_dict` using ``torch.save``
+    and ``torch.load``.
+
+    .. warning::
+        Loading is **not** safe for untrusted files. ``torch.load`` deserializes a
+        pickle stream (the zipfile produced by ``torch.save`` is only a container
+        around that pickle), so a maliciously crafted ``.pt`` file can execute
+        arbitrary code on load. To mitigate this, ``PyTorchDataset`` enforces
+        ``weights_only=True`` by default, which restricts loading to tensors and a
+        small allow-list of safe types. Only set ``load_args: {weights_only: false}``
+        for files you fully trust, and prefer ``torch>=2.6`` (where ``weights_only=True``
+        is also the upstream default) or a non-pickle format such as ``safetensors``
+        when handling untrusted inputs.
 
     ### Example usage for the [YAML API](https://kedro.readthedocs.io/en/stable/data/data_catalog_yaml_examples.html)
 
@@ -47,7 +59,11 @@ class PyTorchDataset(AbstractVersionedDataset[Any, Any]):
 
     """
 
-    DEFAULT_LOAD_ARGS: dict[str, Any] = {}
+    # Enforce safe deserialization by default. ``weights_only=True`` restricts
+    # ``torch.load`` to tensors and a small allow-list of safe types, blocking the
+    # arbitrary-code-execution path through pickle's ``__reduce__``. Users can opt
+    # out for trusted files via ``load_args``.
+    DEFAULT_LOAD_ARGS: dict[str, Any] = {"weights_only": True}
     DEFAULT_SAVE_ARGS: dict[str, Any] = {}
 
     def __init__(  # noqa: PLR0913
@@ -64,6 +80,9 @@ class PyTorchDataset(AbstractVersionedDataset[Any, Any]):
         _fs_args = deepcopy(fs_args) or {}
         _fs_open_args_load = _fs_args.pop("open_args_load", {})
         _fs_open_args_save = _fs_args.pop("open_args_save", {})
+        # PyTorch serialization is binary; open in binary mode by default.
+        _fs_open_args_load.setdefault("mode", "rb")
+        _fs_open_args_save.setdefault("mode", "wb")
         _credentials = deepcopy(credentials) or {}
 
         protocol, path = get_protocol_and_path(filepath, version)
@@ -104,11 +123,15 @@ class PyTorchDataset(AbstractVersionedDataset[Any, Any]):
 
     def load(self) -> Any:
         load_path = get_filepath_str(self._get_load_path(), self._protocol)
-        return torch.load(load_path, **self._fs_open_args_load)  #nosec: B614
+        with self._fs.open(load_path, **self._fs_open_args_load) as fs_file:
+            # ``weights_only=True`` is enforced via DEFAULT_LOAD_ARGS unless the user
+            # explicitly opts out for a trusted file.
+            return torch.load(fs_file, **self._load_args)  # nosec: B614
 
     def save(self, data: torch.nn.Module) -> None:
         save_path = get_filepath_str(self._get_save_path(), self._protocol)
-        torch.save(data.state_dict(), save_path, **self._fs_open_args_save)  #nosec: B614
+        with self._fs.open(save_path, **self._fs_open_args_save) as fs_file:
+            torch.save(data.state_dict(), fs_file, **self._save_args)  # nosec: B614
 
         self._invalidate_cache()
 

--- a/kedro-datasets/kedro_datasets_experimental/pytorch/pytorch_dataset.py
+++ b/kedro-datasets/kedro_datasets_experimental/pytorch/pytorch_dataset.py
@@ -124,9 +124,10 @@ class PyTorchDataset(AbstractVersionedDataset[Any, Any]):
     def load(self) -> Any:
         load_path = get_filepath_str(self._get_load_path(), self._protocol)
         with self._fs.open(load_path, **self._fs_open_args_load) as fs_file:
-            # ``weights_only=True`` is enforced via DEFAULT_LOAD_ARGS unless the user
-            # explicitly opts out for a trusted file.
-            return torch.load(fs_file, **self._load_args)
+            # nosec: B614 - weights_only defaults to True via DEFAULT_LOAD_ARGS,
+            # restricting deserialisation to safe types. Users may override via
+            # load_args only for files they fully trust.
+            return torch.load(fs_file, **self._load_args)  # nosec: B614
 
     def save(self, data: torch.nn.Module) -> None:
         save_path = get_filepath_str(self._get_save_path(), self._protocol)

--- a/kedro-datasets/kedro_datasets_experimental/pytorch/pytorch_dataset.py
+++ b/kedro-datasets/kedro_datasets_experimental/pytorch/pytorch_dataset.py
@@ -124,7 +124,7 @@ class PyTorchDataset(AbstractVersionedDataset[Any, Any]):
     def load(self) -> Any:
         load_path = get_filepath_str(self._get_load_path(), self._protocol)
         with self._fs.open(load_path, **self._fs_open_args_load) as fs_file:
-            # nosec: B614 - weights_only defaults to True via DEFAULT_LOAD_ARGS,
+            # Suppression of B614 - weights_only defaults to True via DEFAULT_LOAD_ARGS,
             # restricting deserialisation to safe types. Users may override via
             # load_args only for files they fully trust.
             return torch.load(fs_file, **self._load_args)  # nosec: B614

--- a/kedro-datasets/kedro_datasets_experimental/pytorch/pytorch_dataset.py
+++ b/kedro-datasets/kedro_datasets_experimental/pytorch/pytorch_dataset.py
@@ -126,12 +126,12 @@ class PyTorchDataset(AbstractVersionedDataset[Any, Any]):
         with self._fs.open(load_path, **self._fs_open_args_load) as fs_file:
             # ``weights_only=True`` is enforced via DEFAULT_LOAD_ARGS unless the user
             # explicitly opts out for a trusted file.
-            return torch.load(fs_file, **self._load_args)  # nosec: B614
+            return torch.load(fs_file, **self._load_args)
 
     def save(self, data: torch.nn.Module) -> None:
         save_path = get_filepath_str(self._get_save_path(), self._protocol)
         with self._fs.open(save_path, **self._fs_open_args_save) as fs_file:
-            torch.save(data.state_dict(), fs_file, **self._save_args)  # nosec: B614
+            torch.save(data.state_dict(), fs_file, **self._save_args)
 
         self._invalidate_cache()
 

--- a/kedro-datasets/kedro_datasets_experimental/tests/pytorch/test_pytorch_dataset.py
+++ b/kedro-datasets/kedro_datasets_experimental/tests/pytorch/test_pytorch_dataset.py
@@ -63,3 +63,23 @@ class TestPyTorchDataset:
         dummy_state_dict = dummy_model.state_dict()
         for key, value in reloaded_state_dict.items():
             assert torch.equal(dummy_state_dict[key], value)
+
+    def test_weights_only_enforced_by_default(self, filepath_model):
+        """A state_dict (tensors only) round-trips under the safe default."""
+        dataset = PyTorchDataset(filepath=filepath_model)
+        assert dataset._load_args == {"weights_only": True}
+        dataset.save(TheModelClass())
+        model = TheModelClass()
+        model.load_state_dict(dataset.load())
+
+    def test_load_args_are_passed_to_torch_load(self, filepath_model, mocker):
+        """User-supplied load_args must reach torch.load, not be silently dropped."""
+        dataset = PyTorchDataset(
+            filepath=filepath_model, load_args={"weights_only": False}
+        )
+        dataset.save(TheModelClass())
+        mocked_load = mocker.patch(
+            "kedro_datasets_experimental.pytorch.pytorch_dataset.torch.load"
+        )
+        dataset.load()
+        assert mocked_load.call_args.kwargs["weights_only"] is False

--- a/kedro-datasets/kedro_datasets_experimental/tests/pytorch/test_pytorch_dataset.py
+++ b/kedro-datasets/kedro_datasets_experimental/tests/pytorch/test_pytorch_dataset.py
@@ -83,3 +83,13 @@ class TestPyTorchDataset:
         )
         dataset.load()
         assert mocked_load.call_args.kwargs["weights_only"] is False
+
+
+    def test_save_args_are_passed_to_torch_save(self, filepath_model, mocker):
+        """User-supplied save_args must reach torch.save, not be silently dropped."""
+        dataset = PyTorchDataset(filepath=filepath_model, save_args={"weights_only": False})
+        mocked_save = mocker.patch(
+            "kedro_datasets_experimental.pytorch.pytorch_dataset.torch.save"
+        )
+        dataset.save(TheModelClass())
+        assert mocked_save.call_args.kwargs["weights_only"] is False


### PR DESCRIPTION
## Description

Closes #1432. Addresses a security report against the experimental `kedro_datasets_experimental.pytorch.PyTorchDataset`.

The dataset was documented as a pickle-*safe* alternative, but `load()` called `torch.load` without `weights_only=True`, which on PyTorch < 2.6 defaults to `weights_only=False` and deserialises arbitrary pickle opcodes, allowing remote code execution from a crafted `.pt` file. It also silently dropped user-supplied `load_args`, so there was no working way to opt into safe loading.

To set expectations: this is an **experimental** dataset (not TSC-maintained, contributed by an OS user) and the underlying behaviour is inherent to PyTorch's `torch.load`. 

## What changed

- **Enforce `weights_only=True` by default** via `DEFAULT_LOAD_ARGS`, with a documented opt-out (`load_args: {weights_only: false}`) for trusted files.
- **Fix `load_args` being dropped on load** — `load()` now passes `self._load_args` to `torch.load` (was `self._fs_open_args_load`), and filesystem open args are routed to the fsspec layer via `self._fs.open(...)`. This also makes `fs_args.open_args_load/save` actually take effect.
- **Correct the misleading docstring** — it no longer claims to "avoid security issues with Pickle"; instead it warns that loading deserialises a pickle and is unsafe for untrusted files unless `weights_only=True`, and points to `torch>=2.6` / `safetensors` for untrusted inputs.
- Added tests for the safe default and `load_args` propagation

## Why not pin `torch>=2.6`

The `weights_only` argument has existed since torch 1.13, so enforcing `weights_only=True` in our own default protects users regardless of the installed PyTorch version. A hard version pin would needlessly break existing installs, so the dependency is left unpinned and the docstring recommends `torch>=2.6`/`safetensors` for untrusted inputs.

## On the Bandit B614 suppression

The original code suppressed Bandit's B614 rule (`torch.load` without `weights_only`) with `# nosec: B614`, at the time hiding a real vulnerability. I removed it initially, but B614 is a static analysis rule that requires `weights_only=True` as a **literal** to pass. Since `weights_only` is passed via `**self._load_args` to preserve the user's ability to opt out for trusted files, Bandit cannot statically resolve it regardless of the default.
