### PR TITLE
feat(datasets): Add WeaviateVectorStoreDataset

### DIFF
--- a/kedro-datasets/RELEASE.md
+++ b/kedro-datasets/RELEASE.md
@@ -5,7 +5,7 @@
 
 | Type                     | Description                                      | Location                           |
 | ------------------------ | ------------------------------------------------ | ---------------------------------- |
-| `weaviate.WeaviateVectorStoreDataset` | A dataset for loading and saving data to Weaviate vector database collections. | `kedro_datasets_experimental.weaviate` |
+| `weaviate.WeaviateVectorStoreDataset` | A dataset that loads a handle for adding, searching, and deleting entries in Weaviate vector database collections. | `kedro_datasets_experimental.weaviate` |
 
 ## Bug fixes and other changes
 ## Community contributions

--- a/kedro-datasets/RELEASE.md
+++ b/kedro-datasets/RELEASE.md
@@ -1,12 +1,18 @@
 # Upcoming release
 ## Major features and improvements
+* Added `vectorstore_base.AbstractVectorStoreDataset` and `vectorstore_base.VectorStoreHandle`, backend-agnostic abstract base classes for vector store datasets.
+- Added the following new **experimental** datasets:
+
+| Type                     | Description                                      | Location                           |
+| ------------------------ | ------------------------------------------------ | ---------------------------------- |
+| `weaviate.WeaviateVectorStoreDataset` | A dataset for loading and saving data to Weaviate vector database collections. | `kedro_datasets_experimental.weaviate` |
+
 ## Bug fixes and other changes
 ## Community contributions
 
 # Release 9.5.0
 
 ## Major features and improvements
-* Added `vectorstore_base.AbstractVectorStoreDataset` and `vectorstore_base.VectorStoreHandle`, backend-agnostic abstract base classes for vector store datasets.
 * Added `send_individually` option to `APIDataset` to send list items as individual requests instead of batched arrays.
 
 ## Bug fixes and other changes

--- a/kedro-datasets/kedro_datasets_experimental/tests/weaviate/test_weaviate_vector_store_dataset.py
+++ b/kedro-datasets/kedro_datasets_experimental/tests/weaviate/test_weaviate_vector_store_dataset.py
@@ -26,14 +26,15 @@ MODULE = "kedro_datasets_experimental.weaviate.weaviate_vector_store_dataset"
 @pytest.fixture
 def mock_client():
     client = MagicMock()
-    client.collections.get_or_create.return_value = MagicMock(name="MyCollection")
+    client.collections.exists.return_value = False
+    client.collections.create.return_value = MagicMock(name="MyCollection")
     client.collections.get.return_value = MagicMock(name="MyCollection")
     return client
 
 
 @pytest.fixture
 def mock_collection(mock_client):
-    collection = mock_client.collections.get_or_create.return_value
+    collection = mock_client.collections.create.return_value
     collection.name = "MyCollection"
     agg_result = MagicMock()
     agg_result.total_count = 42
@@ -231,12 +232,23 @@ class TestConnect:
 
 
 class TestLoad:
-    def test_load_returns_handle(self, mock_client, mock_collection):
+    def test_load_creates_collection_when_missing(self, mock_client, mock_collection):
+        mock_client.collections.exists.return_value = False
         with patch(f"{MODULE}.weaviate.connect_to_local", return_value=mock_client):
             ds = WeaviateVectorStoreDataset(collection_name="MyCollection")
             handle = ds._load()
             assert isinstance(handle, WeaviateVectorStoreHandle)
-            mock_client.collections.get_or_create.assert_called_once_with("MyCollection")
+            mock_client.collections.exists.assert_called_once_with("MyCollection")
+            mock_client.collections.create.assert_called_once_with("MyCollection")
+
+    def test_load_gets_existing_collection(self, mock_client, mock_collection):
+        mock_client.collections.exists.return_value = True
+        with patch(f"{MODULE}.weaviate.connect_to_local", return_value=mock_client):
+            ds = WeaviateVectorStoreDataset(collection_name="MyCollection")
+            handle = ds._load()
+            assert isinstance(handle, WeaviateVectorStoreHandle)
+            mock_client.collections.get.assert_called_once_with("MyCollection")
+            mock_client.collections.create.assert_not_called()
 
     def test_load_get_only_when_no_create(self, mock_client):
         with patch(f"{MODULE}.weaviate.connect_to_local", return_value=mock_client):
@@ -246,10 +258,10 @@ class TestLoad:
             )
             ds._load()
             mock_client.collections.get.assert_called_once_with("MyCollection")
-            mock_client.collections.get_or_create.assert_not_called()
+            mock_client.collections.exists.assert_not_called()
 
     def test_collection_error_closes_client_and_raises(self, mock_client):
-        mock_client.collections.get_or_create.side_effect = RuntimeError("not found")
+        mock_client.collections.exists.side_effect = RuntimeError("not found")
         with patch(f"{MODULE}.weaviate.connect_to_local", return_value=mock_client):
             ds = WeaviateVectorStoreDataset(collection_name="Missing")
             with pytest.raises(DatasetError, match="Failed to access Weaviate collection"):

--- a/kedro-datasets/kedro_datasets_experimental/tests/weaviate/test_weaviate_vector_store_dataset.py
+++ b/kedro-datasets/kedro_datasets_experimental/tests/weaviate/test_weaviate_vector_store_dataset.py
@@ -311,14 +311,93 @@ class TestHandle:
         assert result == {"collection": "MyCollection", "count": 42}
         mock_collection.aggregate.over_all.assert_called_once_with(total_count=True)
 
-    def test_add_raises_not_implemented(self, handle):
-        with pytest.raises(NotImplementedError, match="ST3"):
-            handle.add([])
-
-    def test_delete_raises_not_implemented(self, handle):
-        with pytest.raises(NotImplementedError, match="ST3"):
-            handle.delete(ids=["a"])
-
     def test_search_raises_not_implemented(self, handle):
         with pytest.raises(NotImplementedError, match="ST4"):
             handle.search(vector=[0.1, 0.2])
+
+
+# ---------------------------------------------------------------------------
+# WeaviateVectorStoreHandle — add()
+# ---------------------------------------------------------------------------
+
+
+class TestHandleAdd:
+    @pytest.fixture
+    def handle(self, mock_client, mock_collection):
+        return WeaviateVectorStoreHandle(mock_client, mock_collection)
+
+    @pytest.fixture
+    def insert_result(self):
+        import uuid
+        result = MagicMock()
+        result.uuids = {0: uuid.UUID("aaaaaaaa-0000-0000-0000-000000000001"),
+                        1: uuid.UUID("bbbbbbbb-0000-0000-0000-000000000002")}
+        result.errors = {}
+        return result
+
+    def test_add_calls_insert_many(self, handle, mock_collection, insert_result):
+        mock_collection.data.insert_many.return_value = insert_result
+        records = [
+            {"vector": [0.1, 0.2], "text": "hello"},
+            {"vector": [0.3, 0.4], "text": "world"},
+        ]
+        handle.add(records)
+        mock_collection.data.insert_many.assert_called_once()
+        objects = mock_collection.data.insert_many.call_args[0][0]
+        assert len(objects) == 2
+        assert objects[0].properties == {"text": "hello"}
+        assert objects[0].vector == [0.1, 0.2]
+        assert objects[1].properties == {"text": "world"}
+
+    def test_add_returns_uuid_strings(self, handle, mock_collection, insert_result):
+        mock_collection.data.insert_many.return_value = insert_result
+        uuids = handle.add([{"vector": [0.1], "text": "a"}, {"vector": [0.2], "text": "b"}])
+        assert uuids == [
+            "aaaaaaaa-0000-0000-0000-000000000001",
+            "bbbbbbbb-0000-0000-0000-000000000002",
+        ]
+
+    def test_add_passes_optional_id(self, handle, mock_collection, insert_result):
+        mock_collection.data.insert_many.return_value = insert_result
+        handle.add([{"id": "my-uuid", "vector": [0.1], "text": "x"}])
+        obj = mock_collection.data.insert_many.call_args[0][0][0]
+        assert obj.uuid == "my-uuid"
+        assert "id" not in obj.properties
+
+    def test_add_raises_on_partial_errors(self, handle, mock_collection):
+        result = MagicMock()
+        result.uuids = {}
+        result.errors = {0: "connection reset"}
+        mock_collection.data.insert_many.return_value = result
+        with pytest.raises(DatasetError, match="add\\(\\) failed for 1 record"):
+            handle.add([{"vector": [0.1], "text": "bad"}])
+
+
+# ---------------------------------------------------------------------------
+# WeaviateVectorStoreHandle — delete()
+# ---------------------------------------------------------------------------
+
+
+class TestHandleDelete:
+    @pytest.fixture
+    def handle(self, mock_client, mock_collection):
+        return WeaviateVectorStoreHandle(mock_client, mock_collection)
+
+    def test_delete_by_ids_calls_delete_by_id(self, handle, mock_collection):
+        handle.delete(ids=["uuid-1", "uuid-2"])
+        assert mock_collection.data.delete_by_id.call_count == 2
+        mock_collection.data.delete_by_id.assert_any_call("uuid-1")
+        mock_collection.data.delete_by_id.assert_any_call("uuid-2")
+
+    def test_delete_by_filter_calls_delete_many(self, handle, mock_collection):
+        f = MagicMock()
+        handle.delete(filters=f)
+        mock_collection.data.delete_many.assert_called_once_with(where=f)
+
+    def test_delete_requires_ids_or_filters(self, handle):
+        with pytest.raises(DatasetError, match="requires exactly one"):
+            handle.delete()
+
+    def test_delete_rejects_both(self, handle):
+        with pytest.raises(DatasetError, match="not both"):
+            handle.delete(ids=["x"], filters=MagicMock())

--- a/kedro-datasets/kedro_datasets_experimental/tests/weaviate/test_weaviate_vector_store_dataset.py
+++ b/kedro-datasets/kedro_datasets_experimental/tests/weaviate/test_weaviate_vector_store_dataset.py
@@ -334,8 +334,8 @@ class TestHandleAdd:
     def test_add_calls_insert_many(self, handle, mock_collection, insert_result):
         mock_collection.data.insert_many.return_value = insert_result
         records = [
-            {"vector": [0.1, 0.2], "text": "hello"},
-            {"vector": [0.3, 0.4], "text": "world"},
+            {"properties": {"text": "hello"}, "vector": [0.1, 0.2]},
+            {"properties": {"text": "world"}, "vector": [0.3, 0.4]},
         ]
         handle.add(records)
         mock_collection.data.insert_many.assert_called_once()
@@ -347,7 +347,12 @@ class TestHandleAdd:
 
     def test_add_returns_uuid_strings(self, handle, mock_collection, insert_result):
         mock_collection.data.insert_many.return_value = insert_result
