### PR TITLE
fix(datasets): preserve remote URIs in ibis.FileDataset

### DIFF
--- a/kedro-datasets/RELEASE.md
+++ b/kedro-datasets/RELEASE.md
@@ -8,6 +8,7 @@
 - Repaired `polars.PolarsDatabaseDataset` end-to-end and added a full test suite for it.
 - Fixed `opik.TraceDataset` so `credentials.project_name` is now passed to `configure()` and persisted to Opik's session configuration.
 - Added `os.PathLike` support for `Spark` datasets.
+- Fixed `ibis.FileDataset` to support remote filepaths (e.g. `s3://`, `abfss://`, `hf://`) and added an `fs_args` argument to authenticate the filesystem used for version discovery.
 
 ## Community contributions
 - [@PragnyaKhandelwal](https://github.com/PragnyaKhandelwal)

--- a/kedro-datasets/kedro_datasets/_utils/databricks_utils.py
+++ b/kedro-datasets/kedro_datasets/_utils/databricks_utils.py
@@ -10,6 +10,9 @@ from typing import TYPE_CHECKING, Union
 from kedro.io.core import get_protocol_and_path
 from pyspark.sql import SparkSession
 
+# Re-exported for backwards compatibility; canonical home is ``file_utils``.
+from kedro_datasets._utils.file_utils import split_filepath  # noqa: F401
+
 if TYPE_CHECKING:
     from databricks.connect import DatabricksSession
     from pyspark.dbutils import DBUtils
@@ -25,13 +28,6 @@ def parse_glob_pattern(pattern: str) -> str:
             break
         clean.append(part)
     return "/".join(clean)
-
-
-def split_filepath(filepath: str | os.PathLike) -> tuple[str, str]:
-    split_ = str(filepath).split("://", 1)
-    if len(split_) == 2:  # noqa: PLR2004
-        return split_[0] + "://", split_[1]
-    return "", split_[0]
 
 
 def strip_dbfs_prefix(path: str, prefix: str = "/dbfs") -> str:

--- a/kedro-datasets/kedro_datasets/_utils/file_utils.py
+++ b/kedro-datasets/kedro_datasets/_utils/file_utils.py
@@ -1,0 +1,24 @@
+"""Filesystem path utilities shared across datasets."""
+from __future__ import annotations
+
+import os
+
+
+def split_filepath(filepath: str | os.PathLike) -> tuple[str, str]:
+    """Split a filepath into its protocol prefix (e.g. ``s3://``) and the rest.
+
+    Unlike ``pathlib``-based parsing, this preserves the ``//`` after the
+    protocol, so cloud/remote URIs (``s3://``, ``abfss://``, ``hf://``, ...)
+    survive a round trip when the prefix is concatenated back onto the path.
+
+    Args:
+        filepath: Raw filepath, e.g. ``s3://bucket/data.parquet`` or a local path.
+
+    Returns:
+        A ``(prefix, path)`` tuple. ``prefix`` is ``""`` for local paths;
+        otherwise it ends with ``://`` (e.g. ``s3://``).
+    """
+    split_ = str(filepath).split("://", 1)
+    if len(split_) == 2:  # noqa: PLR2004
+        return split_[0] + "://", split_[1]
+    return "", split_[0]

--- a/kedro-datasets/kedro_datasets/ibis/file_dataset.py
+++ b/kedro-datasets/kedro_datasets/ibis/file_dataset.py
@@ -5,10 +5,12 @@ from copy import deepcopy
 from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING, Any, ClassVar
 
+import fsspec
 import ibis.expr.types as ir
 from kedro.io import AbstractVersionedDataset, DatasetError, Version
 
 from kedro_datasets._utils import ConnectionMixin
+from kedro_datasets._utils.file_utils import split_filepath
 
 if TYPE_CHECKING:
     from ibis import BaseBackend
@@ -83,6 +85,7 @@ class FileDataset(ConnectionMixin, AbstractVersionedDataset[ir.Table, ir.Table])
         credentials: dict[str, Any] | None = None,
         load_args: dict[str, Any] | None = None,
         save_args: dict[str, Any] | None = None,
+        fs_args: dict[str, Any] | None = None,
         version: Version | None = None,
         metadata: dict[str, Any] | None = None,
     ) -> None:
@@ -118,6 +121,12 @@ class FileDataset(ConnectionMixin, AbstractVersionedDataset[ir.Table, ir.Table])
                 `read_{file_format}` method.
             save_args: Additional arguments passed to the Ibis backend's
                 `to_{file_format}` method.
+            fs_args: Extra arguments to pass into underlying filesystem class
+                constructor (e.g. ``{"project": "my-project"}`` for
+                ``GCSFileSystem``). Used only to discover versions and check
+                existence of a remote ``filepath``; reading and writing is left
+                to the Ibis backend. Note that fsspec credentials go here, not
+                in ``credentials`` (which configures the Ibis connection).
             version: If specified, should be an instance of
                 ``kedro.io.core.Version``. If its ``load`` attribute is
                 None, the latest version will be loaded. If its ``save``
@@ -130,12 +139,17 @@ class FileDataset(ConnectionMixin, AbstractVersionedDataset[ir.Table, ir.Table])
         _connection_config = connection or self.DEFAULT_CONNECTION_CONFIG
         _credentials = deepcopy(credentials) or {}
         self._connection_config = {**_connection_config, **_credentials}
+        self._fs_args = deepcopy(fs_args or {})
         self.metadata = metadata
 
+        self._fs_prefix, path = split_filepath(filepath)
+        self._fs: fsspec.AbstractFileSystem | None = None
+
         super().__init__(
-            filepath=PurePosixPath(filepath),
+            filepath=PurePosixPath(path),
             version=version,
-            exists_function=lambda filepath: Path(filepath).exists(),
+            exists_function=self._fs_exists if self._fs_prefix else None,
+            glob_function=self._fs_glob if self._fs_prefix else None,
         )
 
         # Set load and save arguments, overwriting defaults if provided.
@@ -159,20 +173,34 @@ class FileDataset(ConnectionMixin, AbstractVersionedDataset[ir.Table, ir.Table])
         """The ``Backend`` instance for the connection configuration."""
         return self._connection
 
+    def _filesystem(self) -> fsspec.AbstractFileSystem:
+        # Build lazily so backend-only users don't need adlfs, s3fs, etc.
+        if self._fs is None:
+            protocol = self._fs_prefix.removesuffix("://")
+            self._fs = fsspec.filesystem(protocol, **self._fs_args)
+        return self._fs
+
+    def _fs_exists(self, path: str) -> bool:
+        return self._filesystem().exists(path)
+
+    def _fs_glob(self, pattern: str) -> list[str]:
+        return self._filesystem().glob(pattern)
+
     def load(self) -> ir.Table:
-        load_path = str(self._get_load_path())
+        load_path = self._fs_prefix + str(self._get_load_path())
         reader = getattr(self.connection, f"read_{self._file_format}")
         return reader(load_path, table_name=self._table_name, **self._load_args)
 
     def save(self, data: ir.Table) -> None:
-        save_path = self._get_save_path()
-        Path(save_path).parent.mkdir(parents=True, exist_ok=True)
+        save_path = self._fs_prefix + str(self._get_save_path())
+        if not self._fs_prefix:  # only local paths need their parent created
+            Path(save_path).parent.mkdir(parents=True, exist_ok=True)
         writer = getattr(self.connection, f"to_{self._file_format}")
-        writer(data, str(save_path), **self._save_args)
+        writer(data, save_path, **self._save_args)
 
     def _describe(self) -> dict[str, Any]:
         return {
-            "filepath": self._filepath,
+            "filepath": self._fs_prefix + str(self._filepath),
             "file_format": self._file_format,
             "table_name": self._table_name,
             "backend": self._connection_config["backend"],
@@ -187,4 +215,4 @@ class FileDataset(ConnectionMixin, AbstractVersionedDataset[ir.Table, ir.Table])
         except DatasetError:
             return False
 
-        return Path(load_path).exists()
+        return self._exists_function(str(load_path))

--- a/kedro-datasets/static/jsonschema/kedro-catalog-1.0.0.json
+++ b/kedro-datasets/static/jsonschema/kedro-catalog-1.0.0.json
@@ -527,6 +527,10 @@
                   "type": "object",
                   "description": "Additional arguments passed to the Ibis backend's to_{file_format} method."
                 },
