### PR TITLE
fix(datasets): Temporarily cap numpy<2.5 so darts/experimental_test resolve again

### DIFF
--- a/kedro-datasets/RELEASE.md
+++ b/kedro-datasets/RELEASE.md
@@ -8,7 +8,6 @@
 | `weaviate.WeaviateVectorStoreDataset` | A dataset that loads a handle for adding, searching, and deleting entries in Weaviate vector database collections. | `kedro_datasets_experimental.weaviate` |
 
 ## Bug fixes and other changes
-- Temporarily capped `numpy<2.5` alongside `u8darts[all]` so the `darts` extras and `experimental_test` resolve again: `numba` (pulled in via `darts` -> `shap`) does not support numpy 2.5 yet, which made resolvers backtrack to an unbuildable 2021-era `llvmlite`. Remove the cap once numba supports numpy 2.5.
 - Fixed `MLRunModel` so user-supplied `load_args` are now passed to `joblib.load()` (previously silently dropped). Added a deserialization warning to the docstring.
 - Hardened `TensorFlowModelDataset`: `safe_mode=True` is now the default for `load_model()` to prevent arbitrary code execution from untrusted model files. Fixed a bug where `tf_device` was lost from `load_args` after the first load call.
 - Added deserialization risk warnings to docstrings of datasets that can execute arbitrary code when loading untrusted files.

--- a/kedro-datasets/RELEASE.md
+++ b/kedro-datasets/RELEASE.md
@@ -8,6 +8,7 @@
 | `weaviate.WeaviateVectorStoreDataset` | A dataset that loads a handle for adding, searching, and deleting entries in Weaviate vector database collections. | `kedro_datasets_experimental.weaviate` |
 
 ## Bug fixes and other changes
+- Temporarily capped `numpy<2.5` alongside `u8darts[all]` so the `darts` extras and `experimental_test` resolve again: `numba` (pulled in via `darts` -> `shap`) does not support numpy 2.5 yet, which made resolvers backtrack to an unbuildable 2021-era `llvmlite`. Remove the cap once numba supports numpy 2.5.
 - Fixed `MLRunModel` so user-supplied `load_args` are now passed to `joblib.load()` (previously silently dropped). Added a deserialization warning to the docstring.
 - Hardened `TensorFlowModelDataset`: `safe_mode=True` is now the default for `load_model()` to prevent arbitrary code execution from untrusted model files. Fixed a bug where `tf_device` was lost from `load_args` after the first load call.
 - Added deserialization risk warnings to docstrings of datasets that can execute arbitrary code when loading untrusted files.

--- a/kedro-datasets/pyproject.toml
+++ b/kedro-datasets/pyproject.toml
@@ -217,8 +217,7 @@ yaml = ["kedro-datasets[yaml-yamldataset]"]
 chromadb-chromadbdataset = ["chromadb>=1.0.0"]
 chromadb = ["kedro-datasets[chromadb-chromadbdataset]"]
 
-# numpy cap: numba (pulled in via darts -> shap) does not support numpy 2.5 yet
-darts-torch-model-dataset = ["u8darts[all]", "numpy<2.5"]
+darts-torch-model-dataset = ["u8darts[all]"]
 darts = ["kedro-datasets[darts-torch-model-dataset]"]
 databricks-externaltabledataset = ["kedro-datasets[hdfs-base,s3fs-base]"]
 langchain-promptdataset = ["langchain>=0.3.0"]

--- a/kedro-datasets/pyproject.toml
+++ b/kedro-datasets/pyproject.toml
@@ -217,7 +217,8 @@ yaml = ["kedro-datasets[yaml-yamldataset]"]
 chromadb-chromadbdataset = ["chromadb>=1.0.0"]
 chromadb = ["kedro-datasets[chromadb-chromadbdataset]"]
 
-darts-torch-model-dataset = ["u8darts[all]"]
+# numpy cap: numba (pulled in via darts -> shap) does not support numpy 2.5 yet
+darts-torch-model-dataset = ["u8darts[all]", "numpy<2.5"]
 darts = ["kedro-datasets[darts-torch-model-dataset]"]
 databricks-externaltabledataset = ["kedro-datasets[hdfs-base,s3fs-base]"]
 langchain-promptdataset = ["langchain>=0.3.0"]
@@ -392,6 +393,7 @@ experimental = [
     "opik",
     "optuna",
     "u8darts[all]",
+    "numpy<2.5",  # numba (pulled in via darts -> shap) does not support numpy 2.5 yet
     "pypdf>=3.0.0",
     "polars>=1.0",
     "SQLAlchemy>=1.4",
@@ -425,6 +427,7 @@ experimental_test = [
     "pytest-xdist[psutil]~=2.2.1",
     "pytest~=7.2",
     "u8darts[all]",
+    "numpy<2.5",  # numba (pulled in via darts -> shap) does not support numpy 2.5 yet
     "pypdf>=3.0.0",
     "moto==5.0.0",
     "gcsfs>=2023.1",


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
CI for kedro-datasets-experimental is currently failing.

numpy 2.5.0 released June 21. Every modern numba release requires numpy<2.5.

## Development notes
<!-- What have you changed, and how has this been tested? -->
Cap numpy<2.5 next to each u8darts[all] occurrence (the darts-torch-model-dataset extras group, experimental, experimental_test). 

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Updated `jsonschema/kedro-catalog-X.XX.json` if necessary
- [x] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
- [ ] Received approvals from at least half of the TSC (required for adding a new, non-experimental dataset)