-        uuids = handle.add([{"vector": [0.1], "text": "a"}, {"vector": [0.2], "text": "b"}])
+        uuids = handle.add(
+            [
+                {"properties": {"text": "a"}, "vector": [0.1]},
+                {"properties": {"text": "b"}, "vector": [0.2]},
+            ]
+        )
         assert uuids == [
             "aaaaaaaa-0000-0000-0000-000000000001",
             "bbbbbbbb-0000-0000-0000-000000000002",
@@ -355,7 +360,7 @@ class TestHandleAdd:
 
     def test_add_passes_optional_id(self, handle, mock_collection, insert_result):
         mock_collection.data.insert_many.return_value = insert_result
-        handle.add([{"id": "my-uuid", "vector": [0.1], "text": "x"}])
+        handle.add([{"id": "my-uuid", "properties": {"text": "x"}, "vector": [0.1]}])
         obj = mock_collection.data.insert_many.call_args[0][0][0]
         assert obj.uuid == "my-uuid"
         assert "id" not in obj.properties
@@ -366,12 +371,12 @@ class TestHandleAdd:
         result.errors = {0: "connection reset"}
         mock_collection.data.insert_many.return_value = result
         with pytest.raises(DatasetError, match="add\\(\\) failed for 1 record"):
-            handle.add([{"vector": [0.1], "text": "bad"}])
+            handle.add([{"properties": {"text": "bad"}, "vector": [0.1]}])
 
     def test_add_wraps_weaviate_exception(self, handle, mock_collection):
         mock_collection.data.insert_many.side_effect = RuntimeError("gRPC timeout")
         with pytest.raises(DatasetError, match="add\\(\\) failed"):
-            handle.add([{"vector": [0.1], "text": "x"}])
+            handle.add([{"properties": {"text": "x"}, "vector": [0.1]}])
 
     def test_add_empty_list_returns_empty(self, handle, mock_collection):
         result = MagicMock()
@@ -382,9 +387,9 @@ class TestHandleAdd:
 
     def test_add_does_not_mutate_input(self, handle, mock_collection, insert_result):
         mock_collection.data.insert_many.return_value = insert_result
-        original = {"vector": [0.1], "id": "u1", "text": "hello"}
+        original = {"vector": [0.1], "id": "u1", "properties": {"text": "hello"}}
         handle.add([original])
-        assert original == {"vector": [0.1], "id": "u1", "text": "hello"}
+        assert original == {"vector": [0.1], "id": "u1", "properties": {"text": "hello"}}
 
 
 # ---------------------------------------------------------------------------
@@ -479,10 +484,16 @@ class TestHandleSearch:
         mock_collection.query.near_vector.return_value = search_result
         results = handle.search(vector=[0.1])
         assert results == [
-            {"id": "aaaaaaaa-0000-0000-0000-000000000001", "distance": 0.12,
-             "text": "hello", "entity_name": "Diabetes"},
-            {"id": "bbbbbbbb-0000-0000-0000-000000000002", "distance": 0.34,
-             "text": "world", "entity_name": "Cancer"},
+            {
+                "id": "aaaaaaaa-0000-0000-0000-000000000001",
+                "distance": 0.12,
+                "properties": {"text": "hello", "entity_name": "Diabetes"},
+            },
+            {
+                "id": "bbbbbbbb-0000-0000-0000-000000000002",
+                "distance": 0.34,
+                "properties": {"text": "world", "entity_name": "Cancer"},
+            },
         ]
 
     def test_search_requires_vector_or_text(self, handle):
@@ -497,17 +508,3 @@ class TestHandleSearch:
         mock_collection.query.near_vector.side_effect = RuntimeError("gRPC error")
         with pytest.raises(DatasetError, match="search\\(\\) failed"):
             handle.search(vector=[0.1])
-
-    def test_search_id_and_distance_override_same_named_properties(
-        self, handle, mock_collection
-    ):
-        obj = MagicMock()
-        obj.uuid = uuid.UUID("aaaaaaaa-0000-0000-0000-000000000001")
-        obj.properties = {"text": "x", "distance": 999.0}
-        obj.metadata.distance = 0.42
-        result = MagicMock()
-        result.objects = [obj]
-        mock_collection.query.near_vector.return_value = result
-        results = handle.search(vector=[0.1])
-        assert results[0]["distance"] == 0.42
-        assert results[0]["id"] == "aaaaaaaa-0000-0000-0000-000000000001"

--- a/kedro-datasets/kedro_datasets_experimental/tests/weaviate/test_weaviate_vector_store_dataset.py
+++ b/kedro-datasets/kedro_datasets_experimental/tests/weaviate/test_weaviate_vector_store_dataset.py
@@ -52,7 +52,7 @@ def cloud_dataset():
         collection_name="MyCollection",
         connection_type="cloud",
         url="https://my-cluster.weaviate.network",
-        credentials={"api_key": "secret"},
+        credentials={"api_key": "secret"},  # pragma: allowlist secret
     )
 
 
@@ -161,7 +161,7 @@ class TestConnect:
                 collection_name="C",
                 connection_type="cloud",
                 url="https://cluster.weaviate.network",
-                credentials={"api_key": "mykey"},
+                credentials={"api_key": "mykey"},  # pragma: allowlist secret
             )
             ds._connect()
             auth_p.assert_called_once_with("mykey")

--- a/kedro-datasets/kedro_datasets_experimental/tests/weaviate/test_weaviate_vector_store_dataset.py
+++ b/kedro-datasets/kedro_datasets_experimental/tests/weaviate/test_weaviate_vector_store_dataset.py
@@ -5,6 +5,7 @@ All tests use mocks — no real Weaviate connection is required.
 
 from __future__ import annotations
 
+import uuid
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -324,7 +325,6 @@ class TestHandleAdd:
 
     @pytest.fixture
     def insert_result(self):
-        import uuid
         result = MagicMock()
         result.uuids = {0: uuid.UUID("aaaaaaaa-0000-0000-0000-000000000001"),
                         1: uuid.UUID("bbbbbbbb-0000-0000-0000-000000000002")}
@@ -411,7 +411,6 @@ class TestHandleSearch:
 
     @pytest.fixture
     def search_result(self):
-        import uuid
         obj1 = MagicMock()
         obj1.uuid = uuid.UUID("aaaaaaaa-0000-0000-0000-000000000001")
         obj1.properties = {"text": "hello", "entity_name": "Diabetes"}

