### PR TITLE
docs(datasets): Potential fix for code scanning alert no. 34: DOM text reinterpreted as HTML

### DIFF
--- a/.github/workflows/validate-pr-title.yaml
+++ b/.github/workflows/validate-pr-title.yaml
@@ -6,12 +6,10 @@ on:
       - opened
       - edited
       - synchronize
-      - ready_for_review
 
 jobs:
   main:
     name: Validate PR title
-    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     steps:
       - uses: amannn/action-semantic-pull-request@v5

--- a/.github/workflows/validate-pr-title.yaml
+++ b/.github/workflows/validate-pr-title.yaml
@@ -6,10 +6,12 @@ on:
       - opened
       - edited
       - synchronize
+      - ready_for_review
 
 jobs:
   main:
     name: Validate PR title
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     steps:
       - uses: amannn/action-semantic-pull-request@v5

--- a/kedro-datasets/docs/javascript/source-links.js
+++ b/kedro-datasets/docs/javascript/source-links.js
@@ -27,11 +27,28 @@ document.addEventListener('DOMContentLoaded', function() {
 
         if (filePath) {
             // Remove any existing kedro-datasets/ prefix to avoid duplication
-            filePath = filePath.replace(/^kedro-datasets\//, '');
-            return filePath;
+            filePath = filePath.replace(/^kedro-datasets\//, '').trim();
+
+            // Allow only safe relative Python source paths
+            const isValidRelativePyPath = /^[A-Za-z0-9._/-]+\.py$/.test(filePath)
+                && !filePath.startsWith('/')
+                && !filePath.includes('..')
+                && !filePath.includes('\\');
+
+            if (isValidRelativePyPath) {
+                return filePath;
+            }
         }
 
         return null;
+    }
+
+    function buildGithubSourceUrl(filePath) {
+        const encodedPath = filePath
+            .split('/')
+            .map(segment => encodeURIComponent(segment))
+            .join('/');
+        return `https://github.com/kedro-org/kedro-plugins/blob/main/kedro-datasets/${encodedPath}`;
     }
 
     // Add [source] buttons to class signatures
@@ -83,7 +100,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 }
 
                 if (sourceFilePath) {
-                    const githubUrl = `https://github.com/kedro-org/kedro-plugins/blob/main/kedro-datasets/${sourceFilePath}`;
+                    const githubUrl = buildGithubSourceUrl(sourceFilePath);
                     const sourceButton = createSourceButton(githubUrl);
 
                     // Add the button to the signature


### PR DESCRIPTION
Potential fix for [https://github.com/kedro-org/kedro-plugins/security/code-scanning/34](https://github.com/kedro-org/kedro-plugins/security/code-scanning/34)

To fix this safely without changing intended behavior, validate and normalize the extracted Python file path using a strict allowlist, and URL-encode path segments before composing the GitHub URL. This prevents DOM-derived text from being interpreted in a dangerous URL context.

Best single fix in `kedro-datasets/docs/javascript/source-links.js`:
1. In `extractFilePath`, after removing the optional `kedro-datasets/` prefix:
   - trim whitespace,
   - reject absolute paths, traversal (`..`), backslashes, or disallowed characters,
   - require `.py` suffix,
   - return only sanitized relative paths.
2. Add a helper `buildGithubSourceUrl(filePath)` that:
   - splits path into segments,
   - `encodeURIComponent` each segment,
   - rejoins with `/`,
   - prepends the fixed GitHub base.
3. Replace direct template interpolation at line 86 with `buildGithubSourceUrl(sourceFilePath)`.

No new dependency is needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
