### PR TITLE
fix: spelling of 'doesn't'.

### DIFF
--- a/kedro-airflow/features/environment.py
+++ b/kedro-airflow/features/environment.py
@@ -27,7 +27,7 @@ def before_scenario(context, scenario):
     context.venv_dir = create_new_venv()
 
     # note the locations of some useful stuff
-    # this is because exe resolution in supbrocess doens't respect a passed env
+    # this is because exe resolution in supbrocess doesn't respect a passed env
     if os.name == "posix":
         bin_dir = context.venv_dir / "bin"
         path_sep = ":"


### PR DESCRIPTION
## Description

I noticed a spelling mistake while reviewing the code.

I am not sure if this change needs to go in the RELEASE.md since it should be invisible to the user interface.

## Development notes

- Changed spelling in a `#` comment.
- No additional testing required beyond visual inspection that the change remains within the comment.

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Updated `jsonschema/kedro-catalog-X.XX.json` if necessary
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
- [ ] Received approvals from at least half of the TSC (required for adding a new, non-experimental dataset)
