### PR TITLE
chore(telemetry): Bump kedro version for dependabot alerts

### DIFF
--- a/kedro-telemetry/tests/integration/dummy-project/requirements.txt
+++ b/kedro-telemetry/tests/integration/dummy-project/requirements.txt
@@ -1,6 +1,6 @@
 ipython>=8.10
 jupyterlab>=3.0
-kedro~=0.19.6
+kedro~=1.5.0
 kedro-datasets[pandas-csvdataset, pandas-exceldataset, pandas-parquetdataset]>=3.0; python_version >= "3.10"
 kedro-telemetry>=0.3.1
 kedro-viz>=6.7.0

--- a/kedro-telemetry/tests/integration/dummy-project/requirements.txt
+++ b/kedro-telemetry/tests/integration/dummy-project/requirements.txt
@@ -1,6 +1,6 @@
 ipython>=8.10
 jupyterlab>=3.0
-kedro~=1.5.0
+kedro>=1.3.0
 kedro-datasets[pandas-csvdataset, pandas-exceldataset, pandas-parquetdataset]>=3.0; python_version >= "3.10"
 kedro-telemetry>=0.3.1
 kedro-viz>=6.7.0


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
Noticed these dependabot alerts https://github.com/kedro-org/kedro-plugins/security/dependabot

This should hopefully get rid of them!

## Development notes
<!-- What have you changed, and how has this been tested? -->

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Updated `jsonschema/kedro-catalog-X.XX.json` if necessary
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
- [ ] Received approvals from at least half of the TSC (required for adding a new, non-experimental dataset)