--- a/kedro-datasets/kedro_datasets_experimental/tests/weaviate/test_weaviate_vector_store_dataset.py
+++ b/kedro-datasets/kedro_datasets_experimental/tests/weaviate/test_weaviate_vector_store_dataset.py
@@ -1,4 +1,4 @@
-"""Tests for WeaviateVectorStoreDataset and WeaviateVectorStoreHandle (ST2).
+"""Tests for WeaviateVectorStoreDataset and WeaviateVectorStoreHandle.
 
 All tests use mocks — no real Weaviate connection is required.
 """

--- a/kedro-datasets/kedro_datasets_experimental/tests/weaviate/test_weaviate_vector_store_dataset.py
+++ b/kedro-datasets/kedro_datasets_experimental/tests/weaviate/test_weaviate_vector_store_dataset.py
@@ -311,10 +311,6 @@ class TestHandle:
         assert result == {"collection": "MyCollection", "count": 42}
         mock_collection.aggregate.over_all.assert_called_once_with(total_count=True)
 
-    def test_search_raises_not_implemented(self, handle):
-        with pytest.raises(NotImplementedError, match="ST4"):
-            handle.search(vector=[0.1, 0.2])
-
 
 # ---------------------------------------------------------------------------
 # WeaviateVectorStoreHandle — add()
@@ -401,3 +397,71 @@ class TestHandleDelete:
     def test_delete_rejects_both(self, handle):
         with pytest.raises(DatasetError, match="not both"):
             handle.delete(ids=["x"], filters=MagicMock())
+
+
+# ---------------------------------------------------------------------------
+# WeaviateVectorStoreHandle — search()
+# ---------------------------------------------------------------------------
+
+
+class TestHandleSearch:
+    @pytest.fixture
+    def handle(self, mock_client, mock_collection):
+        return WeaviateVectorStoreHandle(mock_client, mock_collection)
+
+    @pytest.fixture
+    def search_result(self):
+        import uuid
+        obj1 = MagicMock()
+        obj1.uuid = uuid.UUID("aaaaaaaa-0000-0000-0000-000000000001")
+        obj1.properties = {"text": "hello", "entity_name": "Diabetes"}
+        obj1.metadata.distance = 0.12
+        obj2 = MagicMock()
+        obj2.uuid = uuid.UUID("bbbbbbbb-0000-0000-0000-000000000002")
+        obj2.properties = {"text": "world", "entity_name": "Cancer"}
+        obj2.metadata.distance = 0.34
+        result = MagicMock()
+        result.objects = [obj1, obj2]
+        return result
+
+    def test_search_by_vector_calls_near_vector(self, handle, mock_collection, search_result):
+        mock_collection.query.near_vector.return_value = search_result
+        handle.search(vector=[0.1, 0.2], top_k=5)
+        mock_collection.query.near_vector.assert_called_once()
+        kwargs = mock_collection.query.near_vector.call_args[1]
+        assert kwargs["near_vector"] == [0.1, 0.2]
+        assert kwargs["limit"] == 5
+        assert kwargs["filters"] is None
+
+    def test_search_by_text_calls_near_text(self, handle, mock_collection, search_result):
+        mock_collection.query.near_text.return_value = search_result
+        handle.search(text="diabetes treatment", top_k=3)
+        mock_collection.query.near_text.assert_called_once()
+        kwargs = mock_collection.query.near_text.call_args[1]
+        assert kwargs["query"] == "diabetes treatment"
+        assert kwargs["limit"] == 3
+
+    def test_search_passes_filters(self, handle, mock_collection, search_result):
+        mock_collection.query.near_vector.return_value = search_result
+        f = MagicMock()
+        handle.search(vector=[0.1], filters=f)
+        kwargs = mock_collection.query.near_vector.call_args[1]
+        assert kwargs["filters"] is f
+
+    def test_search_returns_formatted_results(self, handle, mock_collection, search_result):
+        mock_collection.query.near_vector.return_value = search_result
+        results = handle.search(vector=[0.1])
+        assert results == [
+            {"id": "aaaaaaaa-0000-0000-0000-000000000001", "distance": 0.12,
+             "text": "hello", "entity_name": "Diabetes"},
+            {"id": "bbbbbbbb-0000-0000-0000-000000000002", "distance": 0.34,
+             "text": "world", "entity_name": "Cancer"},
+        ]
+
+    def test_search_requires_vector_or_text(self, handle):
+        with pytest.raises(DatasetError, match="requires exactly one"):
+            handle.search()
+
+    def test_search_rejects_both(self, handle):
+        with pytest.raises(DatasetError, match="not both"):
+            handle.search(vector=[0.1], text="query")

--- a/kedro-datasets/kedro_datasets_experimental/tests/weaviate/test_weaviate_vector_store_dataset.py
+++ b/kedro-datasets/kedro_datasets_experimental/tests/weaviate/test_weaviate_vector_store_dataset.py
@@ -164,7 +164,7 @@ class TestConnect:
                 credentials={"api_key": "mykey"},  # pragma: allowlist secret
             )
             ds._connect()
-            auth_p.assert_called_once_with("mykey")
+            auth_p.assert_called_once_with("mykey")  # pragma: allowlist secret
             p.assert_called_once_with(
                 cluster_url="https://cluster.weaviate.network",
                 auth_credentials=mock_auth,

--- a/kedro-datasets/kedro_datasets_experimental/tests/weaviate/test_weaviate_vector_store_dataset.py
+++ b/kedro-datasets/kedro_datasets_experimental/tests/weaviate/test_weaviate_vector_store_dataset.py
@@ -74,7 +74,7 @@ class TestDatasetInit:
     def test_cloud_params(self, cloud_dataset):
         assert cloud_dataset._connection_type == "cloud"
         assert cloud_dataset._url == "https://my-cluster.weaviate.network"
-        assert cloud_dataset._credentials == {"api_key": "secret"}
+        assert cloud_dataset._credentials == {"api_key": "secret"}  # pragma: allowlist secret
 
     def test_none_dicts_become_empty(self):
         ds = WeaviateVectorStoreDataset(

--- a/kedro-datasets/kedro_datasets_experimental/tests/weaviate/test_weaviate_vector_store_dataset.py
+++ b/kedro-datasets/kedro_datasets_experimental/tests/weaviate/test_weaviate_vector_store_dataset.py
@@ -19,11 +19,6 @@ from kedro_datasets_experimental.weaviate.weaviate_vector_store_dataset import (
 MODULE = "kedro_datasets_experimental.weaviate.weaviate_vector_store_dataset"
 
 
-# ---------------------------------------------------------------------------
-# Fixtures
-# ---------------------------------------------------------------------------
-
-
 @pytest.fixture
 def mock_client():
     client = MagicMock()
@@ -56,11 +51,6 @@ def cloud_dataset():
         url="https://my-cluster.weaviate.network",
         credentials={"api_key": "secret"},  # pragma: allowlist secret
     )
-
-
-# ---------------------------------------------------------------------------
-# WeaviateVectorStoreDataset — init and describe
-# ---------------------------------------------------------------------------
 
 
 class TestDatasetInit:
@@ -115,20 +105,10 @@ class TestDescribe:
         assert "api_key" not in str(desc)
 
 
-# ---------------------------------------------------------------------------
-# WeaviateVectorStoreDataset — save() disabled
-# ---------------------------------------------------------------------------
-
-
 class TestSaveDisabled:
     def test_save_raises(self, local_dataset):
         with pytest.raises(DatasetError, match="Saving is not supported"):
             local_dataset.save({"data": "value"})
-
-
-# ---------------------------------------------------------------------------
-# WeaviateVectorStoreDataset — _connect
-# ---------------------------------------------------------------------------
 
 
 class TestConnect:
@@ -227,11 +207,6 @@ class TestConnect:
                 ds._connect()
 
 
-# ---------------------------------------------------------------------------
-# WeaviateVectorStoreDataset — _load
-# ---------------------------------------------------------------------------
-
-
 class TestLoad:
     def test_load_creates_collection_when_missing(self, mock_client, mock_collection):
         mock_client.collections.exists.return_value = False
@@ -270,11 +245,6 @@ class TestLoad:
             mock_client.close.assert_called_once()
 
 
-# ---------------------------------------------------------------------------
-# WeaviateVectorStoreHandle — lifecycle
-# ---------------------------------------------------------------------------
-
-
 class TestHandle:
     @pytest.fixture
     def handle(self, mock_client, mock_collection):
@@ -311,11 +281,6 @@ class TestHandle:
         result = handle.describe()
         assert result == {"collection": "MyCollection", "count": 42}
         mock_collection.aggregate.over_all.assert_called_once_with(total_count=True)
-
-
-# ---------------------------------------------------------------------------
-# WeaviateVectorStoreHandle — add()
-# ---------------------------------------------------------------------------
 
 
 class TestHandleAdd:
@@ -392,21 +357,35 @@ class TestHandleAdd:
         assert original == {"vector": [0.1], "id": "u1", "properties": {"text": "hello"}}
 
 
-# ---------------------------------------------------------------------------
-# WeaviateVectorStoreHandle — delete()
-# ---------------------------------------------------------------------------
-
-
 class TestHandleDelete:
     @pytest.fixture
     def handle(self, mock_client, mock_collection):
         return WeaviateVectorStoreHandle(mock_client, mock_collection)
 
-    def test_delete_by_ids_calls_delete_by_id(self, handle, mock_collection):
-        handle.delete(ids=["uuid-1", "uuid-2"])
-        assert mock_collection.data.delete_by_id.call_count == 2
-        mock_collection.data.delete_by_id.assert_any_call("uuid-1")
-        mock_collection.data.delete_by_id.assert_any_call("uuid-2")
+    def test_delete_by_ids_calls_delete_many_with_contains_any_filter(
+        self, handle, mock_collection
+    ):
+        with patch(f"{MODULE}.wvc.query.Filter") as mock_filter_cls:
+            mock_filter = mock_filter_cls.by_id.return_value.contains_any.return_value
+            handle.delete(ids=["uuid-1", "uuid-2"])
+            mock_filter_cls.by_id.return_value.contains_any.assert_called_once_with(
+                ["uuid-1", "uuid-2"]
+            )
+            mock_collection.data.delete_many.assert_called_once_with(where=mock_filter)
+
+    def test_delete_by_ids_batches_lists_over_10000(self, handle, mock_collection):
+        ids = [f"uuid-{i}" for i in range(10_001)]
+        with patch(f"{MODULE}.wvc.query.Filter") as mock_filter_cls:
+            handle.delete(ids=ids)
+            contains_any = mock_filter_cls.by_id.return_value.contains_any
+            assert contains_any.call_count == 2
+            assert len(contains_any.call_args_list[0].args[0]) == 10_000
+            assert len(contains_any.call_args_list[1].args[0]) == 1
+            assert mock_collection.data.delete_many.call_count == 2
+
+    def test_delete_by_ids_empty_list_is_noop(self, handle, mock_collection):
+        handle.delete(ids=[])
+        mock_collection.data.delete_many.assert_not_called()
 
     def test_delete_by_filter_calls_delete_many(self, handle, mock_collection):
         f = MagicMock()
@@ -422,7 +401,7 @@ class TestHandleDelete:
             handle.delete(ids=["x"], filters=MagicMock())
 
     def test_delete_wraps_weaviate_exception_on_ids(self, handle, mock_collection):
-        mock_collection.data.delete_by_id.side_effect = RuntimeError("connection lost")
+        mock_collection.data.delete_many.side_effect = RuntimeError("connection lost")
         with pytest.raises(DatasetError, match="delete\\(\\) failed"):
             handle.delete(ids=["uuid-1"])
 
@@ -430,11 +409,6 @@ class TestHandleDelete:
         mock_collection.data.delete_many.side_effect = RuntimeError("invalid filter")
         with pytest.raises(DatasetError, match="delete\\(\\) failed"):
             handle.delete(filters=MagicMock())
-
-
-# ---------------------------------------------------------------------------
-# WeaviateVectorStoreHandle — search()
-# ---------------------------------------------------------------------------
 
 
 class TestHandleSearch:

--- a/kedro-datasets/kedro_datasets_experimental/tests/weaviate/test_weaviate_vector_store_dataset.py
+++ b/kedro-datasets/kedro_datasets_experimental/tests/weaviate/test_weaviate_vector_store_dataset.py
@@ -12,6 +12,7 @@ import pytest
 from kedro.io.core import DatasetError
 
 from kedro_datasets_experimental.weaviate.weaviate_vector_store_dataset import (
+    _DELETE_BY_ID_BATCH_SIZE,
     WeaviateVectorStoreDataset,
     WeaviateVectorStoreHandle,
 )
@@ -92,6 +93,7 @@ class TestDescribe:
             "connection_type": "local",
             "url": None,
             "create_collection_if_missing": True,
+            "delete_batch_size": _DELETE_BY_ID_BATCH_SIZE,
         }
 
     def test_cloud_describe(self, cloud_dataset):
@@ -103,6 +105,12 @@ class TestDescribe:
         desc = cloud_dataset._describe()
         assert "credentials" not in desc
         assert "api_key" not in str(desc)
+
+    def test_describe_reflects_non_default_delete_batch_size(self):
+        ds = WeaviateVectorStoreDataset(
+            collection_name="MyCollection", delete_batch_size=500
+        )
+        assert ds._describe()["delete_batch_size"] == 500
 
 
 class TestSaveDisabled:
@@ -388,9 +396,29 @@ class TestHandleDelete:
         mock_collection.data.delete_many.assert_not_called()
 
     def test_delete_by_filter_calls_delete_many(self, handle, mock_collection):
+        mock_result = MagicMock()
+        mock_result.matches = 0
+        mock_collection.data.delete_many.return_value = mock_result
         f = MagicMock()
         handle.delete(filters=f)
         mock_collection.data.delete_many.assert_called_once_with(where=f)
+
+    def test_delete_by_filter_reruns_until_no_matches(self, handle, mock_collection):
+        first_result = MagicMock()
+        first_result.matches = 5
+        second_result = MagicMock()
+        second_result.matches = 0
+        mock_collection.data.delete_many.side_effect = [first_result, second_result]
+        f = MagicMock()
+        handle.delete(filters=f)
+        assert mock_collection.data.delete_many.call_count == 2
+
+    def test_delete_by_filter_raises_after_max_iterations(self, handle, mock_collection):
+        result = MagicMock()
+        result.matches = 1
+        mock_collection.data.delete_many.return_value = result
+        with pytest.raises(DatasetError, match="still matched objects"):
+            handle.delete(filters=MagicMock())
 
     def test_delete_requires_ids_or_filters(self, handle):
         with pytest.raises(DatasetError, match="requires exactly one"):

--- a/kedro-datasets/kedro_datasets_experimental/tests/weaviate/test_weaviate_vector_store_dataset.py
+++ b/kedro-datasets/kedro_datasets_experimental/tests/weaviate/test_weaviate_vector_store_dataset.py
@@ -5,7 +5,7 @@ All tests use mocks — no real Weaviate connection is required.
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from kedro.io.core import DatasetError
@@ -188,6 +188,13 @@ class TestConnect:
             collection_name="C", connection_type="cloud"
         )
         with pytest.raises(DatasetError, match="'url' is required"):
+            ds._connect()
+
+    def test_unknown_connection_type_raises(self):
+        ds = WeaviateVectorStoreDataset(
+            collection_name="C", connection_type="grpc"  # type: ignore[arg-type]
+        )
+        with pytest.raises(DatasetError, match="Unknown connection_type"):
             ds._connect()
 
     def test_custom_params_forwarded(self, mock_client):

--- a/kedro-datasets/kedro_datasets_experimental/tests/weaviate/test_weaviate_vector_store_dataset.py
+++ b/kedro-datasets/kedro_datasets_experimental/tests/weaviate/test_weaviate_vector_store_dataset.py
@@ -1,0 +1,305 @@
+"""Tests for WeaviateVectorStoreDataset and WeaviateVectorStoreHandle (ST2).
+
+All tests use mocks — no real Weaviate connection is required.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+from kedro.io.core import DatasetError
+
+from kedro_datasets_experimental.weaviate.weaviate_vector_store_dataset import (
+    WeaviateVectorStoreDataset,
+    WeaviateVectorStoreHandle,
+)
+
+MODULE = "kedro_datasets_experimental.weaviate.weaviate_vector_store_dataset"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_client():
+    client = MagicMock()
+    client.collections.get_or_create.return_value = MagicMock(name="MyCollection")
+    client.collections.get.return_value = MagicMock(name="MyCollection")
+    return client
+
+
+@pytest.fixture
+def mock_collection(mock_client):
+    collection = mock_client.collections.get_or_create.return_value
+    collection.name = "MyCollection"
+    agg_result = MagicMock()
+    agg_result.total_count = 42
+    collection.aggregate.over_all.return_value = agg_result
+    return collection
+
+
+@pytest.fixture
+def local_dataset():
+    return WeaviateVectorStoreDataset(collection_name="MyCollection")
+
+
+@pytest.fixture
+def cloud_dataset():
+    return WeaviateVectorStoreDataset(
+        collection_name="MyCollection",
+        connection_type="cloud",
+        url="https://my-cluster.weaviate.network",
+        credentials={"api_key": "secret"},
+    )
+
+
+# ---------------------------------------------------------------------------
+# WeaviateVectorStoreDataset — init and describe
+# ---------------------------------------------------------------------------
+
+
+class TestDatasetInit:
+    def test_defaults(self, local_dataset):
+        assert local_dataset._collection_name == "MyCollection"
+        assert local_dataset._connection_type == "local"
+        assert local_dataset._url is None
+        assert local_dataset._connection_params == {}
+        assert local_dataset._credentials == {}
+        assert local_dataset._create_collection_if_missing is True
+        assert local_dataset.metadata is None
+
+    def test_cloud_params(self, cloud_dataset):
+        assert cloud_dataset._connection_type == "cloud"
+        assert cloud_dataset._url == "https://my-cluster.weaviate.network"
+        assert cloud_dataset._credentials == {"api_key": "secret"}
+
+    def test_none_dicts_become_empty(self):
+        ds = WeaviateVectorStoreDataset(
+            collection_name="X",
+            connection_params=None,
+            credentials=None,
+        )
+        assert ds._connection_params == {}
+        assert ds._credentials == {}
+
+    def test_metadata_stored(self):
+        ds = WeaviateVectorStoreDataset(
+            collection_name="X", metadata={"owner": "team-a"}
+        )
+        assert ds.metadata == {"owner": "team-a"}
+
+
+class TestDescribe:
+    def test_local_describe(self, local_dataset):
+        desc = local_dataset._describe()
+        assert desc == {
+            "collection_name": "MyCollection",
+            "connection_type": "local",
+            "url": None,
+            "create_collection_if_missing": True,
+        }
+
+    def test_cloud_describe(self, cloud_dataset):
+        desc = cloud_dataset._describe()
+        assert desc["connection_type"] == "cloud"
+        assert desc["url"] == "https://my-cluster.weaviate.network"
+
+    def test_describe_omits_credentials(self, cloud_dataset):
+        desc = cloud_dataset._describe()
+        assert "credentials" not in desc
+        assert "api_key" not in str(desc)
+
+
+# ---------------------------------------------------------------------------
+# WeaviateVectorStoreDataset — save() disabled
+# ---------------------------------------------------------------------------
+
+
+class TestSaveDisabled:
+    def test_save_raises(self, local_dataset):
+        with pytest.raises(DatasetError, match="Saving is not supported"):
+            local_dataset.save({"data": "value"})
+
+
+# ---------------------------------------------------------------------------
+# WeaviateVectorStoreDataset — _connect
+# ---------------------------------------------------------------------------
+
+
+class TestConnect:
+    def test_local_default_host(self, mock_client):
+        with patch(f"{MODULE}.weaviate.connect_to_local", return_value=mock_client) as p:
+            ds = WeaviateVectorStoreDataset(collection_name="C")
+            ds._connect()
+            p.assert_called_once_with(host="localhost")
+
+    def test_local_custom_host(self, mock_client):
+        with patch(f"{MODULE}.weaviate.connect_to_local", return_value=mock_client) as p:
+            ds = WeaviateVectorStoreDataset(collection_name="C", url="myhost")
+            ds._connect()
+            p.assert_called_once_with(host="myhost")
+
+    def test_local_extra_params_forwarded(self, mock_client):
+        with patch(f"{MODULE}.weaviate.connect_to_local", return_value=mock_client) as p:
+            ds = WeaviateVectorStoreDataset(
+                collection_name="C",
+                connection_params={"port": 9090, "grpc_port": 50052},
+            )
+            ds._connect()
+            p.assert_called_once_with(host="localhost", port=9090, grpc_port=50052)
+
+    def test_cloud_with_api_key(self, mock_client):
+        mock_auth = MagicMock()
+        with (
+            patch(f"{MODULE}.weaviate.connect_to_weaviate_cloud", return_value=mock_client) as p,
+            patch(f"{MODULE}.wvc.init.Auth.api_key", return_value=mock_auth) as auth_p,
+        ):
+            ds = WeaviateVectorStoreDataset(
+                collection_name="C",
+                connection_type="cloud",
+                url="https://cluster.weaviate.network",
+                credentials={"api_key": "mykey"},
+            )
+            ds._connect()
+            auth_p.assert_called_once_with("mykey")
+            p.assert_called_once_with(
+                cluster_url="https://cluster.weaviate.network",
+                auth_credentials=mock_auth,
+            )
+
+    def test_cloud_without_api_key(self, mock_client):
+        with patch(f"{MODULE}.weaviate.connect_to_weaviate_cloud", return_value=mock_client) as p:
+            ds = WeaviateVectorStoreDataset(
+                collection_name="C",
+                connection_type="cloud",
+                url="https://cluster.weaviate.network",
+            )
+            ds._connect()
+            p.assert_called_once_with(
+                cluster_url="https://cluster.weaviate.network",
+                auth_credentials=None,
+            )
+
+    def test_cloud_missing_url_raises(self):
+        ds = WeaviateVectorStoreDataset(
+            collection_name="C", connection_type="cloud"
+        )
+        with pytest.raises(DatasetError, match="'url' is required"):
+            ds._connect()
+
+    def test_custom_params_forwarded(self, mock_client):
+        params = {
+            "http_host": "h",
+            "http_port": 80,
+            "http_secure": False,
+            "grpc_host": "h",
+            "grpc_port": 50051,
+            "grpc_secure": False,
+        }
+        with patch(f"{MODULE}.weaviate.connect_to_custom", return_value=mock_client) as p:
+            ds = WeaviateVectorStoreDataset(
+                collection_name="C",
+                connection_type="custom",
+                connection_params=params,
+            )
+            ds._connect()
+            p.assert_called_once_with(**params)
+
+    def test_connection_error_wrapped(self):
+        with patch(
+            f"{MODULE}.weaviate.connect_to_local",
+            side_effect=RuntimeError("timeout"),
+        ):
+            ds = WeaviateVectorStoreDataset(collection_name="C")
+            with pytest.raises(DatasetError, match="Failed to connect to Weaviate"):
+                ds._connect()
+
+
+# ---------------------------------------------------------------------------
+# WeaviateVectorStoreDataset — _load
+# ---------------------------------------------------------------------------
+
+
+class TestLoad:
+    def test_load_returns_handle(self, mock_client, mock_collection):
+        with patch(f"{MODULE}.weaviate.connect_to_local", return_value=mock_client):
+            ds = WeaviateVectorStoreDataset(collection_name="MyCollection")
+            handle = ds._load()
+            assert isinstance(handle, WeaviateVectorStoreHandle)
+            mock_client.collections.get_or_create.assert_called_once_with("MyCollection")
+
+    def test_load_get_only_when_no_create(self, mock_client):
+        with patch(f"{MODULE}.weaviate.connect_to_local", return_value=mock_client):
+            ds = WeaviateVectorStoreDataset(
+                collection_name="MyCollection",
+                create_collection_if_missing=False,
+            )
+            ds._load()
+            mock_client.collections.get.assert_called_once_with("MyCollection")
+            mock_client.collections.get_or_create.assert_not_called()
+
+    def test_collection_error_closes_client_and_raises(self, mock_client):
+        mock_client.collections.get_or_create.side_effect = RuntimeError("not found")
+        with patch(f"{MODULE}.weaviate.connect_to_local", return_value=mock_client):
+            ds = WeaviateVectorStoreDataset(collection_name="Missing")
+            with pytest.raises(DatasetError, match="Failed to access Weaviate collection"):
+                ds._load()
+            mock_client.close.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# WeaviateVectorStoreHandle — lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestHandle:
+    @pytest.fixture
+    def handle(self, mock_client, mock_collection):
+        return WeaviateVectorStoreHandle(mock_client, mock_collection)
+
+    def test_raw_client_returns_client(self, handle, mock_client):
+        assert handle.raw_client is mock_client
+
+    def test_close_calls_client_close(self, handle, mock_client):
+        handle.close()
+        mock_client.close.assert_called_once()
+
+    def test_close_is_idempotent(self, handle, mock_client):
+        handle.close()
+        handle.close()
+        mock_client.close.assert_called_once()
+
+    def test_context_manager_closes_on_exit(self, handle, mock_client):
+        with handle:
+            pass
+        mock_client.close.assert_called_once()
+
+    def test_context_manager_closes_on_exception(self, handle, mock_client):
+        with pytest.raises(ValueError):
+            with handle:
+                raise ValueError("boom")
+        mock_client.close.assert_called_once()
+
+    def test_context_manager_returns_self(self, handle):
+        with handle as h:
+            assert h is handle
+
+    def test_describe_returns_name_and_count(self, handle, mock_collection):
+        result = handle.describe()
+        assert result == {"collection": "MyCollection", "count": 42}
+        mock_collection.aggregate.over_all.assert_called_once_with(total_count=True)
+
+    def test_add_raises_not_implemented(self, handle):
+        with pytest.raises(NotImplementedError, match="ST3"):
+            handle.add([])
+
+    def test_delete_raises_not_implemented(self, handle):
+        with pytest.raises(NotImplementedError, match="ST3"):
+            handle.delete(ids=["a"])
+
+    def test_search_raises_not_implemented(self, handle):
+        with pytest.raises(NotImplementedError, match="ST4"):
+            handle.search(vector=[0.1, 0.2])

