### PR TITLE
fix(datasets): use removesuffix for Spark protocol

### DIFF
--- a/kedro-datasets/kedro_datasets/spark/spark_dataset.py
+++ b/kedro-datasets/kedro_datasets/spark/spark_dataset.py
@@ -240,7 +240,7 @@ class SparkDataset(AbstractVersionedDataset[DataFrame, DataFrame]):
                 glob_function = partial(dbfs_glob, dbutils=dbutils)
                 exists_function = partial(dbfs_exists, dbutils=dbutils)
         else:
-            filesystem = fsspec.filesystem(fs_prefix.strip("://"), **credentials)
+            filesystem = fsspec.filesystem(fs_prefix.removesuffix("://"), **credentials)
             exists_function = filesystem.exists
             glob_function = filesystem.glob
 


### PR DESCRIPTION
## Description

`SparkDataset` derives the fsspec protocol from the filepath prefix with
`fs_prefix.strip("://")`. `str.strip` removes the *character set* `{":", "/"}`
from both ends rather than the `://` suffix — it happens to work for every real
protocol, but is imprecise and would mangle an unusual one. Since `split_filepath`
guarantees the prefix ends in exactly `://`, `removesuffix("://")` drops precisely
that suffix.

Behavior is identical for all real protocols, so this is effectively a
robustness/clarity change (not worth a release note).

Follow-up to #1436, which applied the same change to `ibis.FileDataset`
([review thread](https://github.com/kedro-org/kedro-plugins/pull/1436#discussion_r3492364694)).

## Development notes

One-line change; no behavior change for any real protocol. Existing `SparkDataset`
tests cover the filesystem-construction path.

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Updated `jsonschema/kedro-catalog-X.XX.json` if necessary
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
- [ ] Received approvals from at least half of the TSC (required for adding a new, non-experimental dataset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
