### PR TITLE
feat(datasets): Refactor ChromaDBDataset to VectorStoreHandle

### DIFF
--- a/kedro-datasets/RELEASE.md
+++ b/kedro-datasets/RELEASE.md
@@ -7,6 +7,9 @@
 | ------------------------ | ------------------------------------------------ | ---------------------------------- |
 | `weaviate.WeaviateVectorStoreDataset` | A dataset that loads a handle for adding, searching, and deleting entries in Weaviate vector database collections. | `kedro_datasets_experimental.weaviate` |
 
+## Breaking changes to experimental datasets
+* Refactored `chromadb.ChromaDBDataset` to the `VectorStoreHandle` approach.
+
 ## Bug fixes and other changes
 - Fixed `MLRunModel` so user-supplied `load_args` are now passed to `joblib.load()` (previously silently dropped). Added a deserialization warning to the docstring.
 - Hardened `TensorFlowModelDataset`: `safe_mode=True` is now the default for `load_model()` to prevent arbitrary code execution from untrusted model files. Fixed a bug where `tf_device` was lost from `load_args` after the first load call.

--- a/kedro-datasets/RELEASE.md
+++ b/kedro-datasets/RELEASE.md
@@ -8,7 +8,7 @@
 | `weaviate.WeaviateVectorStoreDataset` | A dataset that loads a handle for adding, searching, and deleting entries in Weaviate vector database collections. | `kedro_datasets_experimental.weaviate` |
 
 ## Breaking changes to experimental datasets
-* Refactored `chromadb.ChromaDBDataset` to the `VectorStoreHandle` approach.
+* Refactored `chromadb.ChromaDBDataset` to the `VectorStoreHandle` approach. `load_args`/`save_args` are removed; the extras group is renamed from `chromadb-chromadbdataset` to `chromadb-dataset`.
 
 ## Bug fixes and other changes
 - Fixed `MLRunModel` so user-supplied `load_args` are now passed to `joblib.load()` (previously silently dropped). Added a deserialization warning to the docstring.

--- a/kedro-datasets/docs/api/kedro_datasets_experimental/chromadb.ChromaDBDataset.md
+++ b/kedro-datasets/docs/api/kedro_datasets_experimental/chromadb.ChromaDBDataset.md
@@ -1,8 +1,13 @@
 # ChromaDBDataset
 
-`ChromaDBDataset` loads and saves data to ChromaDB collections.
+`ChromaDBDataset` loads a handle for adding, searching, and deleting entries in ChromaDB vector database collections.
 
 ::: kedro_datasets_experimental.chromadb.ChromaDBDataset
+    options:
+        members: true
+        show_source: true
+
+::: kedro_datasets_experimental.chromadb.ChromaVectorStoreHandle
     options:
         members: true
         show_source: true

--- a/kedro-datasets/docs/api/kedro_datasets_experimental/index.md
+++ b/kedro-datasets/docs/api/kedro_datasets_experimental/index.md
@@ -6,7 +6,7 @@
 
 Name | Description
 -----|------------
-[chromadb.ChromaDBDataset](chromadb.ChromaDBDataset.md) | ``ChromaDBDataset`` loads and saves data to ChromaDB vector database collections.
+[chromadb.ChromaDBDataset](chromadb.ChromaDBDataset.md) | ``ChromaDBDataset`` loads a handle for adding, searching, and deleting entries in ChromaDB vector database collections.
 [databricks.ExternalTableDataset](databricks.ExternalTableDataset.md) | ``ExternalTableDataset`` implementation to access external tables in Databricks.
 [langchain.PromptDataset](langchain.PromptDataset.md) | ``PromptDataset`` loads a `langchain` prompt template.
 [langfuse.EvaluationDataset](langfuse.EvaluationDataset.md) | ``EvaluationDataset`` manages Langfuse evaluation datasets for LLM experiment workflows, supporting local file syncing and remote dataset versioning.

--- a/kedro-datasets/kedro_datasets_experimental/chromadb/__init__.py
+++ b/kedro-datasets/kedro_datasets_experimental/chromadb/__init__.py
@@ -1,16 +1,20 @@
-"""``AbstractDataset`` implementation for ChromaDB collections."""
+"""`ChromaDBDataset` connects to a ChromaDB collection as a vector store."""
 
 from typing import Any
 
 import lazy_loader as lazy
 
 try:
-    from .chromadb_dataset import ChromaDBDataset
+    from .chromadb_dataset import ChromaDBDataset, ChromaVectorStoreHandle
 except (ImportError, RuntimeError):
     # For documentation builds that might fail due to dependency issues
     # https://github.com/pylint-dev/pylint/issues/4300#issuecomment-1043601901
     ChromaDBDataset: Any
+    ChromaVectorStoreHandle: Any
 
 __getattr__, __dir__, __all__ = lazy.attach(
-    __name__, submod_attrs={"chromadb_dataset": ["ChromaDBDataset"]}
+    __name__,
+    submod_attrs={
+        "chromadb_dataset": ["ChromaDBDataset", "ChromaVectorStoreHandle"]
+    },
 )

--- a/kedro-datasets/kedro_datasets_experimental/chromadb/chromadb_dataset.py
+++ b/kedro-datasets/kedro_datasets_experimental/chromadb/chromadb_dataset.py
@@ -351,26 +351,37 @@ class ChromaDBDataset(AbstractVectorStoreDataset):
 
     def _create_client(self) -> ClientAPI:
         settings = dict(self._client_settings)
-        if self._client_type == "ephemeral":
-            return chromadb.EphemeralClient(**settings)
-        elif self._client_type == "persistent":
-            return chromadb.PersistentClient(
-                path=settings.pop("path", "./chroma_db"), **settings
-            )
-        elif self._client_type == "http":
-            return chromadb.HttpClient(
-                host=settings.pop("host", "localhost"),
-                port=settings.pop("port", 8000),
-                **settings,
-            )
-        else:
+        try:
+            if self._client_type == "ephemeral":
+                return chromadb.EphemeralClient(**settings)
+            elif self._client_type == "persistent":
+                return chromadb.PersistentClient(
+                    path=settings.pop("path", "./chroma_db"), **settings
+                )
+            elif self._client_type == "http":
+                return chromadb.HttpClient(
+                    host=settings.pop("host", "localhost"),
+                    port=settings.pop("port", 8000),
+                    **settings,
+                )
+            else:
+                raise DatasetError(
+                    f"Unsupported client_type: '{self._client_type}'. "
+                    "Must be one of: 'ephemeral', 'persistent', 'http'."
+                )
+        except DatasetError:
+            raise
+        except Exception as e:
             raise DatasetError(
-                f"Unsupported client_type: '{self._client_type}'. "
-                "Must be one of: 'ephemeral', 'persistent', 'http'."
-            )
+                f"Failed to create Chroma client "
+                f"(client_type='{self._client_type}'): {e}"
+            ) from e
 
     def _load(self) -> ChromaVectorStoreHandle:
         client = self._create_client()