--- a/kedro-datasets/kedro_datasets_experimental/tests/weaviate/test_weaviate_vector_store_dataset.py
+++ b/kedro-datasets/kedro_datasets_experimental/tests/weaviate/test_weaviate_vector_store_dataset.py
@@ -368,6 +368,24 @@ class TestHandleAdd:
         with pytest.raises(DatasetError, match="add\\(\\) failed for 1 record"):
             handle.add([{"vector": [0.1], "text": "bad"}])
 
+    def test_add_wraps_weaviate_exception(self, handle, mock_collection):
+        mock_collection.data.insert_many.side_effect = RuntimeError("gRPC timeout")
+        with pytest.raises(DatasetError, match="add\\(\\) failed"):
+            handle.add([{"vector": [0.1], "text": "x"}])
+
+    def test_add_empty_list_returns_empty(self, handle, mock_collection):
+        result = MagicMock()
+        result.uuids = {}
+        result.errors = {}
+        mock_collection.data.insert_many.return_value = result
+        assert handle.add([]) == []
+
+    def test_add_does_not_mutate_input(self, handle, mock_collection, insert_result):
+        mock_collection.data.insert_many.return_value = insert_result
+        original = {"vector": [0.1], "id": "u1", "text": "hello"}
+        handle.add([original])
+        assert original == {"vector": [0.1], "id": "u1", "text": "hello"}
+
 
 # ---------------------------------------------------------------------------
 # WeaviateVectorStoreHandle — delete()
@@ -397,6 +415,16 @@ class TestHandleDelete:
     def test_delete_rejects_both(self, handle):
         with pytest.raises(DatasetError, match="not both"):
             handle.delete(ids=["x"], filters=MagicMock())
+
+    def test_delete_wraps_weaviate_exception_on_ids(self, handle, mock_collection):
+        mock_collection.data.delete_by_id.side_effect = RuntimeError("connection lost")
+        with pytest.raises(DatasetError, match="delete\\(\\) failed"):
+            handle.delete(ids=["uuid-1"])
+
+    def test_delete_wraps_weaviate_exception_on_filter(self, handle, mock_collection):
+        mock_collection.data.delete_many.side_effect = RuntimeError("invalid filter")
+        with pytest.raises(DatasetError, match="delete\\(\\) failed"):
+            handle.delete(filters=MagicMock())
 
 
 # ---------------------------------------------------------------------------
@@ -464,3 +492,22 @@ class TestHandleSearch:
     def test_search_rejects_both(self, handle):
         with pytest.raises(DatasetError, match="not both"):
             handle.search(vector=[0.1], text="query")
+
+    def test_search_wraps_weaviate_exception(self, handle, mock_collection):
+        mock_collection.query.near_vector.side_effect = RuntimeError("gRPC error")
+        with pytest.raises(DatasetError, match="search\\(\\) failed"):
+            handle.search(vector=[0.1])
+
+    def test_search_id_and_distance_override_same_named_properties(
+        self, handle, mock_collection
+    ):
+        obj = MagicMock()
+        obj.uuid = uuid.UUID("aaaaaaaa-0000-0000-0000-000000000001")
+        obj.properties = {"text": "x", "distance": 999.0}
+        obj.metadata.distance = 0.42
+        result = MagicMock()
+        result.objects = [obj]
+        mock_collection.query.near_vector.return_value = result
+        results = handle.search(vector=[0.1])
+        assert results[0]["distance"] == 0.42
+        assert results[0]["id"] == "aaaaaaaa-0000-0000-0000-000000000001"