+                "fs_args": {
+                  "type": ["object", "null"],
+                  "description": "Extra arguments (e.g. credentials) for the fsspec filesystem used for version discovery and existence checks on a remote filepath. Data reading/writing is delegated to the Ibis backend."
+                },
                 "version": {
                   "type": ["object", "null"],
                   "description": "kedro.io.core.Version instance for versioned data."

--- a/kedro-datasets/tests/ibis/test_file_dataset.py
+++ b/kedro-datasets/tests/ibis/test_file_dataset.py
@@ -95,6 +95,64 @@ class TestFileDataset:
         reloaded = ds.load()
         assert_frame_equal(dummy_table.execute(), reloaded.execute())
 
+    @pytest.mark.parametrize(
+        "filepath",
+        [
+            "s3://bucket/data/cars.parquet",
+            "abfss://container@account.dfs.core.windows.net/data/cars.parquet",
+            "hf://datasets/user/repo/cars.parquet",
+        ],
+    )
+    def test_load_save_preserve_remote_uri(self, mocker, filepath, dummy_table):
+        """Cloud/remote URIs must reach Ibis intact; the protocol `//` should
+        not be collapsed by ``PurePosixPath`` (see #1298, #918)."""
+        mocker.patch.dict(FileDataset._connections, clear=True)
+        backend = mocker.patch("ibis.duckdb")
+        ds = FileDataset(
+            filepath=filepath,
+            file_format="parquet",
+            connection={"backend": "duckdb"},
+        )
+        connection = backend.connect.return_value
+
+        ds.load()
+        connection.read_parquet.assert_called_once_with(filepath, table_name=None)
+
+        ds.save(dummy_table)
+        connection.to_parquet.assert_called_once_with(dummy_table, filepath)
+
+    def test_remote_exists_uses_filesystem(self, mocker):
+        """`exists` on a remote path should go through ``fsspec`` with a
+        protocol-less path."""
+        mocker.patch.dict(FileDataset._connections, clear=True)
+        mocker.patch("ibis.duckdb")
+        filesystem = mocker.patch("fsspec.filesystem")
+        filesystem.return_value.exists.return_value = True
+        ds = FileDataset(
+            filepath="s3://bucket/data/cars.parquet",
+            file_format="parquet",
+            connection={"backend": "duckdb"},
+        )
+        assert ds.exists()
+        filesystem.return_value.exists.assert_called_once_with(
+            "bucket/data/cars.parquet"
+        )
+
+    def test_remote_unversioned_does_not_build_filesystem(self, mocker, dummy_table):
+        """Unversioned remote IO is delegated to Ibis, so no ``fsspec``
+        filesystem (and therefore no extra dependency like ``s3fs``) is needed."""
+        mocker.patch.dict(FileDataset._connections, clear=True)
+        mocker.patch("ibis.duckdb")
+        filesystem = mocker.patch("fsspec.filesystem")
+        ds = FileDataset(
+            filepath="s3://bucket/data/cars.parquet",
+            file_format="parquet",
+            connection={"backend": "duckdb"},
+        )
+        ds.save(dummy_table)
+        ds.load()
+        filesystem.assert_not_called()
+
     @pytest.mark.parametrize("load_args", [{"filename": True}], indirect=True)
     def test_load_extra_params(self, file_dataset, load_args, dummy_table):
         """Test overriding the default load arguments."""
@@ -312,6 +370,46 @@ class TestFileDatasetVersioned:
             version=Version(None, None),
         )
         assert ds_new.resolve_load_version() == second_load_version