+        # Closing an ephemeral client would destroy the process-shared
+        # in-memory store, so only persistent/http clients are ever closed.
+        close_client = self._client_type != "ephemeral"
         try:
             if self._create_collection_if_missing:
                 collection = client.get_or_create_collection(
@@ -379,19 +390,19 @@ class ChromaDBDataset(AbstractVectorStoreDataset):
             else:
                 collection = client.get_collection(name=self._collection_name)
         except NotFoundError as e:
+            if close_client:
+                client.close()
             raise DatasetError(
                 f"Chroma collection '{self._collection_name}' does not exist "
                 "and create_collection_if_missing is False."
             ) from e
         except Exception as e:
+            if close_client:
+                client.close()
             raise DatasetError(
                 f"Failed to access Chroma collection '{self._collection_name}': {e}"
             ) from e
-        # Closing an ephemeral client would destroy the process-shared
-        # in-memory store, so only persistent/http handles close theirs.
-        return ChromaVectorStoreHandle(
-            client, collection, close_client=self._client_type != "ephemeral"
-        )
+        return ChromaVectorStoreHandle(client, collection, close_client=close_client)
 
     def _describe(self) -> dict[str, Any]:
         # client_settings is withheld: for http clients it can carry

--- a/kedro-datasets/kedro_datasets_experimental/chromadb/chromadb_dataset.py
+++ b/kedro-datasets/kedro_datasets_experimental/chromadb/chromadb_dataset.py
@@ -1,275 +1,442 @@
-"""``ChromaDBDataset`` loads and saves data from/to ChromaDB collections."""
+"""`ChromaDBDataset` connects to a ChromaDB collection as a vector store."""
 
 from __future__ import annotations
 
-from typing import Any
+import uuid
+from typing import Any, Literal
 
 import chromadb
+from chromadb.api import ClientAPI
 from chromadb.api.models.Collection import Collection
 from chromadb.errors import NotFoundError
-from kedro.io.core import AbstractDataset, DatasetError
+from kedro.io.core import DatasetError
+
+from kedro_datasets_experimental.vectorstore_base import (
+    AbstractVectorStoreDataset,
+    VectorStoreHandle,
+)
 
 
-class ChromaDBDataset(AbstractDataset[dict[str, Any], dict[str, Any]]):
-    """``ChromaDBDataset`` loads and saves data from/to ChromaDB collections.
+class ChromaVectorStoreHandle(VectorStoreHandle):
+    """Handle for interacting with a ChromaDB collection.
 
-    ChromaDB is a vector database for building AI applications. This dataset allows you to
-    interact with ChromaDB collections for storing and retrieving documents with embeddings.
+    Returned by `ChromaDBDataset.load()`. All reads and writes go through
+    this handle; the dataset itself only configures the connection.
+
+    What `close()` releases depends on the client type. Persistent
+    clients hold open SQLite and HNSW index file handles, and HTTP clients
+    hold a connection pool — for both, `close()` releases those resources
+    and the handle must not be used afterwards. Ephemeral clients are a
+    special case: their in-memory store is shared by every ephemeral client
+    in the process and would be destroyed by closing the underlying client,
+    so `close()` is deliberately a no-op for them (the handle stays
+    usable). Either way, calling `close()` — or using the handle as a
+    context manager — is always safe and idempotent::
+
+        with catalog.load("my_store") as store:
+            store.add([{"properties": {"document": "hello"}, "vector": [0.1, 0.2]}])
+            hits = store.search(vector=[0.1, 0.2], top_k=5)
+
+    Kedro never closes the handle for you: whether it arrives as a node
+    input in a `kedro run` or from a hand-built catalog, closing it is
+    the receiving code's responsibility.
+
+    Record format
+        `add()` takes records shaped as
+        `{"properties": dict, "vector": list[float] | None, "id": str | None}`.
+        Chroma stores a record's text separately from its metadata, so one
+        key inside `properties` is reserved:
+
+        - `"document"` — the record's text; mapped to Chroma's
+          `documents` field. Optional.
+        - every other `properties` key–value pair is stored as Chroma
+          metadata (values must be types Chroma accepts as metadata, e.g.
+          `str`, `int`, `float` or `bool` — not `None`).
+
+        `search()` results merge the two back into a single
+        `"properties"` dict, so what you `add()` is what you get back.
+
+    Embeddings
+        Chroma's equivalent of a server-side vectorizer is the collection's
+        embedding function. When records are added without a `"vector"`,
+        Chroma embeds each record's `"document"` with that function — by
+        default [all-MiniLM-L6-v2](https://docs.trychroma.com/docs/embeddings/embedding-functions),
+        which downloads the model on first use. Records with precomputed
+        vectors bypass it entirely.
+
+    The `raw_client` property exposes the underlying `chromadb` client
+    for operations outside this interface (e.g. `where_document`
+    full-text filters, `upsert`, or multi-query batching).
+    """
+
+    def __init__(
+        self,
+        client: ClientAPI,
+        collection: Collection,
+        close_client: bool = True,
+    ) -> None:
+        self._client = client
+        self._collection = collection
+        self._close_client = close_client
+        self._closed = False
+
+    @property
+    def raw_client(self) -> ClientAPI:
+        """The underlying `chromadb` client instance."""
+        return self._client
+
+    def close(self) -> None:
+        """Release the resources held by the client. Safe to call more than once.
+
+        For persistent clients this releases the SQLite and HNSW index file
+        handles; for HTTP clients, the connection pool. The handle must not
+        be used after closing. For ephemeral clients this is a no-op (see
+        the class docstring) and the handle stays usable.
+        """
+        if not self._closed:
+            if self._close_client:
+                self._client.close()
+            self._closed = True
+
+    def describe(self) -> dict[str, Any]:
+        """Return collection name and current record count."""
+        return {
+            "collection": self._collection.name,
+            "count": self._collection.count(),
+        }
+
+    def add(self, records: list[dict[str, Any]]) -> list[str]:
+        """Insert records into the collection and return their IDs.
+
+        Each record is a plain dict with the following keys:
+
+        - `"properties"` — the record's payload (`dict`). The reserved
+          `"document"` key holds the record's text (stored as Chroma's
+          document); all other keys become Chroma metadata.
+        - `"vector"` — the embedding (`list[float]`). Either all records
+          in the batch carry one, or none do; when none do, Chroma embeds
+          each record's `"document"` with the collection's embedding
+          function.
+        - `"id"` — optional ID string. Chroma does not generate IDs, so
+          a UUID is generated for any record without one.
+
+        Records whose ID already exists in the collection are rejected
+        (Chroma would otherwise skip them silently while this method
+        reports success). To update existing records, use `raw_client`
+        with `collection.upsert()`.
+
+        Args:
+            records: Records to insert.
+
+        Returns:
+            List of ID strings for the inserted records, in the same order
+            as the input records.
+
+        Raises:
+            DatasetError: If some records have a `"vector"` and others do
+                not, if a record's ID already exists in the collection, or
+                if the insert call to Chroma fails (e.g. a record has
+                neither a vector nor a document to embed).
+        """
+        if not records:
+            return []
+
+        with_vector = sum(1 for record in records if record.get("vector") is not None)
+        if 0 < with_vector < len(records):
+            raise DatasetError(
+                f"add() requires either all records or no records to carry a "
+                f"'vector': got {with_vector} of {len(records)} with one. "
+                "Chroma cannot mix precomputed and function-computed "
+                "embeddings in a single batch."
+            )
+
+        ids: list[str] = []
+        documents: list[str | None] = []
+        metadatas: list[dict[str, Any] | None] = []
+        embeddings: list[list[float]] = []
+        for record in records:
+            props = dict(record.get("properties") or {})
+            documents.append(props.pop("document", None))
+            metadatas.append(props or None)
+            record_id = record.get("id")
+            ids.append(uuid.uuid4().hex if record_id is None else record_id)
+            if with_vector:
+                embeddings.append(record["vector"])
+
+        explicit_ids = [
+            record["id"] for record in records if record.get("id") is not None
+        ]
+        if explicit_ids:
+            try:
+                existing = self._collection.get(ids=explicit_ids, include=[])["ids"]
+            except Exception as e:
+                raise DatasetError(f"add() failed: {e}") from e
+            if existing:
+                raise DatasetError(
+                    f"add() rejected {len(existing)} record(s) whose ID already "
+                    f"exists in the collection: {existing}. Chroma silently "
+                    "skips existing IDs on insert; use raw_client with "
+                    "collection.upsert() to update existing records."
+                )
+
+        add_kwargs: dict[str, Any] = {"ids": ids}
+        if with_vector:
+            add_kwargs["embeddings"] = embeddings
+        if any(document is not None for document in documents):
+            add_kwargs["documents"] = documents
+        if any(metadata is not None for metadata in metadatas):
+            add_kwargs["metadatas"] = metadatas
+
+        try:
+            self._collection.add(**add_kwargs)
+        except Exception as e:
+            raise DatasetError(f"add() failed: {e}") from e
+        return ids
+
+    def delete(
+        self,
+        *,
+        ids: list[str] | None = None,
+        filters: Any = None,
+    ) -> None:
+        """Delete records from the collection by ID or metadata filter.
+
+        Exactly one of `ids` or `filters` must be provided.
+
+        Args:
+            ids: List of ID strings to delete.
+            filters: A Chroma `where` filter dict (backend-native,
+                MongoDB-style — e.g. `{"topic": "ml"}` or
+                `{"$and": [...]}`) selecting the records to delete. For
+                `where_document` full-text filters, use `raw_client`.
+
+        Raises:
+            DatasetError: If neither or both arguments are supplied, or if
+                the deletion call to Chroma fails.
+        """
+        if ids is None and filters is None:
+            raise DatasetError("delete() requires exactly one of 'ids' or 'filters'.")
+        if ids is not None and filters is not None:
+            raise DatasetError("delete() accepts 'ids' or 'filters', not both.")
+        if ids is not None and not ids:
+            return
+
+        try:
+            if ids is not None:
+                self._collection.delete(ids=ids)
+            else:
+                self._collection.delete(where=filters)
+        except Exception as e:
+            raise DatasetError(f"delete() failed: {e}") from e
+
+    def search(
+        self,
+        *,
+        vector: list[float] | None = None,
+        text: str | None = None,
+        top_k: int = 10,
+        filters: Any = None,
+    ) -> list[dict[str, Any]]:
+        """Search the collection by vector or text and return the top matches.
+
+        Exactly one of `vector` or `text` must be provided. `vector`
+        queries with the embedding directly; `text` is embedded first with
+        the collection's embedding function (downloading the default model
+        on first use if the collection has no custom one).
+
+        Args:
+            vector: Query embedding for similarity search.
+            text: Query string, embedded with the collection's embedding
+                function.
+            top_k: Maximum number of results to return. Defaults to 10.
+            filters: A Chroma `where` filter dict (backend-native,
+                MongoDB-style) restricting the search scope. For
+                `where_document` full-text filters, use `raw_client`.
+
+        Returns:
+            List of result dicts, each containing `"id"` (str),
+            `"properties"` (dict of stored metadata, plus the
+            `"document"` key when the record has one), and `"distance"`
+            (float).
+
+        Raises:
+            DatasetError: If neither or both of `vector`/`text` are
+                supplied, or if the query call to Chroma fails.
+        """
+        if vector is None and text is None:
+            raise DatasetError("search() requires exactly one of 'vector' or 'text'.")
+        if vector is not None and text is not None:
+            raise DatasetError("search() accepts 'vector' or 'text', not both.")
+
+        query_kwargs: dict[str, Any] = {"n_results": top_k, "where": filters}
+        if vector is not None:
+            query_kwargs["query_embeddings"] = [vector]
+        else:
+            query_kwargs["query_texts"] = [text]
+
+        try:
+            result = self._collection.query(**query_kwargs)
+        except Exception as e:
+            raise DatasetError(f"search() failed: {e}") from e
+
+        # Chroma returns one inner list per query; we always send exactly one.
+        ids = result["ids"][0]
+        documents = (result.get("documents") or [[None] * len(ids)])[0]
+        metadatas = (result.get("metadatas") or [[None] * len(ids)])[0]
+        distances = (result.get("distances") or [[None] * len(ids)])[0]
+
+        hits = []
+        for record_id, document, metadata, distance in zip(
+            ids, documents, metadatas, distances
+        ):
+            properties = dict(metadata or {})
+            if document is not None:
+                properties["document"] = document
+            hits.append(
+                {"id": record_id, "properties": properties, "distance": distance}
+            )
+        return hits
+
+
+class ChromaDBDataset(AbstractVectorStoreDataset):
+    """Connect to a ChromaDB collection and return a `ChromaVectorStoreHandle`.
+
+    `load()` creates a Chroma client, resolves (or creates) the target
+    collection, and returns a handle. All read/write operations go through
+    the handle. `save()` is intentionally disabled and raises
+    `DatasetError`.
+
+    Three client types are supported, selected with `client_type`:
+
+    - `"ephemeral"` (default) — an in-memory store. Note that ephemeral
+      clients created within the same process share state, and the data is
+      lost when the process exits.
+    - `"persistent"` — an on-disk store; set the location with
+      `client_settings: {path: ...}`.
+    - `"http"` — a running Chroma server; set `client_settings:
+      {host: ..., port: ...}`.
+
+    `collection_name` is a lookup key. When
+    `create_collection_if_missing=True` (the default) the collection is
+    created on first use with Chroma's defaults — including the default
+    embedding function ([all-MiniLM-L6-v2](https://docs.trychroma.com/docs/embeddings/embedding-functions),
+    downloaded on first use), which serves text search and vector-less
+    `add()` calls. To use a custom embedding function or collection
+    configuration, create the collection yourself first via the Chroma
+    client.
 
     Examples:
         Using the [YAML API](https://docs.kedro.org/en/stable/catalog-data/data_catalog_yaml_examples/):
 
-        ```yaml
-        my_collection:
-          type: chromadb.ChromaDBDataset
-          collection_name: "documents"
-          client_type: "persistent"
+        ``yaml
+        my_store:
+          type: kedro_datasets_experimental.chromadb.ChromaDBDataset
+          collection_name: documents
+          client_type: persistent
           client_settings:
-            path: "./chroma_db"
-        ```
+            path: ./chroma_db
+        ``
 
         Using the [Python API](https://docs.kedro.org/en/stable/catalog-data/advanced_data_catalog_usage/):
 
         >>> from kedro_datasets_experimental.chromadb import ChromaDBDataset
         >>>
-        >>> # Save data to ChromaDB
-        >>> data = {
-        ...     "documents": ["This is a document", "This is another document"],
-        ...     "metadatas": [{"type": "text"}, {"type": "text"}],
-        ...     "ids": ["doc1", "doc2"]
-        ... }
-        >>> dataset = ChromaDBDataset(collection_name="test_collection")
-        >>> dataset.save(data)
-        >>>
-        >>> # Load data from ChromaDB
-        >>> loaded_data = dataset.load()
-        >>> print(loaded_data["documents"])  # ['This is a document', 'This is another document']
-        >>>
-        >>> # Query for similar vectors (efficient for large datasets)
-        >>> query_dataset = ChromaDBDataset(
-        ...     collection_name="documents",
-        ...     load_args={
-        ...         "query_texts": ["machine learning"],
-        ...         "n_results": 5,
-        ...         "include": ["documents", "metadatas", "distances"]
-        ...     }
+        >>> dataset = ChromaDBDataset(collection_name="documents")
+        >>> store = dataset.load()
+        >>> ids = store.add(
+        ...     [
+        ...         {
+        ...             "properties": {"document": "A document about ML", "topic": "ml"},
+        ...             "vector": [0.1, 0.2, 0.3],
+        ...         }
+        ...     ]
         ... )
-        >>> results = query_dataset.load()  # Returns top-5 similar documents
-
+        >>> hits = store.search(vector=[0.1, 0.2, 0.3], top_k=5)
+        >>> store.delete(ids=ids)
     """
-    # Attribute annotations for IDEs / type-checkers (instance values set in __init__)
-    _client: chromadb.Client | None
-    _collection: Collection | None
 
-    def __init__(  # noqa: PLR0913
+    def __init__(
         self,
         *,
         collection_name: str,
-        client_type: str = "ephemeral",
+        client_type: Literal["ephemeral", "persistent", "http"] = "ephemeral",
         client_settings: dict[str, Any] | None = None,
-        load_args: dict[str, Any] | None = None,
-        save_args: dict[str, Any] | None = None,
+        create_collection_if_missing: bool = True,
         metadata: dict[str, Any] | None = None,
     ) -> None:
-        """Creates a new instance of ``ChromaDBDataset``.
+        """Create a new `ChromaDBDataset`.
 
         Args:
-            collection_name: The name of the ChromaDB collection.
-            client_type: Type of ChromaDB client. Options: "ephemeral", "persistent", "http".
-                Defaults to "ephemeral".
-            client_settings: Settings for the ChromaDB client. For "persistent", use {"path": "/path/to/db"}.
-                For "http", use {"host": "localhost", "port": 8000}.
-            load_args: Additional arguments for loading data from ChromaDB collection.
-                Can include "where", "where_document", "include", "n_results", etc.
-                For vector similarity queries, use:
-                - "query_embeddings": List of embeddings to query for similarity
-                - "query_texts": List of texts to query for similarity
-                - "n_results": Number of results to return (default: 10)
-                - "where": Metadata filter conditions
-                - "where_document": Document content filter conditions
-            save_args: Additional arguments for saving data to ChromaDB collection.
-                Can include "embeddings" if you want to provide custom embeddings.
-            metadata: Any arbitrary metadata.
-                This is ignored by Kedro, but may be consumed by users or external plugins.
+            collection_name: Name of the ChromaDB collection to connect to.
+            client_type: Type of ChromaDB client — `"ephemeral"`,
+                `"persistent"`, or `"http"`. Defaults to `"ephemeral"`.
+            client_settings: Keyword arguments for the client. For
+                `"persistent"`: `{"path": "/path/to/db"}` (default path
+                `"./chroma_db"`). For `"http"`: `{"host": ..., "port": ...}`
+                (defaults `"localhost"` and `8000`). Extra keys are
+                forwarded to the underlying `chromadb` client constructor.
+            create_collection_if_missing: When `True` (default), the
+                collection is created — with Chroma's default configuration
+                and embedding function — if it does not already exist. When
+                `False`, `load()` raises if the collection is absent.
+            metadata: Arbitrary metadata passed through by Kedro; ignored by
+                this dataset.
         """
         self._collection_name = collection_name
         self._client_type = client_type
         self._client_settings = client_settings or {}
-        self._load_args = load_args or {}
-        self._save_args = save_args or {}
+        self._create_collection_if_missing = create_collection_if_missing
         self.metadata = metadata
-        # Initialize instance attributes (actual annotations are at class-level)
-        self._client = None
-        self._collection = None
 
-    def _create_client(self) -> chromadb.Client:
-        """Create ChromaDB client based on configuration."""
+    def _create_client(self) -> ClientAPI:
+        settings = dict(self._client_settings)
         if self._client_type == "ephemeral":
-            return chromadb.EphemeralClient()
+            return chromadb.EphemeralClient(**settings)
         elif self._client_type == "persistent":
-            path = self._client_settings.get("path", "./chroma_db")
-            return chromadb.PersistentClient(path=path, **{
-                k: v for k, v in self._client_settings.items() if k != "path"
-            })
+            return chromadb.PersistentClient(
+                path=settings.pop("path", "./chroma_db"), **settings
+            )
         elif self._client_type == "http":
-            host = self._client_settings.get("host", "localhost")
-            port = self._client_settings.get("port", 8000)
-            return chromadb.HttpClient(host=host, port=port, **{
-                k: v for k, v in self._client_settings.items() if k not in ["host", "port"]
-            })
+            return chromadb.HttpClient(
+                host=settings.pop("host", "localhost"),
+                port=settings.pop("port", 8000),
+                **settings,
+            )
         else:
             raise DatasetError(
-                f"Unsupported client_type: {self._client_type}. "
-                f"Must be one of: 'ephemeral', 'persistent', 'http'"
+                f"Unsupported client_type: '{self._client_type}'. "
+                "Must be one of: 'ephemeral', 'persistent', 'http'."
             )
 
-    def _get_client(self) -> chromadb.Client:
-        """Get or create the ChromaDB client."""
-        if self._client is None:
-            self._client = self._create_client()
-        return self._client
-
-    def _get_collection(self, create_if_missing: bool = True) -> Collection | None:
-        """Get or create the ChromaDB collection.
-
-        Args:
-            create_if_missing: If True, creates the collection if it doesn't exist.
-                              If False, returns None when collection is not found.
-
-        Returns:
-            Collection object if found/created, None if not found and create_if_missing=False.
-        """
-        if self._collection is None:
-            client = self._get_client()
-            try:
-                self._collection = client.get_collection(name=self._collection_name)
-            except NotFoundError:
-                if create_if_missing:
-                    # Collection doesn't exist, create it
-                    self._collection = client.create_collection(name=self._collection_name)
-                else:
-                    # Don't create collection, return None instead of raising
-                    return None
-        return self._collection
+    def _load(self) -> ChromaVectorStoreHandle:
+        client = self._create_client()
+        try:
+            if self._create_collection_if_missing:
+                collection = client.get_or_create_collection(
+                    name=self._collection_name
+                )
+            else:
+                collection = client.get_collection(name=self._collection_name)
+        except NotFoundError as e:
+            raise DatasetError(
+                f"Chroma collection '{self._collection_name}' does not exist "
+                "and create_collection_if_missing is False."
+            ) from e
+        except Exception as e:
+            raise DatasetError(
+                f"Failed to access Chroma collection '{self._collection_name}': {e}"
+            ) from e
+        # Closing an ephemeral client would destroy the process-shared
+        # in-memory store, so only persistent/http handles close theirs.
+        return ChromaVectorStoreHandle(
+            client, collection, close_client=self._client_type != "ephemeral"
+        )
 
     def _describe(self) -> dict[str, Any]:
-        """Returns a dictionary describing the dataset configuration."""
+        # client_settings is withheld: for http clients it can carry
+        # authentication headers.
         return {
             "collection_name": self._collection_name,
             "client_type": self._client_type,
-            "client_settings": self._client_settings,
-            "load_args": self._load_args,
-            "save_args": self._save_args,
+            "create_collection_if_missing": self._create_collection_if_missing,
         }
-
-    def load(self) -> dict[str, Any]:
-        """Loads data from the ChromaDB collection.
-
-        Returns:
-            dict[str, Any]: A dictionary containing the collection data with keys:
-                - "documents": List of document texts
-                - "metadatas": List of metadata dictionaries
-                - "ids": List of document IDs
-                - "embeddings": List of embeddings (if included)
-        """
-        collection = self._get_collection(create_if_missing=False)
-
-        # If collection doesn't exist, return empty result rather than creating it
-        if collection is None:
-            return {"documents": [], "metadatas": [], "ids": [], "embeddings": []}
-
-        # Prepare load arguments
-        load_args = {
-            "include": ["documents", "metadatas", "embeddings"],
-            **self._load_args
-        }
-
-        try:
-            # Use query() for vector similarity search or filtering
-            if any(key in load_args for key in ["query_embeddings", "query_texts", "where", "where_document"]):
-                # Vector similarity query - more efficient for large datasets
-                if "n_results" not in load_args:
-                    load_args["n_results"] = 10  # Default limit for queries
-                result = collection.query(**load_args)
-            else:
-                # Use get() for retrieving all documents (not recommended for large collections)
-                if "n_results" in load_args:
-                    # Convert n_results to limit for get() method
-                    load_args["limit"] = load_args.pop("n_results")
-                result = collection.get(**load_args)
-
-            return {
-                "documents": result.get("documents", []),
-                "metadatas": result.get("metadatas", []),
-                "ids": result.get("ids", []),
-                "embeddings": result.get("embeddings", [])
-            }
-        except Exception as e:
-            raise DatasetError(
-                f"Failed to load data from ChromaDB collection '{self._collection_name}': {e}"
-            ) from e
-
-    def save(self, data: dict[str, Any]) -> None:
-        """Saves data to the ChromaDB collection.
-
-        Args:
-            data: A dictionary containing the data to save. Expected keys:
-                - "documents": List of document texts (required)
-                - "ids": List of document IDs (required)
-                - "metadatas": List of metadata dictionaries (optional)
-                - "embeddings": List of embeddings (optional, will be auto-generated if not provided)
-        """
-        if not isinstance(data, dict):
-            raise DatasetError(f"Data must be a dictionary, got {type(data)}")
-
-        if "documents" not in data or "ids" not in data:
-            raise DatasetError("Data must contain 'documents' and 'ids' keys")
-
-        collection = self._get_collection(create_if_missing=True)
-
-        if collection is None:
-            raise DatasetError(f"Failed to access or create ChromaDB collection '{self._collection_name}'")
-
-        try:
-            # Prepare the data for ChromaDB
-            add_kwargs = {
-                "documents": data["documents"],
-                "ids": data["ids"],
-                **self._save_args
-            }
-
-            # Add optional fields if present
-            if "metadatas" in data:
-                add_kwargs["metadatas"] = data["metadatas"]
-            if "embeddings" in data:
-                add_kwargs["embeddings"] = data["embeddings"]
-
-            # Add documents to collection
-            collection.add(**add_kwargs)
-
-        except Exception as e:
-            raise DatasetError(
-                f"Failed to save data to ChromaDB collection '{self._collection_name}': {e}"
-            ) from e
-
-    def exists(self) -> bool:
-        """Checks if the collection exists and contains data."""
-        try:
-            collection = self._collection or self._get_collection(create_if_missing=False)
-            # In case both return None
-            if collection is None:
-                return False
-            return collection.count() > 0
-        except Exception:
-            return False
-            # Use the same collection instance if we already have it
-            if self._collection is not None:
-                count = self._collection.count()
-                return count > 0
-
-            # Otherwise try to get the collection from the client
-            collection = self._get_collection(create_if_missing=False)
-            count = collection.count()
-            return count > 0
-        except Exception:
-            return False

--- a/kedro-datasets/kedro_datasets_experimental/chromadb/chromadb_dataset.py
+++ b/kedro-datasets/kedro_datasets_experimental/chromadb/chromadb_dataset.py
@@ -21,52 +21,31 @@ class ChromaVectorStoreHandle(VectorStoreHandle):
     """Handle for interacting with a ChromaDB collection.
 
     Returned by `ChromaDBDataset.load()`. All reads and writes go through
-    this handle; the dataset itself only configures the connection.
+    the handle; the dataset only configures the connection.
 
-    What `close()` releases depends on the client type. Persistent
-    clients hold open SQLite and HNSW index file handles, and HTTP clients
-    hold a connection pool — for both, `close()` releases those resources
-    and the handle must not be used afterwards. Ephemeral clients are a
-    special case: their in-memory store is shared by every ephemeral client
-    in the process and would be destroyed by closing the underlying client,
-    so `close()` is deliberately a no-op for them (the handle stays
-    usable). Either way, calling `close()` — or using the handle as a
-    context manager — is always safe and idempotent::
+    Records passed to `add()` are dicts of the form
+    `{"properties": dict, "vector": list[float], "id": str}`. The reserved
+    `"document"` key inside `properties` maps to Chroma's documents field;
+    all other keys are stored as Chroma metadata. `search()` merges them
+    back into a single `"properties"` dict. When records carry no
+    `"vector"`, Chroma embeds each record's `"document"` with the
+    collection's embedding function (by default
+    [all-MiniLM-L6-v2](https://docs.trychroma.com/docs/embeddings/embedding-functions),
+    downloaded on first use).
+
+    `close()` releases the client's resources (SQLite and HNSW file handles
+    for persistent clients, the connection pool for HTTP clients); a closed
+    handle must not be reused. For ephemeral clients `close()` is a no-op,
+    since their in-memory store is shared by every ephemeral client in the
+    process. Kedro never closes the handle for you — close it explicitly or
+    use it as a context manager::
 
         with catalog.load("my_store") as store:
             store.add([{"properties": {"document": "hello"}, "vector": [0.1, 0.2]}])
             hits = store.search(vector=[0.1, 0.2], top_k=5)
 
-    Kedro never closes the handle for you: whether it arrives as a node
-    input in a `kedro run` or from a hand-built catalog, closing it is
-    the receiving code's responsibility.
-
-    Record format
-        `add()` takes records shaped as
-        `{"properties": dict, "vector": list[float] | None, "id": str | None}`.
-        Chroma stores a record's text separately from its metadata, so one
-        key inside `properties` is reserved:
-
-        - `"document"` — the record's text; mapped to Chroma's
-          `documents` field. Optional.
-        - every other `properties` key–value pair is stored as Chroma
-          metadata (values must be types Chroma accepts as metadata, e.g.
-          `str`, `int`, `float` or `bool` — not `None`).
-
-        `search()` results merge the two back into a single
-        `"properties"` dict, so what you `add()` is what you get back.
-
-    Embeddings
-        Chroma's equivalent of a server-side vectorizer is the collection's
-        embedding function. When records are added without a `"vector"`,
-        Chroma embeds each record's `"document"` with that function — by
-        default [all-MiniLM-L6-v2](https://docs.trychroma.com/docs/embeddings/embedding-functions),
-        which downloads the model on first use. Records with precomputed
-        vectors bypass it entirely.
-
-    The `raw_client` property exposes the underlying `chromadb` client
-    for operations outside this interface (e.g. `where_document`
-    full-text filters, `upsert`, or multi-query batching).
+    `raw_client` exposes the underlying `chromadb` client for operations
+    outside this interface (e.g. `where_document` filters or `upsert`).
     """
 
     def __init__(
@@ -86,13 +65,7 @@ class ChromaVectorStoreHandle(VectorStoreHandle):
         return self._client
 
     def close(self) -> None:
-        """Release the resources held by the client. Safe to call more than once.
-
-        For persistent clients this releases the SQLite and HNSW index file
-        handles; for HTTP clients, the connection pool. The handle must not
-        be used after closing. For ephemeral clients this is a no-op (see
-        the class docstring) and the handle stays usable.
-        """
+        """Release the client's resources. Idempotent; a no-op for ephemeral clients."""
         if not self._closed:
             if self._close_client:
                 self._client.close()
@@ -108,35 +81,23 @@ class ChromaVectorStoreHandle(VectorStoreHandle):
     def add(self, records: list[dict[str, Any]]) -> list[str]:
         """Insert records into the collection and return their IDs.
 
-        Each record is a plain dict with the following keys:
-
-        - `"properties"` — the record's payload (`dict`). The reserved
-          `"document"` key holds the record's text (stored as Chroma's
-          document); all other keys become Chroma metadata.
-        - `"vector"` — the embedding (`list[float]`). Either all records
-          in the batch carry one, or none do; when none do, Chroma embeds
-          each record's `"document"` with the collection's embedding
-          function.
-        - `"id"` — optional ID string. Chroma does not generate IDs, so
-          a UUID is generated for any record without one.
-
-        Records whose ID already exists in the collection are rejected
-        (Chroma would otherwise skip them silently while this method
-        reports success). To update existing records, use `raw_client`
-        with `collection.upsert()`.
+        See the class docstring for the record format. Either all records
+        in the batch carry a `"vector"` or none do. A UUID is generated for
+        any record without an `"id"`. Records whose ID already exists in
+        the collection are rejected (Chroma would otherwise skip them
+        silently); to update existing records, use `raw_client` with
+        `collection.upsert()`.
 
         Args:
             records: Records to insert.
 
         Returns:
-            List of ID strings for the inserted records, in the same order
-            as the input records.
+            List of ID strings for the inserted records, in input order.
 
         Raises:
             DatasetError: If some records have a `"vector"` and others do
                 not, if a record's ID already exists in the collection, or
-                if the insert call to Chroma fails (e.g. a record has
-                neither a vector nor a document to embed).
+                if the insert call to Chroma fails.
         """
         if not records:
             return []
@@ -328,14 +289,14 @@ class ChromaDBDataset(AbstractVectorStoreDataset):
     Examples:
         Using the [YAML API](https://docs.kedro.org/en/stable/catalog-data/data_catalog_yaml_examples/):
 
-        ``yaml
+        ```yaml
         my_store:
           type: kedro_datasets_experimental.chromadb.ChromaDBDataset
           collection_name: documents
           client_type: persistent
           client_settings:
             path: ./chroma_db
-        ``
+        ```
 
         Using the [Python API](https://docs.kedro.org/en/stable/catalog-data/advanced_data_catalog_usage/):
 

--- a/kedro-datasets/kedro_datasets_experimental/tests/chromadb/test_chromadb_dataset.py
+++ b/kedro-datasets/kedro_datasets_experimental/tests/chromadb/test_chromadb_dataset.py
@@ -196,6 +196,14 @@ class TestCreateClient:
             ds._create_client()
         assert settings == {"path": str(tmp_path)}
 
+    def test_client_error_wrapped(self, dataset):
+        with patch(
+            f"{MODULE}.chromadb.EphemeralClient",
+            side_effect=RuntimeError("permission denied"),
+        ):
+            with pytest.raises(DatasetError, match="Failed to create Chroma client"):
+                dataset._create_client()
+
 
 # ---------------------------------------------------------------------------
 # ChromaDBDataset — load()
@@ -233,6 +241,19 @@ class TestLoad:
         with patch.object(dataset, "_create_client", return_value=mock_client):
             with pytest.raises(DatasetError, match="Failed to access Chroma collection"):
                 dataset.load()
+        # Ephemeral clients must not be closed: the store is process-shared.
+        mock_client.close.assert_not_called()
+
+    def test_load_error_closes_persistent_client(self, collection_name):
+        ds = ChromaDBDataset(
+            collection_name=collection_name, client_type="persistent"
+        )
+        mock_client = MagicMock()
+        mock_client.get_or_create_collection.side_effect = RuntimeError("boom")
+        with patch.object(ds, "_create_client", return_value=mock_client):
+            with pytest.raises(DatasetError, match="Failed to access Chroma collection"):
+                ds.load()
+        mock_client.close.assert_called_once()
 
 
 # ---------------------------------------------------------------------------

--- a/kedro-datasets/kedro_datasets_experimental/tests/chromadb/test_chromadb_dataset.py
+++ b/kedro-datasets/kedro_datasets_experimental/tests/chromadb/test_chromadb_dataset.py
@@ -1,271 +1,571 @@
+"""Tests for ChromaDBDataset and ChromaVectorStoreHandle.
+
+Handle read/write tests run against a real in-process ephemeral Chroma
+client (always with explicit vectors, so no embedding model is downloaded).
+Error-wrapping and text-search paths use mocks.
+"""
+
+from __future__ import annotations
+
 import uuid
+from unittest.mock import MagicMock, patch
 
 import chromadb
 import pytest
 from kedro.io.core import DatasetError
 
-from kedro_datasets_experimental.chromadb import ChromaDBDataset
+from kedro_datasets_experimental.chromadb import (
+    ChromaDBDataset,
+    ChromaVectorStoreHandle,
+)
+
+MODULE = "kedro_datasets_experimental.chromadb.chromadb_dataset"
 
 
 @pytest.fixture
-def sample_data():
-    """Sample data for testing ChromaDB operations."""
-    return {
-        "documents": [
-            "This is the first document about machine learning",
-            "This is the second document about data science",
-            "This is the third document about artificial intelligence"
-        ],
-        "ids": ["doc1", "doc2", "doc3"],
-        "metadatas": [
-            {"topic": "ml", "author": "Alice"},
-            {"topic": "ds", "author": "Bob"},
-            {"topic": "ai", "author": "Charlie"}
-        ]
-    }
+def collection_name():
+    """Unique name per test: ephemeral Chroma clients share in-process state."""
+    return f"test_collection_{uuid.uuid4().hex[:8]}"
 
 
 @pytest.fixture
-def chromadb_dataset():
-    """ChromaDB dataset with ephemeral client for testing."""
-    # Use unique collection name to avoid test interference
-    unique_name = f"test_collection_{uuid.uuid4().hex[:8]}"
-    return ChromaDBDataset(
-        collection_name=unique_name,
-        client_type="ephemeral"
-    )
+def dataset(collection_name):
+    return ChromaDBDataset(collection_name=collection_name)
 
 
 @pytest.fixture
-def persistent_chromadb_dataset(tmp_path):
-    """ChromaDB dataset with persistent client for testing."""
-    # Use unique collection name to avoid test interference
-    unique_name = f"test_collection_{uuid.uuid4().hex[:8]}"
-    return ChromaDBDataset(
-        collection_name=unique_name,
-        client_type="persistent",
-        client_settings={"path": str(tmp_path / "test_chroma_db")}
-    )
+def store(dataset):
+    return dataset.load()
 
 
-class TestChromaDBDataset:
-    """Test suite for ChromaDBDataset."""
+@pytest.fixture
+def sample_records():
+    return [
+        {
+            "id": "doc1",
+            "properties": {"document": "A document about machine learning", "topic": "ml"},
+            "vector": [1.0, 0.0, 0.0],
+        },
+        {
+            "id": "doc2",
+            "properties": {"document": "A document about data science", "topic": "ds"},
+            "vector": [0.0, 1.0, 0.0],
+        },
+        {
+            "id": "doc3",
+            "properties": {"document": "A document about AI", "topic": "ai"},
+            "vector": [0.0, 0.0, 1.0],
+        },
+    ]
 
-    def test_save_and_load(self, chromadb_dataset, sample_data):
-        """Test saving and loading data."""
-        # Save data
-        chromadb_dataset.save(sample_data)
 
-        # Load data back
-        loaded_data = chromadb_dataset.load()
+# ---------------------------------------------------------------------------
+# ChromaDBDataset — init and describe
+# ---------------------------------------------------------------------------
 
-        # Verify the data
-        assert loaded_data["documents"] == sample_data["documents"]
-        assert loaded_data["ids"] == sample_data["ids"]
-        assert loaded_data["metadatas"] == sample_data["metadatas"]
 
-    def test_exists(self, chromadb_dataset, sample_data):
-        """Test the exists method."""
-        # Initially, collection shouldn't exist or be empty
-        assert not chromadb_dataset.exists()
+class TestDatasetInit:
+    def test_defaults(self, dataset, collection_name):
+        assert dataset._collection_name == collection_name
+        assert dataset._client_type == "ephemeral"
+        assert dataset._client_settings == {}
+        assert dataset._create_collection_if_missing is True
+        assert dataset.metadata is None
 
-        # After saving data, it should exist
-        chromadb_dataset.save(sample_data)
-        assert chromadb_dataset.exists()
-
-    def test_save_without_required_fields(self, chromadb_dataset):
-        """Test saving data without required fields raises error."""
-        # Missing 'ids'
-        invalid_data = {"documents": ["test doc"]}
-        with pytest.raises(DatasetError, match="Data must contain 'documents' and 'ids' keys"):
-            chromadb_dataset.save(invalid_data)
-
-        # Missing 'documents'
-        invalid_data = {"ids": ["doc1"]}
-        with pytest.raises(DatasetError, match="Data must contain 'documents' and 'ids' keys"):
-            chromadb_dataset.save(invalid_data)
-
-    def test_save_non_dict_data(self, chromadb_dataset):
-        """Test saving non-dictionary data raises error."""
-        with pytest.raises(DatasetError, match="Data must be a dictionary"):
-            chromadb_dataset.save(["not", "a", "dict"])
-
-    @pytest.mark.skip(reason="Skipping for now, need to investigate")
-    def test_vector_similarity_query(self, chromadb_dataset, sample_data):
-        """Test vector similarity queries without loading entire collection."""
-        # Save initial data
-        chromadb_dataset.save(sample_data)
-
-        # Create a new dataset instance with query args for similarity search
-        query_dataset = ChromaDBDataset(
-            collection_name=chromadb_dataset._collection_name,
-            client_type="ephemeral",
-            load_args={
-                "query_texts": ["machine learning"],
-                "n_results": 2,
-                "include": ["documents", "metadatas", "distances"]
-            }
-        )
-
-        # Load with vector query - should return limited results based on similarity
-        results = query_dataset.load()
-
-        # Should return limited results (not the entire collection)
-        assert len(results["documents"]) <= 2
-        assert "distances" in results  # Query results include distances
-
-        # Verify it's actually a similarity search result
-        assert isinstance(results["documents"], list)
-        if results["documents"]:
-            # Should contain documents similar to "machine learning"
-            assert any("machine" in doc.lower() or "learning" in doc.lower()
-                      for doc in results["documents"])
-
-    def test_load_with_query_args(self, chromadb_dataset, sample_data):
-        """Test loading data with query arguments."""
-        # Save initial data
-        chromadb_dataset.save(sample_data)
-
-        # Use the same dataset instance to load with limit
-        # Create a new dataset instance with load args using same collection name
-        dataset_with_query = ChromaDBDataset(
-            collection_name=chromadb_dataset._collection_name,
-            client_type="ephemeral",
-            load_args={"limit": 2}  # Use limit instead of n_results for get() method
-        )
-
-        # Load with query - should return limited results
-        loaded_data = dataset_with_query.load()
-        assert len(loaded_data["documents"]) <= 2
-
-    def test_save_with_embeddings(self, chromadb_dataset):
-        """Test saving data with custom embeddings."""
-        # First save some data to establish the embedding dimension
-        initial_data = {
-            "documents": ["Initial document"],
-            "ids": ["initial_doc"]
-        }
-        chromadb_dataset.save(initial_data)
-
-        # Now try with custom embeddings that match the established dimension
-        # ChromaDB uses 384-dim embeddings by default, so skip this test
-        # or use a collection with compatible embedding function
-        data_with_embeddings = {
-            "documents": ["Test document"],
-            "ids": ["doc1"],
-            # Skip custom embeddings as they need to match the embedding function dimension
-        }
-
-        # Should not raise an error
-        chromadb_dataset.save(data_with_embeddings)
-
-        # Verify data was saved
-        loaded_data = chromadb_dataset.load()
-        assert "Test document" in loaded_data["documents"]
-        assert "doc1" in loaded_data["ids"]
-
-    def test_persistent_client(self, persistent_chromadb_dataset, sample_data):
-        """Test ChromaDB with persistent client."""
-        # Save data
-        persistent_chromadb_dataset.save(sample_data)
-
-        # Load data back
-        loaded_data = persistent_chromadb_dataset.load()
-
-        # Verify the data
-        assert loaded_data["documents"] == sample_data["documents"]
-        assert loaded_data["ids"] == sample_data["ids"]
-
-    def test_describe(self, chromadb_dataset):
-        """Test the describe method."""
-        description = chromadb_dataset._describe()
-
-        assert description["collection_name"] == chromadb_dataset._collection_name
-        assert description["client_type"] == "ephemeral"
-        assert isinstance(description["client_settings"], dict)
-        assert isinstance(description["load_args"], dict)
-        assert isinstance(description["save_args"], dict)
-
-    def test_invalid_client_type(self):
-        """Test invalid client type raises error."""
-        dataset = ChromaDBDataset(
-            collection_name="test",
-            client_type="invalid"
-        )
-        # Error should be raised when we try to use the dataset (lazy loading)
-        with pytest.raises(DatasetError, match="Unsupported client_type: invalid"):
-            dataset._get_client()
-
-    def test_http_client_config(self):
-        """Test HTTP client configuration without connecting."""
-        # This test creates the dataset but doesn't trigger client creation
-        # since we don't have a real HTTP server running
-        dataset = ChromaDBDataset(
-            collection_name="test_collection",
+    def test_custom_params(self):
+        ds = ChromaDBDataset(
+            collection_name="X",
             client_type="http",
-            client_settings={"host": "localhost", "port": 8000}
+            client_settings={"host": "myhost", "port": 9000},
+            create_collection_if_missing=False,
+            metadata={"owner": "team-a"},
         )
+        assert ds._client_type == "http"
+        assert ds._client_settings == {"host": "myhost", "port": 9000}
+        assert ds._create_collection_if_missing is False
+        assert ds.metadata == {"owner": "team-a"}
 
-        # Test the configuration is stored correctly
-        description = dataset._describe()
-        assert description["client_type"] == "http"
-        assert description["client_settings"]["host"] == "localhost"
-        assert description["client_settings"]["port"] == 8000
+    def test_none_settings_become_empty(self):
+        ds = ChromaDBDataset(collection_name="X", client_settings=None)
+        assert ds._client_settings == {}
 
-        # Test that the client is not created yet (lazy initialization)
-        assert dataset._client is None
 
-    def test_metadata_handling(self, chromadb_dataset, sample_data):
-        """Test that metadata is properly handled."""
-        # Create dataset with metadata
-        dataset_with_metadata = ChromaDBDataset(
-            collection_name="test_collection",
-            client_type="ephemeral",
-            metadata={"version": "1.0", "description": "Test dataset"}
+class TestDescribe:
+    def test_describe(self, dataset, collection_name):
+        assert dataset._describe() == {
+            "collection_name": collection_name,
+            "client_type": "ephemeral",
+            "create_collection_if_missing": True,
+        }
+
+    def test_describe_omits_client_settings(self):
+        # http client_settings can carry authentication headers
+        ds = ChromaDBDataset(
+            collection_name="X",
+            client_type="http",
+            client_settings={"headers": {"Authorization": "Bearer token"}},
         )
+        desc = ds._describe()
+        assert "client_settings" not in desc
+        assert "token" not in str(desc)
 
-        # Metadata should be stored
-        assert dataset_with_metadata.metadata == {"version": "1.0", "description": "Test dataset"}
 
-        # Normal operations should still work
-        dataset_with_metadata.save(sample_data)
-        loaded_data = dataset_with_metadata.load()
-        assert loaded_data["documents"] == sample_data["documents"]
+# ---------------------------------------------------------------------------
+# ChromaDBDataset — save() disabled
+# ---------------------------------------------------------------------------
 
-    def test_collection_reuse(self, sample_data):
-        """Test that multiple dataset instances can use the same collection."""
-        # Use a unique collection name for this test
-        collection_name = f"shared_collection_{uuid.uuid4().hex[:8]}"
 
-        # Create two dataset instances pointing to the same collection
-        dataset1 = ChromaDBDataset(collection_name=collection_name, client_type="ephemeral")
-        dataset2 = ChromaDBDataset(collection_name=collection_name, client_type="ephemeral")
+class TestSaveDisabled:
+    def test_save_raises(self, dataset):
+        with pytest.raises(DatasetError, match="Saving is not supported"):
+            dataset.save({"documents": ["x"], "ids": ["1"]})
 
-        # Save data with first dataset
-        dataset1.save(sample_data)
 
-        # For ephemeral clients, different instances don't share collections
-        # This test verifies the pattern works for persistent clients
-        # With ephemeral clients, this is expected behavior
-        try:
-            loaded_data = dataset2.load()
-            # If it works, verify the data (this would work with persistent clients)
-            assert loaded_data["documents"] == sample_data["documents"]
-        except Exception:
-            # Ephemeral clients don't share collections, which is expected
-            # This test demonstrates the difference between client types
-            pass
+# ---------------------------------------------------------------------------
+# ChromaDBDataset — client creation
+# ---------------------------------------------------------------------------
 
-    def test_empty_collection_load(self, chromadb_dataset):
-        """Test loading from an empty collection."""
-        # First create an empty collection by accessing it
-        chromadb_dataset._get_collection()
 
-        # Load from empty collection should return empty lists
-        loaded_data = chromadb_dataset.load()
+class TestCreateClient:
+    def test_ephemeral(self, dataset):
+        with patch(f"{MODULE}.chromadb.EphemeralClient") as p:
+            dataset._create_client()
+            p.assert_called_once_with()
 
-        assert loaded_data["documents"] == []
-        assert loaded_data["ids"] == []
-        assert loaded_data["metadatas"] == []
-        # Check embeddings length instead of direct comparison (avoids numpy array comparison issue)
-        assert len(loaded_data["embeddings"]) == 0
+    def test_persistent_default_path(self, collection_name):
+        ds = ChromaDBDataset(collection_name=collection_name, client_type="persistent")
+        with patch(f"{MODULE}.chromadb.PersistentClient") as p:
+            ds._create_client()
+            p.assert_called_once_with(path="./chroma_db")
+
+    def test_persistent_custom_path(self, collection_name, tmp_path):
+        ds = ChromaDBDataset(
+            collection_name=collection_name,
+            client_type="persistent",
+            client_settings={"path": str(tmp_path)},
+        )
+        with patch(f"{MODULE}.chromadb.PersistentClient") as p:
+            ds._create_client()
+            p.assert_called_once_with(path=str(tmp_path))
+
+    def test_ephemeral_settings_forwarded(self, collection_name):
+        ds = ChromaDBDataset(
+            collection_name=collection_name,
+            client_settings={"tenant": "my_tenant"},
+        )
+        with patch(f"{MODULE}.chromadb.EphemeralClient") as p:
+            ds._create_client()
+            p.assert_called_once_with(tenant="my_tenant")
+
+    def test_http_defaults_and_extras(self, collection_name):
+        ds = ChromaDBDataset(
+            collection_name=collection_name,
+            client_type="http",
+            client_settings={"host": "myhost", "ssl": True},
+        )
+        with patch(f"{MODULE}.chromadb.HttpClient") as p:
+            ds._create_client()
+            p.assert_called_once_with(host="myhost", port=8000, ssl=True)
+
+    def test_http_default_host_and_custom_port(self, collection_name):
+        ds = ChromaDBDataset(
+            collection_name=collection_name,
+            client_type="http",
+            client_settings={"port": 9000},
+        )
+        with patch(f"{MODULE}.chromadb.HttpClient") as p:
+            ds._create_client()
+            p.assert_called_once_with(host="localhost", port=9000)
+
+    def test_unsupported_type_raises(self, collection_name):
+        ds = ChromaDBDataset(
+            collection_name=collection_name,
+            client_type="grpc",  # type: ignore[arg-type]
+        )
+        with pytest.raises(DatasetError, match="Unsupported client_type"):
+            ds._create_client()
+
+    def test_settings_not_mutated(self, collection_name, tmp_path):
+        settings = {"path": str(tmp_path)}
+        ds = ChromaDBDataset(
+            collection_name=collection_name,
+            client_type="persistent",
+            client_settings=settings,
+        )
+        with patch(f"{MODULE}.chromadb.PersistentClient"):
+            ds._create_client()
+        assert settings == {"path": str(tmp_path)}
+
+
+# ---------------------------------------------------------------------------
+# ChromaDBDataset — load()
+# ---------------------------------------------------------------------------
+
+
+class TestLoad:
+    def test_load_returns_handle(self, dataset):
+        handle = dataset.load()
+        assert isinstance(handle, ChromaVectorStoreHandle)
+
+    def test_load_creates_missing_collection(self, dataset, collection_name):
+        handle = dataset.load()
+        assert handle.describe() == {"collection": collection_name, "count": 0}
+
+    def test_load_missing_collection_raises_when_no_create(self, collection_name):
+        ds = ChromaDBDataset(
+            collection_name=collection_name, create_collection_if_missing=False
+        )
+        with pytest.raises(DatasetError, match="does not exist"):
+            ds.load()
+
+    def test_load_gets_existing_collection_when_no_create(
+        self, dataset, collection_name, sample_records
+    ):
+        dataset.load().add(sample_records)
+        ds = ChromaDBDataset(
+            collection_name=collection_name, create_collection_if_missing=False
+        )
+        assert ds.load().describe()["count"] == 3
+
+    def test_load_wraps_client_errors(self, dataset):
+        mock_client = MagicMock()
+        mock_client.get_or_create_collection.side_effect = RuntimeError("boom")
+        with patch.object(dataset, "_create_client", return_value=mock_client):
+            with pytest.raises(DatasetError, match="Failed to access Chroma collection"):
+                dataset.load()
+
+
+# ---------------------------------------------------------------------------
+# ChromaVectorStoreHandle — lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestHandleLifecycle:
+    def test_raw_client(self, store):
+        assert isinstance(store.raw_client, chromadb.api.ClientAPI)
+
+    def test_close_calls_client_close_when_owned(self):
+        mock_client = MagicMock()
+        handle = ChromaVectorStoreHandle(mock_client, MagicMock(), close_client=True)
+        handle.close()
+        mock_client.close.assert_called_once()
+
+    def test_close_is_idempotent(self):
+        mock_client = MagicMock()
+        handle = ChromaVectorStoreHandle(mock_client, MagicMock(), close_client=True)
+        handle.close()
+        handle.close()
+        mock_client.close.assert_called_once()
+
+    def test_close_is_noop_for_ephemeral(self, store):
+        # Ephemeral handles must not close the process-shared client.
+        assert store._close_client is False
+        with patch.object(store._client, "close") as mock_close:
+            store.close()
+        mock_close.assert_not_called()
+
+    def test_persistent_load_closes_client(self, collection_name, tmp_path):
+        ds = ChromaDBDataset(
+            collection_name=collection_name,
+            client_type="persistent",
+            client_settings={"path": str(tmp_path / "chroma")},
+        )
+        handle = ds.load()
+        assert handle._close_client is True
+        handle.close()
+
+    def test_context_manager_returns_self_and_closes(self, store):
+        with store as s:
+            assert s is store
+        assert store._closed is True
+
+    def test_ephemeral_operations_work_after_context_exit(self, store, sample_records):
+        # close() is a documented no-op for ephemeral clients.
+        with store:
+            store.add(sample_records)
+        assert store.describe()["count"] == 3
+
+
+# ---------------------------------------------------------------------------
+# ChromaVectorStoreHandle — add()
+# ---------------------------------------------------------------------------
+
+
+class TestHandleAdd:
+    def test_add_returns_ids_in_input_order(self, store, sample_records):
+        assert store.add(sample_records) == ["doc1", "doc2", "doc3"]
+
+    def test_add_generates_ids_when_missing(self, store):
+        ids = store.add(
+            [
+                {"properties": {"document": "no id"}, "vector": [1.0, 0.0, 0.0]},
+                {"properties": {"document": "also no id"}, "vector": [0.0, 1.0, 0.0]},
+            ]
+        )
+        assert len(ids) == 2
+        assert all(isinstance(record_id, str) and record_id for record_id in ids)
+        assert ids[0] != ids[1]
+
+    def test_add_maps_document_and_metadata(self, store, sample_records):
+        store.add(sample_records)
+        stored = store._collection.get(ids=["doc1"], include=["documents", "metadatas"])
+        assert stored["documents"] == ["A document about machine learning"]
+        assert stored["metadatas"] == [{"topic": "ml"}]
+
+    def test_add_vector_only_records(self, store):
+        ids = store.add([{"properties": {"topic": "ml"}, "vector": [1.0, 0.0, 0.0]}])
+        assert store.describe()["count"] == 1
+        stored = store._collection.get(ids=ids, include=["documents", "metadatas"])
+        assert stored["documents"] == [None]
+        assert stored["metadatas"] == [{"topic": "ml"}]
+
+    def test_add_document_only_properties(self, store):
+        # properties with only a document -> empty metadata must become None
+        ids = store.add(
+            [{"properties": {"document": "just text"}, "vector": [1.0, 0.0, 0.0]}]
+        )
+        stored = store._collection.get(ids=ids, include=["documents", "metadatas"])
+        assert stored["documents"] == ["just text"]
+        assert stored["metadatas"] == [None]
+
+    def test_add_without_properties_key(self, store):
+        ids = store.add([{"vector": [1.0, 0.0, 0.0]}])
+        assert len(ids) == 1
+        assert store.describe()["count"] == 1
+
+    def test_add_with_none_properties(self, store):
+        ids = store.add([{"properties": None, "vector": [1.0, 0.0, 0.0]}])
+        assert len(ids) == 1
+        assert store.describe()["count"] == 1
+
+    def test_add_heterogeneous_batch(self, store):
+        # One record with document+metadata, one with neither.
+        ids = store.add(
+            [
+                {
+                    "id": "full",
+                    "properties": {"document": "text", "topic": "ml"},
+                    "vector": [1.0, 0.0, 0.0],
+                },
+                {"id": "bare", "properties": {}, "vector": [0.0, 1.0, 0.0]},
+            ]
+        )
+        assert ids == ["full", "bare"]
+        stored = store._collection.get(ids=ids, include=["documents", "metadatas"])
+        by_id = dict(zip(stored["ids"], zip(stored["documents"], stored["metadatas"])))
+        assert by_id["full"] == ("text", {"topic": "ml"})
+        assert by_id["bare"] == (None, None)
+
+    def test_add_existing_id_raises(self, store, sample_records):
+        store.add(sample_records)
+        with pytest.raises(DatasetError, match="already[\\s\\S]*exists"):
+            store.add(
+                [{"id": "doc1", "properties": {"document": "replacement"},
+                  "vector": [0.5, 0.5, 0.0]}]
+            )
+        # Original record untouched
+        stored = store._collection.get(ids=["doc1"], include=["documents"])
+        assert stored["documents"] == ["A document about machine learning"]
+
+    def test_add_mixed_new_and_existing_ids_writes_nothing(self, store, sample_records):
+        store.add(sample_records)
+        with pytest.raises(DatasetError, match="doc1"):
+            store.add(
+                [
+                    {"id": "doc1", "properties": {"document": "stale"},
+                     "vector": [0.5, 0.5, 0.0]},
+                    {"id": "doc4", "properties": {"document": "new"},
+                     "vector": [0.0, 0.5, 0.5]},
+                ]
+            )
+        assert store.describe()["count"] == 3
+
+    def test_add_empty_string_id_rejected(self, store):
+        # "" is passed through to Chroma, which rejects empty IDs.
+        with pytest.raises(DatasetError, match="add\\(\\) failed"):
+            store.add(
+                [{"id": "", "properties": {"document": "x"}, "vector": [1.0, 0.0, 0.0]}]
+            )
+
+    def test_add_empty_list_returns_empty(self, store):
+        assert store.add([]) == []
+        assert store.describe()["count"] == 0
+
+    def test_add_mixed_vectors_raises(self, store):
+        with pytest.raises(DatasetError, match="all records or no records"):
+            store.add(
+                [
+                    {"properties": {"document": "a"}, "vector": [1.0, 0.0, 0.0]},
+                    {"properties": {"document": "b"}},
+                ]
+            )
+
+    def test_add_does_not_mutate_input(self, store):
+        record = {
+            "id": "u1",
+            "properties": {"document": "hello", "topic": "ml"},
+            "vector": [1.0, 0.0, 0.0],
+        }
+        store.add([record])
+        assert record == {
+            "id": "u1",
+            "properties": {"document": "hello", "topic": "ml"},
+            "vector": [1.0, 0.0, 0.0],
+        }
+
+    def test_add_wraps_chroma_exception(self, store):
+        with patch.object(
+            store._collection, "add", side_effect=RuntimeError("disk full")
+        ):
+            with pytest.raises(DatasetError, match="add\\(\\) failed"):
+                store.add([{"properties": {"document": "x"}, "vector": [1.0, 0.0, 0.0]}])
+
+    def test_add_wrong_vector_dims_error_wrapped(self, store, sample_records):
+        store.add(sample_records)
+        with pytest.raises(DatasetError, match="add\\(\\) failed"):
+            store.add([{"properties": {"document": "bad dims"}, "vector": [1.0]}])
+
+
+# ---------------------------------------------------------------------------
+# ChromaVectorStoreHandle — delete()
+# ---------------------------------------------------------------------------
+
+
+class TestHandleDelete:
+    def test_delete_by_ids(self, store, sample_records):
+        store.add(sample_records)
+        store.delete(ids=["doc1", "doc2"])
+        assert store.describe()["count"] == 1
+
+    def test_delete_by_filters(self, store, sample_records):
+        store.add(sample_records)
+        store.delete(filters={"topic": "ml"})
+        assert store.describe()["count"] == 2
+
+    def test_delete_empty_ids_is_noop(self, store, sample_records):
+        store.add(sample_records)
+        store.delete(ids=[])
+        assert store.describe()["count"] == 3
+
+    def test_delete_requires_ids_or_filters(self, store):
+        with pytest.raises(DatasetError, match="requires exactly one"):
+            store.delete()
+
+    def test_delete_rejects_both(self, store):
+        with pytest.raises(DatasetError, match="not both"):
+            store.delete(ids=["doc1"], filters={"topic": "ml"})
+
+    def test_delete_wraps_chroma_exception(self, store):
+        with patch.object(
+            store._collection, "delete", side_effect=RuntimeError("connection lost")
+        ):
+            with pytest.raises(DatasetError, match="delete\\(\\) failed"):
+                store.delete(ids=["doc1"])
+
+
+# ---------------------------------------------------------------------------
+# ChromaVectorStoreHandle — search()
+# ---------------------------------------------------------------------------
+
+
+class TestHandleSearch:
+    def test_search_by_vector_returns_formatted_results(self, store, sample_records):
+        store.add(sample_records)
+        results = store.search(vector=[1.0, 0.0, 0.0], top_k=1)
+        assert len(results) == 1
+        assert results[0]["id"] == "doc1"
+        assert results[0]["properties"] == {
+            "document": "A document about machine learning",
+            "topic": "ml",
+        }
+        assert results[0]["distance"] == pytest.approx(0.0)
+
+    def test_search_respects_top_k(self, store, sample_records):
+        store.add(sample_records)
+        assert len(store.search(vector=[1.0, 0.0, 0.0], top_k=2)) == 2
+
+    def test_search_empty_collection_returns_empty(self, store):
+        assert store.search(vector=[1.0, 0.0, 0.0], top_k=5) == []
+
+    def test_search_top_k_above_count_returns_all(self, store, sample_records):
+        store.add(sample_records)
+        assert len(store.search(vector=[1.0, 0.0, 0.0], top_k=50)) == 3
+
+    def test_search_with_filters(self, store, sample_records):
+        store.add(sample_records)
+        results = store.search(vector=[1.0, 0.0, 0.0], top_k=3, filters={"topic": "ds"})
+        assert [hit["id"] for hit in results] == ["doc2"]
+
+    def test_search_result_without_document(self, store):
+        ids = store.add([{"properties": {"topic": "ml"}, "vector": [1.0, 0.0, 0.0]}])
+        results = store.search(vector=[1.0, 0.0, 0.0], top_k=1)
+        assert results[0]["id"] == ids[0]
+        assert results[0]["properties"] == {"topic": "ml"}
+        assert "document" not in results[0]["properties"]
+
+    def test_search_by_text_uses_query_texts(self, store):
+        # Mocked: real text search would download the default embedding model.
+        fake_result = {
+            "ids": [["doc1"]],
+            "documents": [["hello"]],
+            "metadatas": [[{"topic": "ml"}]],
+            "distances": [[0.25]],
+        }
+        with patch.object(
+            store._collection, "query", return_value=fake_result
+        ) as mock_query:
+            results = store.search(text="machine learning", top_k=5)
+        mock_query.assert_called_once_with(
+            n_results=5, where=None, query_texts=["machine learning"]
+        )
+        assert results == [
+            {
+                "id": "doc1",
+                "properties": {"topic": "ml", "document": "hello"},
+                "distance": 0.25,
+            }
+        ]
+
+    def test_search_requires_vector_or_text(self, store):
+        with pytest.raises(DatasetError, match="requires exactly one"):
+            store.search()
+
+    def test_search_rejects_both(self, store):
+        with pytest.raises(DatasetError, match="not both"):
+            store.search(vector=[1.0, 0.0, 0.0], text="query")
+
+    def test_search_wraps_chroma_exception(self, store):
+        with patch.object(
+            store._collection, "query", side_effect=RuntimeError("index error")
+        ):
+            with pytest.raises(DatasetError, match="search\\(\\) failed"):
+                store.search(vector=[1.0, 0.0, 0.0])
+
+
+# ---------------------------------------------------------------------------
+# End-to-end roundtrip
+# ---------------------------------------------------------------------------
+
+
+class TestRoundtrip:
+    def test_add_search_delete_roundtrip(self, store, sample_records):
+        ids = store.add(sample_records)
+        assert store.describe()["count"] == 3
+
+        hits = store.search(vector=[0.0, 1.0, 0.0], top_k=1)
+        assert hits[0]["id"] == "doc2"
+        assert hits[0]["properties"]["topic"] == "ds"
+
+        store.delete(ids=ids)
+        assert store.describe()["count"] == 0
+
+    def test_persistent_roundtrip(self, collection_name, tmp_path, sample_records):
+        ds = ChromaDBDataset(
+            collection_name=collection_name,
+            client_type="persistent",
+            client_settings={"path": str(tmp_path / "chroma")},
+        )
+        ds.load().add(sample_records)
+
+        # A fresh load against the same path sees the persisted data.
+        assert ds.load().describe()["count"] == 3

--- a/kedro-datasets/pyproject.toml
+++ b/kedro-datasets/pyproject.toml
@@ -217,8 +217,7 @@ yaml = ["kedro-datasets[yaml-yamldataset]"]
 chromadb-dataset = ["chromadb>=1.0.0"]
 chromadb = ["kedro-datasets[chromadb-dataset]"]
 
-# numpy cap: numba (pulled in via darts -> shap) does not support numpy 2.5 yet
-darts-torch-model-dataset = ["u8darts[all]", "numpy<2.5"]
+darts-torch-model-dataset = ["u8darts[all]"]
 darts = ["kedro-datasets[darts-torch-model-dataset]"]
 databricks-externaltabledataset = ["kedro-datasets[hdfs-base,s3fs-base]"]
 langchain-promptdataset = ["langchain>=0.3.0"]
@@ -393,7 +392,6 @@ experimental = [
     "opik",
     "optuna",
     "u8darts[all]",
-    "numpy<2.5",  # numba (pulled in via darts -> shap) does not support numpy 2.5 yet
     "pypdf>=3.0.0",
     "polars>=1.0",
     "SQLAlchemy>=1.4",
@@ -427,7 +425,6 @@ experimental_test = [
     "pytest-xdist[psutil]~=2.2.1",
     "pytest~=7.2",
     "u8darts[all]",
-    "numpy<2.5",  # numba (pulled in via darts -> shap) does not support numpy 2.5 yet
     "pypdf>=3.0.0",
     "moto==5.0.0",
     "gcsfs>=2023.1",

--- a/kedro-datasets/pyproject.toml
+++ b/kedro-datasets/pyproject.toml
@@ -217,7 +217,8 @@ yaml = ["kedro-datasets[yaml-yamldataset]"]
 chromadb-dataset = ["chromadb>=1.0.0"]
 chromadb = ["kedro-datasets[chromadb-dataset]"]
 
-darts-torch-model-dataset = ["u8darts[all]"]
+# numpy cap: numba (pulled in via darts -> shap) does not support numpy 2.5 yet
+darts-torch-model-dataset = ["u8darts[all]", "numpy<2.5"]
 darts = ["kedro-datasets[darts-torch-model-dataset]"]
 databricks-externaltabledataset = ["kedro-datasets[hdfs-base,s3fs-base]"]
 langchain-promptdataset = ["langchain>=0.3.0"]
@@ -392,6 +393,7 @@ experimental = [
     "opik",
     "optuna",
     "u8darts[all]",
+    "numpy<2.5",  # numba (pulled in via darts -> shap) does not support numpy 2.5 yet
     "pypdf>=3.0.0",
     "polars>=1.0",
     "SQLAlchemy>=1.4",
@@ -425,6 +427,7 @@ experimental_test = [
     "pytest-xdist[psutil]~=2.2.1",
     "pytest~=7.2",
     "u8darts[all]",
+    "numpy<2.5",  # numba (pulled in via darts -> shap) does not support numpy 2.5 yet
     "pypdf>=3.0.0",
     "moto==5.0.0",
     "gcsfs>=2023.1",

--- a/kedro-datasets/pyproject.toml
+++ b/kedro-datasets/pyproject.toml
@@ -214,8 +214,8 @@ yaml-yamldataset = ["kedro-datasets[pandas-base]", "PyYAML>=4.2, <7.0"]
 yaml = ["kedro-datasets[yaml-yamldataset]"]
 
 # Experimental Datasets
-chromadb-chromadbdataset = ["chromadb>=1.0.0"]
-chromadb = ["kedro-datasets[chromadb-chromadbdataset]"]
+chromadb-dataset = ["chromadb>=1.0.0"]
+chromadb = ["kedro-datasets[chromadb-dataset]"]
 
 darts-torch-model-dataset = ["u8darts[all]"]
 darts = ["kedro-datasets[darts-torch-model-dataset]"]


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
Related to: #1352

Refactors the experimental `ChromaDBDataset` onto the `VectorStoreHandle` abstraction from #1430, following the pattern set by `WeaviateVectorStoreDataset` (#1444).

## Development notes
<!-- What have you changed, and how has this been tested? -->

- `load()` now returns a `ChromaVectorStoreHandle` instead of collection data; `save()` is disabled as all writes go through the handle (`add()`, `delete()`).
- The handle implements `add()` / `search()` / `delete()` / `describe()` / `close()` and exposes the Chroma client via `raw_client`.
- Records follow the shared format: {"properties": dict, "vector": [...], "id": str}. The reserved "document" key inside properties maps to Chroma's documents field; other keys become metadata. search() merges them back, so what you add is what you get back.
- Backend-native filters: `search()`/`delete()` take Chroma where dicts directly.
- Breaking (experimental): load_args/save_args removed; extras group renamed chromadb-chromadbdataset → chromadb-dataset to match the weaviate-dataset convention.

## Test
```
pip install "kedro-datasets[chromadb-dataset] @ ." pytest
pytest kedro_datasets_experimental/tests/chromadb/
```


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [ ] Updated `jsonschema/kedro-catalog-X.XX.json` if necessary
- [x] Added a description of this change in the relevant `RELEASE.md` file
- [x] Added tests to cover my changes
- [ ] Received approvals from at least half of the TSC (required for adding a new, non-experimental dataset)