--- a/kedro-datasets/kedro_datasets_experimental/weaviate/__init__.py
+++ b/kedro-datasets/kedro_datasets_experimental/weaviate/__init__.py
@@ -1,0 +1,16 @@
+"""``WeaviateVectorStoreDataset`` connects to a Weaviate collection as a vector store."""
+
+from typing import Any
+
+import lazy_loader as lazy
+
+try:
+    from .weaviate_vector_store_dataset import WeaviateVectorStoreDataset
+except (ImportError, RuntimeError):
+    # https://github.com/pylint-dev/pylint/issues/4300#issuecomment-1043601901
+    WeaviateVectorStoreDataset: Any
+
+__getattr__, __dir__, __all__ = lazy.attach(
+    __name__,
+    submod_attrs={"weaviate_vector_store_dataset": ["WeaviateVectorStoreDataset"]},
+)

--- a/kedro-datasets/kedro_datasets_experimental/weaviate/weaviate_vector_store_dataset.py
+++ b/kedro-datasets/kedro_datasets_experimental/weaviate/weaviate_vector_store_dataset.py
@@ -59,7 +59,41 @@ class WeaviateVectorStoreHandle(VectorStoreHandle):
     # --- write path (ST3) ---
 
     def add(self, records: list[dict[str, Any]]) -> list[str]:
-        raise NotImplementedError("add() will be implemented in ST3.")  # pragma: no cover
+        """Insert records into the collection and return their UUIDs.
+
+        Each record is a plain dict.  Two keys are reserved:
+
+        - ``"vector"`` — the embedding (required, ``list[float]``).
+        - ``"id"`` — an optional UUID string; Weaviate auto-generates one if absent.
+
+        All remaining keys are stored as Weaviate object properties.
+
+        Args:
+            records: Records to insert.
+
+        Returns:
+            List of UUID strings for the inserted objects, in the same order
+            as the input records.
+
+        Raises:
+            DatasetError: If any record fails to insert.
+        """
+        from weaviate.classes.data import DataObject
+
+        objects = []
+        for record in records:
+            record = record.copy()
+            vector = record.pop("vector", None)
+            uuid = record.pop("id", None)
+            objects.append(DataObject(properties=record, uuid=uuid, vector=vector))
+
+        result = self._collection.data.insert_many(objects)
+        if result.errors:
+            raise DatasetError(
+                f"add() failed for {len(result.errors)} record(s): "
+                + ", ".join(f"index {i}: {e}" for i, e in result.errors.items())
+            )
+        return [str(uid) for uid in result.uuids.values()]
 
     def delete(
         self,
@@ -67,7 +101,29 @@ class WeaviateVectorStoreHandle(VectorStoreHandle):
         ids: list[str] | None = None,
         filters: Any = None,
     ) -> None:
-        raise NotImplementedError("delete() will be implemented in ST3.")  # pragma: no cover
+        """Delete objects from the collection by ID or filter.
+
+        Exactly one of ``ids`` or ``filters`` must be provided.
+
+        Args:
+            ids: List of UUID strings to delete individually.
+            filters: A ``weaviate.classes.query.Filter`` expression that
+                selects objects to delete (passed directly to
+                ``collection.data.delete_many(where=filters)``).
+
+        Raises:
+            DatasetError: If neither or both arguments are supplied.
+        """
+        if ids is None and filters is None:
+            raise DatasetError("delete() requires exactly one of 'ids' or 'filters'.")
+        if ids is not None and filters is not None:
+            raise DatasetError("delete() accepts 'ids' or 'filters', not both.")
+
+        if ids is not None:
+            for uid in ids:
+                self._collection.data.delete_by_id(uid)
+        else:
+            self._collection.data.delete_many(where=filters)
 
     # --- read path (ST4) ---
 

--- a/kedro-datasets/kedro_datasets_experimental/weaviate/weaviate_vector_store_dataset.py
+++ b/kedro-datasets/kedro_datasets_experimental/weaviate/weaviate_vector_store_dataset.py
@@ -7,6 +7,7 @@ from typing import Any, Literal
 import weaviate
 import weaviate.classes as wvc
 from kedro.io.core import DatasetError
+from weaviate.classes.data import DataObject
 
 from kedro_datasets_experimental.vectorstore_base import (
     AbstractVectorStoreDataset,
@@ -78,14 +79,12 @@ class WeaviateVectorStoreHandle(VectorStoreHandle):
         Raises:
             DatasetError: If any record fails to insert.
         """
-        from weaviate.classes.data import DataObject
-
         objects = []
         for record in records:
-            record = record.copy()
-            vector = record.pop("vector", None)
-            uuid = record.pop("id", None)
-            objects.append(DataObject(properties=record, uuid=uuid, vector=vector))
+            props = record.copy()
+            vector = props.pop("vector", None)
+            uid = props.pop("id", None)
+            objects.append(DataObject(properties=props, uuid=uid, vector=vector))
 
         result = self._collection.data.insert_many(objects)
         if result.errors:

--- a/kedro-datasets/kedro_datasets_experimental/weaviate/weaviate_vector_store_dataset.py
+++ b/kedro-datasets/kedro_datasets_experimental/weaviate/weaviate_vector_store_dataset.py
@@ -78,7 +78,8 @@ class WeaviateVectorStoreHandle(VectorStoreHandle):
             as the input records.
 
         Raises:
-            DatasetError: If any record fails to insert.
+            DatasetError: If the batch insert call fails, or if Weaviate
+                returns errors for one or more objects.
         """
         objects = []
         for record in records:
@@ -116,7 +117,8 @@ class WeaviateVectorStoreHandle(VectorStoreHandle):
                 ``collection.data.delete_many(where=filters)``).
 
         Raises:
-            DatasetError: If neither or both arguments are supplied.
+            DatasetError: If neither or both arguments are supplied, or if
+                the deletion call to Weaviate fails.
         """
         if ids is None and filters is None:
             raise DatasetError("delete() requires exactly one of 'ids' or 'filters'.")
@@ -160,7 +162,8 @@ class WeaviateVectorStoreHandle(VectorStoreHandle):
             plus ``"id"`` (UUID string) and ``"distance"`` (float).
 
         Raises:
-            DatasetError: If neither or both of ``vector``/``text`` are supplied.
+            DatasetError: If neither or both of ``vector``/``text`` are
+                supplied, or if the query call to Weaviate fails.
         """
         if vector is None and text is None:
             raise DatasetError("search() requires exactly one of 'vector' or 'text'.")
@@ -199,7 +202,7 @@ class WeaviateVectorStoreDataset(AbstractVectorStoreDataset):
         with catalog.load("my_store") as store:
             store.describe()
 
-    Three connection modes are supported, selected via ``connection_type``:
+    Three connection modes are supported, selected with ``connection_type``:
 
     - ``"local"`` (default) — connects to a locally running Weaviate instance.
     - ``"cloud"`` — connects to Weaviate Cloud; requires ``url`` (cluster URL)
@@ -281,7 +284,7 @@ class WeaviateVectorStoreDataset(AbstractVectorStoreDataset):
                 ``"local"``: optional overrides such as ``port`` or
                 ``grpc_port``.  For ``"custom"``: all required networking
                 parameters (``http_host``, ``http_port``, ``grpc_host``, etc.).
-            credentials: Sensitive connection values, typically supplied via
+            credentials: Sensitive connection values, typically supplied through
                 Kedro's credentials store.  Recognised key: ``"api_key"``
                 (used for ``"cloud"`` connections).
             create_collection_if_missing: When ``True`` (default), the

--- a/kedro-datasets/kedro_datasets_experimental/weaviate/weaviate_vector_store_dataset.py
+++ b/kedro-datasets/kedro_datasets_experimental/weaviate/weaviate_vector_store_dataset.py
@@ -231,7 +231,10 @@ class WeaviateVectorStoreDataset(AbstractVectorStoreDataset):
         client = self._connect()
         try:
             if self._create_collection_if_missing:
-                collection = client.collections.get_or_create(self._collection_name)
+                if client.collections.exists(self._collection_name):
+                    collection = client.collections.get(self._collection_name)
+                else:
+                    collection = client.collections.create(self._collection_name)
             else:
                 collection = client.collections.get(self._collection_name)
         except Exception as e:

--- a/kedro-datasets/kedro_datasets_experimental/weaviate/weaviate_vector_store_dataset.py
+++ b/kedro-datasets/kedro_datasets_experimental/weaviate/weaviate_vector_store_dataset.py
@@ -62,13 +62,12 @@ class WeaviateVectorStoreHandle(VectorStoreHandle):
     def add(self, records: list[dict[str, Any]]) -> list[str]:
         """Insert records into the collection and return their UUIDs.
 
-        Each record is a plain dict.  Two keys are reserved:
+        Each record is a plain dict with the following keys:
 
+        - ``"properties"`` — the object's properties (``dict``).
         - ``"vector"`` — the embedding (``list[float]``); optional when the
           collection has a server-side vectorizer configured.
         - ``"id"`` — an optional UUID string; Weaviate auto-generates one if absent.
-
-        All remaining keys are stored as Weaviate object properties.
 
         Args:
             records: Records to insert.
@@ -83,9 +82,9 @@ class WeaviateVectorStoreHandle(VectorStoreHandle):
         """
         objects = []
         for record in records:
-            props = record.copy()
-            vector = props.pop("vector", None)
-            uid = props.pop("id", None)
+            props = record.get("properties", {})
+            vector = record.get("vector")
+            uid = record.get("id")
             objects.append(DataObject(properties=props, uuid=uid, vector=vector))
 
         try:
@@ -158,8 +157,9 @@ class WeaviateVectorStoreHandle(VectorStoreHandle):
                 the search scope (passed directly to the underlying query).
 
         Returns:
-            List of result dicts, each containing all stored object properties
-            plus ``"id"`` (UUID string) and ``"distance"`` (float).
+            List of result dicts, each containing ``"id"`` (UUID string),
+            ``"properties"`` (dict of stored object properties), and
+            ``"distance"`` (float).
 
         Raises:
             DatasetError: If neither or both of ``vector``/``text`` are
@@ -185,7 +185,11 @@ class WeaviateVectorStoreHandle(VectorStoreHandle):
             raise DatasetError(f"search() failed: {e}") from e
 
         return [
-            {**obj.properties, "id": str(obj.uuid), "distance": obj.metadata.distance}
+            {
+                "id": str(obj.uuid),
+                "properties": dict(obj.properties),
+                "distance": obj.metadata.distance,
+            }
             for obj in results.objects
         ]
 

--- a/kedro-datasets/kedro_datasets_experimental/weaviate/weaviate_vector_store_dataset.py
+++ b/kedro-datasets/kedro_datasets_experimental/weaviate/weaviate_vector_store_dataset.py
@@ -64,7 +64,8 @@ class WeaviateVectorStoreHandle(VectorStoreHandle):
 
         Each record is a plain dict.  Two keys are reserved:
 
-        - ``"vector"`` — the embedding (required, ``list[float]``).
+        - ``"vector"`` — the embedding (``list[float]``); optional when the
+          collection has a server-side vectorizer configured.
         - ``"id"`` — an optional UUID string; Weaviate auto-generates one if absent.
 
         All remaining keys are stored as Weaviate object properties.
@@ -86,7 +87,11 @@ class WeaviateVectorStoreHandle(VectorStoreHandle):
             uid = props.pop("id", None)
             objects.append(DataObject(properties=props, uuid=uid, vector=vector))
 