+
+    def test_remote_versioned_uses_filesystem(self, mocker):
+        """Version discovery on remote storage must go through ``fsspec`` and
+        operate on protocol-less paths."""
+        mocker.patch.dict(FileDataset._connections, clear=True)
+        mocker.patch("ibis.duckdb")
+        filesystem = mocker.patch("fsspec.filesystem")
+        filesystem.return_value.glob.return_value = []
+        ds = FileDataset(
+            filepath="s3://bucket/data/cars.parquet",
+            file_format="parquet",
+            connection={"backend": "duckdb"},
+            version=Version(None, None),
+        )
+        with pytest.raises(DatasetError, match="Did not find any versions"):
+            ds.load()
+
+        filesystem.assert_called_once_with("s3")
+        pattern = filesystem.return_value.glob.call_args[0][0]
+        assert not pattern.startswith("s3://")
+        assert pattern.startswith("bucket/data/cars.parquet")
+
+    def test_remote_fs_args_forwarded(self, mocker):
+        """``fs_args`` should be forwarded to ``fsspec.filesystem`` for version
+        discovery, independently of the Ibis connection credentials."""
+        mocker.patch.dict(FileDataset._connections, clear=True)
+        mocker.patch("ibis.duckdb")
+        filesystem = mocker.patch("fsspec.filesystem")
+        filesystem.return_value.glob.return_value = []
+        ds = FileDataset(
+            filepath="s3://bucket/data/cars.parquet",
+            file_format="parquet",
+            connection={"backend": "duckdb"},
+            version=Version(None, None),
+            fs_args={"key": "abc", "secret": "xyz"},  # pragma: allowlist secret
+        )
+        with pytest.raises(DatasetError, match="Did not find any versions"):
+            ds.load()
+
+        filesystem.assert_called_once_with("s3", key="abc", secret="xyz")
 
     def test_no_versions(self, versioned_file_dataset):
         """Check the error if no versions are available for load."""


### PR DESCRIPTION
## Description

Fixes #1298 and #918.

`ibis.FileDataset` wrapped the filepath in `PurePosixPath`, which collapses the
`//` in remote URIs (`s3://` → `s3:/`, `abfss://` → `abfss:/`, `hf://`,
`https://`, ...). Every subsequent operation then treated the mangled string as
a local path, so cloud and web reads/writes failed (the `s3://` example in the
docstring never actually worked).

This mirrors how `spark.SparkDataset` already solves the same problem: peel the
protocol prefix off with `split_filepath`, store the remainder as a
`PurePosixPath`, and reattach the prefix (`self._fs_prefix + str(...)`) before
handing the path to Ibis. The Ibis backend still does the actual I/O and its own
authentication via `connection`/`credentials`.

For Kedro version discovery and existence checks on remote paths, an `fsspec`
filesystem is built **lazily** (so backend-only users aren't forced to install
`adlfs`, `s3fs`, etc.) and a new `fs_args` argument carries its credentials,
kept separate from the Ibis connection `credentials`.

Note: this supersedes the path handling from #1380 — that PR correctly fixed a
*different* bug (#1378, Polars calling `len()` on a `PurePosixPath`), and its
regression test is preserved here.

### Minor behavior changes (cosmetic; not release-noted)

- `ibis.FileDataset`'s string representation now shows the full URI (prefix +
  path) rather than the previously mangled, local-looking path.
- Trailing slashes in paths are normalized away (e.g. `s3://bucket/dir/` becomes
  `s3://bucket/dir`).

## Development notes

- Relocated `split_filepath` to a dependency-free `kedro_datasets/_utils/file_utils.py`
  and re-exported it from `databricks_utils` (which imports `pyspark`), so it can
  be reused by Ibis without dragging in Spark.
- Added tests: remote-URI round-trip for `s3`/`abfss`/`hf`, the lazy-`fsspec`
  guarantee (no filesystem built for unversioned remote I/O), protocol-less
  globbing for remote versioning, and `fs_args` forwarding.
- Verified end-to-end by reading a public `https://` CSV through DuckDB.
- A small consistency follow-up applying the same `removesuffix("://")` tidy-up
  to `spark.SparkDataset` is in #1441.

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Updated `jsonschema/kedro-catalog-X.XX.json` if necessary
- [x] Added a description of this change in the relevant `RELEASE.md` file
- [x] Added tests to cover my changes
- [ ] Received approvals from at least half of the TSC (required for adding a new, non-experimental dataset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