-        result = self._collection.data.insert_many(objects)
+        try:
+            result = self._collection.data.insert_many(objects)
+        except Exception as e:
+            raise DatasetError(f"add() failed: {e}") from e
+
         if result.errors:
             raise DatasetError(
                 f"add() failed for {len(result.errors)} record(s): "
@@ -118,11 +123,14 @@ class WeaviateVectorStoreHandle(VectorStoreHandle):
         if ids is not None and filters is not None:
             raise DatasetError("delete() accepts 'ids' or 'filters', not both.")
 
-        if ids is not None:
-            for uid in ids:
-                self._collection.data.delete_by_id(uid)
-        else:
-            self._collection.data.delete_many(where=filters)
+        try:
+            if ids is not None:
+                for uid in ids:
+                    self._collection.data.delete_by_id(uid)
+            else:
+                self._collection.data.delete_many(where=filters)
+        except Exception as e:
+            raise DatasetError(f"delete() failed: {e}") from e
 
     # --- read path (ST4) ---
 
@@ -165,13 +173,16 @@ class WeaviateVectorStoreHandle(VectorStoreHandle):
             return_metadata=wvc.query.MetadataQuery(distance=True),
         )
 
-        if vector is not None:
-            results = self._collection.query.near_vector(near_vector=vector, **common_kwargs)
-        else:
-            results = self._collection.query.near_text(query=text, **common_kwargs)
+        try:
+            if vector is not None:
+                results = self._collection.query.near_vector(near_vector=vector, **common_kwargs)
+            else:
+                results = self._collection.query.near_text(query=text, **common_kwargs)
+        except Exception as e:
+            raise DatasetError(f"search() failed: {e}") from e
 
         return [
-            {"id": str(obj.uuid), "distance": obj.metadata.distance, **obj.properties}
+            {**obj.properties, "id": str(obj.uuid), "distance": obj.metadata.distance}
             for obj in results.objects
         ]
 

--- a/kedro-datasets/kedro_datasets_experimental/weaviate/weaviate_vector_store_dataset.py
+++ b/kedro-datasets/kedro_datasets_experimental/weaviate/weaviate_vector_store_dataset.py
@@ -498,4 +498,5 @@ class WeaviateVectorStoreDataset(AbstractVectorStoreDataset):
             "connection_type": self._connection_type,
             "url": self._url,
             "create_collection_if_missing": self._create_collection_if_missing,
+            "delete_batch_size": self._delete_batch_size,
         }

--- a/kedro-datasets/kedro_datasets_experimental/weaviate/weaviate_vector_store_dataset.py
+++ b/kedro-datasets/kedro_datasets_experimental/weaviate/weaviate_vector_store_dataset.py
@@ -152,7 +152,7 @@ class WeaviateVectorStoreDataset(AbstractVectorStoreDataset):
         ...     print(store.describe())
     """
 
-    def __init__(
+    def __init__(  # noqa: PLR0913
         self,
         *,
         collection_name: str,

--- a/kedro-datasets/kedro_datasets_experimental/weaviate/weaviate_vector_store_dataset.py
+++ b/kedro-datasets/kedro_datasets_experimental/weaviate/weaviate_vector_store_dataset.py
@@ -25,8 +25,58 @@ class WeaviateVectorStoreHandle(VectorStoreHandle):
         with catalog.load("my_store") as store:
             store.describe()
 
+    This applies in every case, including when the handle is loaded as a
+    node input in a ``kedro run`` pipeline rather than through a hand-built
+    catalog as above. Kedro never closes it for you, and there's no way to
+    make it do so implicitly.
+
+    The Weaviate client opens a persistent HTTP connection pool and gRPC
+    channel on ``connect()``. This lets repeated ``add()``/``search()``/
+    ``delete()`` calls skip the TCP handshake, TLS negotiation, and version
+    handshake each time. Only ``close()`` tears both down.
+
+    Kedro's own cleanup hook, ``catalog.release()``, operates on the
+    *dataset* object registered in the catalog, not on the *handle* object
+    that ``load()`` returns and that a node function receives. The dataset
+    doesn't keep a reference to the handles it hands out, so there's
+    nothing for ``release()`` to close even when it does run.
+
+    This dataset is atypical in that respect. Unlike a CSV or JSON
+    dataset, where ``load()`` returns inert data, this ``load()`` returns
+    a value that stays tethered to a live external connection.
+
+    If you receive this handle as a node input, close it — or wrap the
+    node body in a ``with`` block — inside that node function. That's the
+    only place with an unambiguous view of when the connection is
+    actually done being used.
+
     The ``raw_client`` property exposes the underlying ``weaviate.WeaviateClient``
     for operations outside this interface.
+
+    Examples:
+        Using a hand-built catalog, with a context manager (recommended)::
+
+            >>> with catalog.load("my_store") as store:
+            ...     store.add([{"properties": {"text": "hello"}, "vector": [0.1, 0.2]}])
+            ...     store.search(vector=[0.1, 0.2], top_k=5)
+            >>> # store.close() has already run here, even if a call above raised.
+
+        Using a hand-built catalog, without a context manager::
+
+            >>> store = catalog.load("my_store")
+            >>> try:
+            ...     store.search(vector=[0.1, 0.2], top_k=5)
+            ... finally:
+            ...     store.close()  # Must close explicitly — nothing else will.
+
+        As a node input in a ``kedro run`` pipeline: Kedro loads the handle
+        and passes it to the node, but never closes it. The node itself
+        must do so::
+
+            def search_products(store: WeaviateVectorStoreHandle, query_vector: list[float]) -> list[dict]:
+                with store:
+                    return store.search(vector=query_vector, top_k=5)
+                # Closed here on return, and also if search() raises.
     """
 
     def __init__(
@@ -211,6 +261,28 @@ class WeaviateVectorStoreDataset(AbstractVectorStoreDataset):
       ``weaviate.connect_to_custom()`` for self-hosted deployments with
       non-standard networking.
 
+    ``collection_name`` is a lookup key, not a schema definition. After
+    connecting, ``load()`` calls ``client.collections.get(collection_name)``
+    to resolve the [Weaviate collection](https://docs.weaviate.io/weaviate/manage-collections)
+    with that name on the server.
+
+    This dataset does not define or manage a collection's schema — its
+    properties, vectorizer, index config, and so on. That schema lives
+    entirely on the Weaviate side. Create it ahead of time (for example
+    through the Weaviate console, client, or REST API), or let ``load()``
+    create it automatically. When ``create_collection_if_missing=True``
+    (the default) and the collection doesn't exist, ``load()`` calls
+    ``client.collections.create(collection_name)`` with **no schema
+    arguments**. That produces an empty collection with Weaviate's default
+    auto-schema and no vectorizer configured.
+
+    That default is enough for ``add()`` with your own precomputed
+    vectors. ``search(text=...)`` needs a server-side vectorizer, and
+    custom property typing needs its own definition — both require
+    configuring the collection yourself first. See the
+    [collections docs](https://docs.weaviate.io/weaviate/manage-collections/collection-operations)
+    for how to define one.
+
     Examples:
         Using the [YAML API](https://docs.kedro.org/en/stable/catalog-data/data_catalog_yaml_examples/):
 
@@ -288,8 +360,12 @@ class WeaviateVectorStoreDataset(AbstractVectorStoreDataset):
                 Kedro's credentials store.  Recognised key: ``"api_key"``
                 (used for ``"cloud"`` connections).
             create_collection_if_missing: When ``True`` (default), the
-                collection is created if it does not already exist.  When
-                ``False``, ``load()`` raises if the collection is absent.
+                collection is created — with no explicit schema, i.e.
+                Weaviate's default auto-schema and no vectorizer — if it
+                does not already exist. When ``False``, ``load()`` raises
+                if the collection is absent. See the class docstring for
+                when you need to define the collection's schema yourself
+                instead of relying on this default.
             metadata: Arbitrary metadata passed through by Kedro; ignored by
                 this dataset.
         """

--- a/kedro-datasets/kedro_datasets_experimental/weaviate/weaviate_vector_store_dataset.py
+++ b/kedro-datasets/kedro_datasets_experimental/weaviate/weaviate_vector_store_dataset.py
@@ -22,8 +22,7 @@ class WeaviateVectorStoreHandle(VectorStoreHandle):
     ``close()`` explicitly or by using the handle as a context manager::
 
         with catalog.load("my_store") as store:
-            store.add([{"properties": {...}, "vector": [...]}])
-            hits = store.search(vector=[...], top_k=5)
+            store.describe()
 
     The ``raw_client`` property exposes the underlying ``weaviate.WeaviateClient``
     for operations outside this interface.
@@ -93,8 +92,7 @@ class WeaviateVectorStoreDataset(AbstractVectorStoreDataset):
     The handle owns the underlying gRPC connection; callers **must** close it::
 
         with catalog.load("my_store") as store:
-            store.add([{"properties": {"text": "hello"}, "vector": [0.1, 0.2]}])
-            hits = store.search(vector=[0.1, 0.2], top_k=5)
+            store.describe()
 
     Three connection modes are supported, selected via ``connection_type``:
 
@@ -211,10 +209,15 @@ class WeaviateVectorStoreDataset(AbstractVectorStoreDataset):
                 )
             elif self._connection_type == "custom":
                 return weaviate.connect_to_custom(**self._connection_params)
-            else:  # local
+            elif self._connection_type == "local":
                 return weaviate.connect_to_local(
                     host=self._url or "localhost",
                     **self._connection_params,
+                )
+            else:
+                raise DatasetError(
+                    f"Unknown connection_type: '{self._connection_type}'. "
+                    "Must be one of: 'local', 'cloud', 'custom'."
                 )
         except DatasetError:
             raise

--- a/kedro-datasets/kedro_datasets_experimental/weaviate/weaviate_vector_store_dataset.py
+++ b/kedro-datasets/kedro_datasets_experimental/weaviate/weaviate_vector_store_dataset.py
@@ -1,0 +1,247 @@
+"""``WeaviateVectorStoreDataset`` connects to a Weaviate collection as a vector store."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+import weaviate
+import weaviate.classes as wvc
+from kedro.io.core import DatasetError
+
+from kedro_datasets_experimental.vectorstore_base import (
+    AbstractVectorStoreDataset,
+    VectorStoreHandle,
+)
+
+
+class WeaviateVectorStoreHandle(VectorStoreHandle):
+    """Handle for interacting with a Weaviate collection.
+
+    Returned by ``WeaviateVectorStoreDataset.load()``. Owns the gRPC connection
+    to Weaviate; the connection must be closed after use, either by calling
+    ``close()`` explicitly or by using the handle as a context manager::
+
+        with catalog.load("my_store") as store:
+            store.add([{"properties": {...}, "vector": [...]}])
+            hits = store.search(vector=[...], top_k=5)
+
+    The ``raw_client`` property exposes the underlying ``weaviate.WeaviateClient``
+    for operations outside this interface.
+    """
+
+    def __init__(
+        self,
+        client: weaviate.WeaviateClient,
+        collection: Any,
+    ) -> None:
+        self._client = client
+        self._collection = collection
+        self._closed = False
+
+    @property
+    def raw_client(self) -> weaviate.WeaviateClient:
+        """The underlying ``weaviate.WeaviateClient`` instance."""
+        return self._client
+
+    def close(self) -> None:
+        """Close the gRPC connection. Safe to call more than once."""
+        if not self._closed:
+            self._client.close()
+            self._closed = True
+
+    def describe(self) -> dict[str, Any]:
+        """Return collection name and current record count."""
+        result = self._collection.aggregate.over_all(total_count=True)
+        return {
+            "collection": self._collection.name,
+            "count": result.total_count,
+        }
+
+    # --- write path (ST3) ---
+
+    def add(self, records: list[dict[str, Any]]) -> list[str]:
+        raise NotImplementedError("add() will be implemented in ST3.")  # pragma: no cover
+
+    def delete(
+        self,
+        *,
+        ids: list[str] | None = None,
+        filters: Any = None,
+    ) -> None:
+        raise NotImplementedError("delete() will be implemented in ST3.")  # pragma: no cover
+
+    # --- read path (ST4) ---
+
+    def search(
+        self,
+        *,
+        vector: list[float] | None = None,
+        text: str | None = None,
+        top_k: int = 10,
+        filters: Any = None,
+    ) -> list[dict[str, Any]]:
+        raise NotImplementedError("search() will be implemented in ST4.")  # pragma: no cover
+
+
+class WeaviateVectorStoreDataset(AbstractVectorStoreDataset):
+    """Connect to a Weaviate collection and return a ``WeaviateVectorStoreHandle``.
+
+    ``load()`` opens a connection to Weaviate, resolves (or creates) the target
+    collection, and returns a handle.  All read/write operations go through the
+    handle.  ``save()`` is intentionally disabled and raises ``DatasetError``.
+
+    The handle owns the underlying gRPC connection; callers **must** close it::
+
+        with catalog.load("my_store") as store:
+            store.add([{"properties": {"text": "hello"}, "vector": [0.1, 0.2]}])
+            hits = store.search(vector=[0.1, 0.2], top_k=5)
+
+    Three connection modes are supported, selected via ``connection_type``:
+
+    - ``"local"`` (default) — connects to a locally running Weaviate instance.
+    - ``"cloud"`` — connects to Weaviate Cloud; requires ``url`` (cluster URL)
+      and, typically, ``credentials: {api_key: ...}``.
+    - ``"custom"`` — passes ``connection_params`` directly to
+      ``weaviate.connect_to_custom()`` for self-hosted deployments with
+      non-standard networking.
+
+    Examples:
+        Using the [YAML API](https://docs.kedro.org/en/stable/catalog-data/data_catalog_yaml_examples/):
+
+        Local instance (default):
+
+        ```yaml
+        my_store:
+          type: weaviate.WeaviateVectorStoreDataset
+          collection_name: MyCollection
+        ```
+
+        Weaviate Cloud:
+
+        ```yaml
+        my_store:
+          type: weaviate.WeaviateVectorStoreDataset
+          collection_name: MyCollection
+          connection_type: cloud
+          url: "https://my-cluster.weaviate.network"
+          credentials:
+            api_key: "${WEAVIATE_API_KEY}"
+        ```
+
+        Self-hosted with custom networking:
+
+        ```yaml
+        my_store:
+          type: weaviate.WeaviateVectorStoreDataset
+          collection_name: MyCollection
+          connection_type: custom
+          connection_params:
+            http_host: my-host.internal
+            http_port: 8080
+            http_secure: false
+            grpc_host: my-host.internal
+            grpc_port: 50051
+            grpc_secure: false
+        ```
+
+        Using the [Python API](https://docs.kedro.org/en/stable/catalog-data/advanced_data_catalog_usage/):
+
+        >>> from kedro_datasets_experimental.weaviate import WeaviateVectorStoreDataset
+        >>> dataset = WeaviateVectorStoreDataset(collection_name="MyCollection")
+        >>> with dataset.load() as store:
+        ...     print(store.describe())
+    """
+
+    def __init__(
+        self,
+        *,
+        collection_name: str,
+        connection_type: Literal["local", "cloud", "custom"] = "local",
+        url: str | None = None,
+        connection_params: dict[str, Any] | None = None,
+        credentials: dict[str, Any] | None = None,
+        create_collection_if_missing: bool = True,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        """Create a new ``WeaviateVectorStoreDataset``.
+
+        Args:
+            collection_name: Name of the Weaviate collection to connect to.
+            connection_type: How to connect — ``"local"``, ``"cloud"``, or
+                ``"custom"``. Defaults to ``"local"``.
+            url: For ``"cloud"``: the Weaviate Cloud cluster URL (e.g.
+                ``"https://my-cluster.weaviate.network"``).
+                For ``"local"``: the host name (defaults to ``"localhost"``).
+                Ignored for ``"custom"``.
+            connection_params: Extra keyword arguments forwarded to the
+                underlying ``weaviate.connect_to_*`` function.  For
+                ``"local"``: optional overrides such as ``port`` or
+                ``grpc_port``.  For ``"custom"``: all required networking
+                parameters (``http_host``, ``http_port``, ``grpc_host``, etc.).
+            credentials: Sensitive connection values, typically supplied via
+                Kedro's credentials store.  Recognised key: ``"api_key"``
+                (used for ``"cloud"`` connections).
+            create_collection_if_missing: When ``True`` (default), the
+                collection is created if it does not already exist.  When
+                ``False``, ``load()`` raises if the collection is absent.
+            metadata: Arbitrary metadata passed through by Kedro; ignored by
+                this dataset.
+        """
+        self._collection_name = collection_name
+        self._connection_type = connection_type
+        self._url = url
+        self._connection_params = connection_params or {}
+        self._credentials = credentials or {}
+        self._create_collection_if_missing = create_collection_if_missing
+        self.metadata = metadata
+
+    def _connect(self) -> weaviate.WeaviateClient:
+        try:
+            if self._connection_type == "cloud":
+                if not self._url:
+                    raise DatasetError(
+                        "'url' is required when connection_type='cloud'."
+                    )
+                api_key = self._credentials.get("api_key")
+                auth = wvc.init.Auth.api_key(api_key) if api_key else None
+                return weaviate.connect_to_weaviate_cloud(
+                    cluster_url=self._url,
+                    auth_credentials=auth,
+                    **self._connection_params,
+                )
+            elif self._connection_type == "custom":
+                return weaviate.connect_to_custom(**self._connection_params)
+            else:  # local
+                return weaviate.connect_to_local(
+                    host=self._url or "localhost",
+                    **self._connection_params,
+                )
+        except DatasetError:
+            raise
+        except Exception as e:
+            raise DatasetError(
+                f"Failed to connect to Weaviate "
+                f"(connection_type='{self._connection_type}'): {e}"
+            ) from e
+
+    def _load(self) -> WeaviateVectorStoreHandle:
+        client = self._connect()
+        try:
+            if self._create_collection_if_missing:
+                collection = client.collections.get_or_create(self._collection_name)
+            else:
+                collection = client.collections.get(self._collection_name)
+        except Exception as e:
+            client.close()
+            raise DatasetError(
+                f"Failed to access Weaviate collection '{self._collection_name}': {e}"
+            ) from e
+        return WeaviateVectorStoreHandle(client, collection)
+
+    def _describe(self) -> dict[str, Any]:
+        return {
+            "collection_name": self._collection_name,
+            "connection_type": self._connection_type,
+            "url": self._url,
+            "create_collection_if_missing": self._create_collection_if_missing,
+        }

--- a/kedro-datasets/kedro_datasets_experimental/weaviate/weaviate_vector_store_dataset.py
+++ b/kedro-datasets/kedro_datasets_experimental/weaviate/weaviate_vector_store_dataset.py
@@ -14,6 +14,22 @@ from kedro_datasets_experimental.vectorstore_base import (
     VectorStoreHandle,
 )
 
+# Weaviate's `QUERY_MAXIMUM_RESULTS` server setting caps how many objects a
+# single query — including a batch delete — can address at once. It defaults
+# to 10,000 self-hosted or 100,000 on Weaviate Cloud, and is tunable via that
+# env var either way; the client has no way to read the value a given server
+# is actually configured with. 10,000 is a safe floor for `delete(ids=...)`'s
+# default chunk size (never above either default), overridable through
+# `delete_batch_size` for deployments configured differently.
+# https://docs.weaviate.io/weaviate/manage-objects/delete#delete-multiple-objects-by-id
+_DELETE_BY_ID_BATCH_SIZE = 10_000
+
+# Safety cap on `delete(filters=...)`'s re-run loop (see delete()) — guards
+# against spinning forever if a filter's match count never reaches zero,
+# rather than limiting how much a single delete() call can legitimately
+# remove.
+_DELETE_BY_FILTER_MAX_ITERATIONS = 1000
+
 
 class WeaviateVectorStoreHandle(VectorStoreHandle):
     """Handle for interacting with a Weaviate collection.
@@ -83,10 +99,12 @@ class WeaviateVectorStoreHandle(VectorStoreHandle):
         self,
         client: weaviate.WeaviateClient,
         collection: Any,
+        delete_batch_size: int = _DELETE_BY_ID_BATCH_SIZE,
     ) -> None:
         self._client = client
         self._collection = collection
         self._closed = False
+        self._delete_batch_size = delete_batch_size
 
     @property
     def raw_client(self) -> weaviate.WeaviateClient:
@@ -157,15 +175,31 @@ class WeaviateVectorStoreHandle(VectorStoreHandle):
 
         Exactly one of ``ids`` or ``filters`` must be provided.
 
+        Weaviate's server-side ``QUERY_MAXIMUM_RESULTS`` setting caps how
+        many objects a single batch delete can address (10,000 self-hosted
+        or 100,000 on Weaviate Cloud, by default). Both branches below
+        account for it, since a single call isn't guaranteed to remove
+        everything a large ``ids`` list or a broadly-matching filter
+        targets:
+
+        - ``ids`` is split into chunks of ``delete_batch_size`` (set on the
+          handle at construction time; defaults to 10,000), each deleted
+          with its own ``collection.data.delete_many(where=Filter.by_id().contains_any(...))``
+          call, rather than one round trip per ID.
+        - ``filters`` is re-run with ``collection.data.delete_many(where=filters)``
+          until it reports no more matches, since one call only deletes up
+          to the server's limit even if more objects match.
+
         Args:
-            ids: List of UUID strings to delete individually.
+            ids: List of UUID strings to delete.
             filters: A ``weaviate.classes.query.Filter`` expression that
-                selects objects to delete (passed directly to
-                ``collection.data.delete_many(where=filters)``).
+                selects objects to delete.
 
         Raises:
-            DatasetError: If neither or both arguments are supplied, or if
-                the deletion call to Weaviate fails.
+            DatasetError: If neither or both arguments are supplied, if the
+                deletion call to Weaviate fails, or if a ``filters`` delete
+                still reports matches after
+                ``_DELETE_BY_FILTER_MAX_ITERATIONS`` re-runs.
         """
         if ids is None and filters is None:
             raise DatasetError("delete() requires exactly one of 'ids' or 'filters'.")
@@ -174,10 +208,25 @@ class WeaviateVectorStoreHandle(VectorStoreHandle):
 
         try:
             if ids is not None:
-                for uid in ids:
-                    self._collection.data.delete_by_id(uid)
+                for i in range(0, len(ids), self._delete_batch_size):
+                    batch = ids[i : i + self._delete_batch_size]
+                    self._collection.data.delete_many(
+                        where=wvc.query.Filter.by_id().contains_any(batch)
+                    )
             else:
-                self._collection.data.delete_many(where=filters)
+                for _ in range(_DELETE_BY_FILTER_MAX_ITERATIONS):
+                    result = self._collection.data.delete_many(where=filters)
+                    if result.matches == 0:
+                        break
+                else:
+                    raise DatasetError(
+                        f"delete(filters=...) still matched objects after "
+                        f"{_DELETE_BY_FILTER_MAX_ITERATIONS} re-runs — the "
+                        "filter may be matching a non-terminating or "
+                        "unexpectedly large set of objects."
+                    )
+        except DatasetError:
+            raise
         except Exception as e:
             raise DatasetError(f"delete() failed: {e}") from e
 
@@ -199,6 +248,10 @@ class WeaviateVectorStoreHandle(VectorStoreHandle):
             vector: Query embedding for similarity search.
             text: Query string for near-text search.
             top_k: Maximum number of results to return. Defaults to 10.
+                Capped by Weaviate's server-side ``QUERY_MAXIMUM_RESULTS``
+                setting (10,000 self-hosted or 100,000 on Weaviate Cloud, by
+                default); a ``top_k`` above that raises ``DatasetError``
+                rather than paginating.
             filters: A ``weaviate.classes.query.Filter`` expression to restrict
                 the search scope (passed directly to the underlying query).
 
@@ -339,6 +392,7 @@ class WeaviateVectorStoreDataset(AbstractVectorStoreDataset):
         connection_params: dict[str, Any] | None = None,
         credentials: dict[str, Any] | None = None,
         create_collection_if_missing: bool = True,
+        delete_batch_size: int = _DELETE_BY_ID_BATCH_SIZE,
         metadata: dict[str, Any] | None = None,
     ) -> None:
         """Create a new ``WeaviateVectorStoreDataset``.
@@ -366,6 +420,13 @@ class WeaviateVectorStoreDataset(AbstractVectorStoreDataset):
                 if the collection is absent. See the class docstring for
                 when you need to define the collection's schema yourself
                 instead of relying on this default.
+            delete_batch_size: Maximum number of IDs sent to Weaviate per
+                call in ``handle.delete(ids=...)``. Defaults to ``10,000``,
+                matching Weaviate's self-hosted default
+                ``QUERY_MAXIMUM_RESULTS``. Raise this (e.g. to ``100,000``)
+                for a Weaviate Cloud deployment, or lower it if your
+                deployment has ``QUERY_MAXIMUM_RESULTS`` configured below
+                the default — see ``WeaviateVectorStoreHandle.delete()``.
             metadata: Arbitrary metadata passed through by Kedro; ignored by
                 this dataset.
         """
@@ -375,6 +436,7 @@ class WeaviateVectorStoreDataset(AbstractVectorStoreDataset):
         self._connection_params = connection_params or {}
         self._credentials = credentials or {}
         self._create_collection_if_missing = create_collection_if_missing
+        self._delete_batch_size = delete_batch_size
         self.metadata = metadata
 
     def _connect(self) -> weaviate.WeaviateClient:
@@ -426,7 +488,9 @@ class WeaviateVectorStoreDataset(AbstractVectorStoreDataset):
             raise DatasetError(
                 f"Failed to access Weaviate collection '{self._collection_name}': {e}"
             ) from e
-        return WeaviateVectorStoreHandle(client, collection)
+        return WeaviateVectorStoreHandle(
+            client, collection, delete_batch_size=self._delete_batch_size
+        )
 
     def _describe(self) -> dict[str, Any]:
         return {

--- a/kedro-datasets/kedro_datasets_experimental/weaviate/weaviate_vector_store_dataset.py
+++ b/kedro-datasets/kedro_datasets_experimental/weaviate/weaviate_vector_store_dataset.py
@@ -135,7 +135,46 @@ class WeaviateVectorStoreHandle(VectorStoreHandle):
         top_k: int = 10,
         filters: Any = None,
     ) -> list[dict[str, Any]]:
-        raise NotImplementedError("search() will be implemented in ST4.")  # pragma: no cover
+        """Search the collection by vector or text and return the top matches.
+
+        Exactly one of ``vector`` or ``text`` must be provided.  ``vector``
+        triggers ``near_vector`` search; ``text`` triggers ``near_text``
+        (requires a vectorizer configured on the collection).
+
+        Args:
+            vector: Query embedding for similarity search.
+            text: Query string for near-text search.
+            top_k: Maximum number of results to return. Defaults to 10.
+            filters: A ``weaviate.classes.query.Filter`` expression to restrict
+                the search scope (passed directly to the underlying query).
+
+        Returns:
+            List of result dicts, each containing all stored object properties
+            plus ``"id"`` (UUID string) and ``"distance"`` (float).
+
+        Raises:
+            DatasetError: If neither or both of ``vector``/``text`` are supplied.
+        """
+        if vector is None and text is None:
+            raise DatasetError("search() requires exactly one of 'vector' or 'text'.")
+        if vector is not None and text is not None:
+            raise DatasetError("search() accepts 'vector' or 'text', not both.")
+
+        common_kwargs = dict(
+            limit=top_k,
+            filters=filters,
+            return_metadata=wvc.query.MetadataQuery(distance=True),
+        )
+
+        if vector is not None:
+            results = self._collection.query.near_vector(near_vector=vector, **common_kwargs)
+        else:
+            results = self._collection.query.near_text(query=text, **common_kwargs)
+
+        return [
+            {"id": str(obj.uuid), "distance": obj.metadata.distance, **obj.properties}
+            for obj in results.objects
+        ]
 
 
 class WeaviateVectorStoreDataset(AbstractVectorStoreDataset):

--- a/kedro-datasets/kedro_datasets_experimental/weaviate/weaviate_vector_store_dataset.py
+++ b/kedro-datasets/kedro_datasets_experimental/weaviate/weaviate_vector_store_dataset.py
@@ -57,8 +57,6 @@ class WeaviateVectorStoreHandle(VectorStoreHandle):
             "count": result.total_count,
         }
 
-    # --- write path (ST3) ---
-
     def add(self, records: list[dict[str, Any]]) -> list[str]:
         """Insert records into the collection and return their UUIDs.
 
@@ -132,8 +130,6 @@ class WeaviateVectorStoreHandle(VectorStoreHandle):
                 self._collection.data.delete_many(where=filters)
         except Exception as e:
             raise DatasetError(f"delete() failed: {e}") from e
-
-    # --- read path (ST4) ---
 
     def search(
         self,

--- a/kedro-datasets/pyproject.toml
+++ b/kedro-datasets/pyproject.toml
@@ -254,6 +254,9 @@ safetensors = ["kedro-datasets[safetensors-safetensorsdataset]"]
 video-videodataset = ["opencv-python~=4.13.0.92"]
 video = ["kedro-datasets[video-videodataset]"]
 
+vectorstore-weaviatevectorstoredataset = ["weaviate-client>=4.0"]
+vectorstore-weaviate = ["kedro-datasets[vectorstore-weaviatevectorstoredataset]"]
+
 # Docs requirements
 docs = [
    "mkdocs>=1.6.1",
@@ -373,6 +376,7 @@ lint = [
 
 # Experimental dataset requirements
 experimental = [
+    "weaviate-client>=4.0",
     "langchain-openai",
     "langchain-cohere",
     "langchain-anthropic",
@@ -394,6 +398,7 @@ experimental = [
 ]
 
 experimental_test = [
+    "weaviate-client>=4.0",
     "delta-spark>=1.0, <3.0; python_version <= '3.11'",
     "delta-spark>=4.0, <4.1; python_version >= '3.12'",
     "langchain-openai",

--- a/kedro-datasets/pyproject.toml
+++ b/kedro-datasets/pyproject.toml
@@ -254,8 +254,8 @@ safetensors = ["kedro-datasets[safetensors-safetensorsdataset]"]
 video-videodataset = ["opencv-python~=4.13.0.92"]
 video = ["kedro-datasets[video-videodataset]"]
 
-vectorstore-weaviatevectorstoredataset = ["weaviate-client>=4.0"]
-vectorstore-weaviate = ["kedro-datasets[vectorstore-weaviatevectorstoredataset]"]
+weaviate-dataset = ["weaviate-client>=4.0"]
+weaviate = ["kedro-datasets[weaviate-dataset]"]
 
 # Docs requirements
 docs = [


### PR DESCRIPTION
## Description

Implements `WeaviateVectorStoreDataset` and `WeaviateVectorStoreHandle`, as the first concrete backend for the `AbstractVectorStoreDataset` abstraction introduced in https://github.com/kedro-org/kedro-plugins/pull/1430

Part of https://github.com/kedro-org/kedro-plugins/issues/1351

---

## What this PR adds

### `WeaviateVectorStoreDataset`

A Kedro dataset that connects to a [Weaviate](https://weaviate.io/) collection and returns a `WeaviateVectorStoreHandle` on `load()`. Three connection modes:

- **`local`** (default) — connects to a locally running Weaviate instance
- **`cloud`** — connects to Weaviate Cloud; requires `url` and optionally `credentials: {api_key: ...}`
- **`custom`** — passes `connection_params` directly to `weaviate.connect_to_custom()` for self-hosted deployments

`save()` is intentionally disabled and raises `DatasetError` — vector stores are not write-once filesystems, so all mutations go through the handle.

### `WeaviateVectorStoreHandle`

Returned by `load()`. Owns the gRPC connection; callers must close it either explicitly or via the context manager:

```python
  with catalog.load("my_store") as store:
      ids = store.add([{"properties": {"text": "..."}, "vector": [...]}])
      results = store.search(vector=[...], top_k=5)
      store.delete(ids=ids)
```

**`add(records)`** — inserts a batch of records via `collection.data.insert_many`. Each record is a plain dict; "vector" and "id" are reserved keys (popped before storage). All other keys become Weaviate object properties. Returns a list of UUID strings in insertion order. Raises `DatasetError` on any failure.

**`delete(*, ids=None, filters=None)`** — exactly one of vector or text required. vector triggers near_vector; text triggers near_text (requires a server-side vectorizer on the collection). Returns a list of dicts, each containing all stored properties plus "id" (UUID string) and "distance" (float). "id" and "distance" always take precedence over same-named properties.

**`search(*, vector=None, text=None, top_k=10, filters=None)`** — exactly one of `vector` or `text` required. `vector` triggers `near_vector`; `text` triggers `near_text`. Returns a list of dicts, each containing all stored properties plus `"id"` (UUID string) and `"distance"` (float). `"id"` and `"distance"` always take precedence over same-named properties.

**`describe()`** — returns collection name and current object count.

**`raw_client`** — escape hatch exposing the underlying `weaviate.WeaviateClient` for operations outside this interface.

---

## Design decisions

**`load()` returns a handle, not data.** Vector stores are stateful connections, not serialisable blobs. The handle owns the connection lifecycle, which maps to Kedro's `load()` contract without requiring a custom runner or session hook.

**`save()` raises unconditionally.** Overriding `save()` directly (not `_save()`) sidesteps the metaclass alias and makes the intent explicit: vector store mutations go through the handle, not the catalog write path. Explained in more detail in https://github.com/kedro-org/kedro-plugins/pull/1430

**Backend-native filters.** `search()` and `delete()` accept `weaviate.classes.query.Filter` objects directly.

**`get_or_create` not available in weaviate-client ≥4.6.** The `_load()` implementation uses `collections.exists()` + `create()`/`get()` rather than the non-existent `get_or_create()`.

## Testing

Besides the unit tests included in the PR, this vector store dataset can be tested using the [GraphRAG ](https://github.com/lrcouto/graphrag/tree/weaviate-backend-test) demo. A separate branch has this dataset used as the vector store for the project instead of ChromaDB. Both of them should work identically.

Needs a Python env with `weaviate-client>=4.0`, `openai`, `kedro`, and a [Weaviate Cloud cluster](https://console.weaviate.cloud) (free tier works fine).

```bash
# Add OpenAI and Weaviate credentials to conf/local/credentials.yml:
# openai:
#   api_key: "<your-key>"
# weaviate_cloud:
#   api_key: "<your-key>"
# And set the cluster URL in conf/base/catalog.yml

# Build vector index (embeds 18 documents into Weaviate via add())
kedro run --pipelines vector_indexing

# Run agent Q&A (queries Weaviate via search())
kedro run --pipelines query_answering

# Run everything end-to-end
kedro run

# Run everything through the Streamlit app
streamlit run app/streamlit_app.py         
```

The catalog entry used in the demo:

```yaml
weaviate_collection:
  type: graphrag.datasets.weaviate_vector_store_dataset.WeaviateVectorStoreDataset
  collection_name: HealthcareKnowledge
  connection_type: cloud
  url: "https://<cluster>.weaviate.cloud"
  credentials: weaviate_cloud
```

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Updated `jsonschema/kedro-catalog-X.XX.json` if necessary
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
- [ ] Received approvals from at least half of the TSC (required for adding a new, non-experimental dataset)
