### PR TITLE
fix(datasets): update dill for Python 3.14 compatibility.

### DIFF
--- a/kedro-datasets/RELEASE.md
+++ b/kedro-datasets/RELEASE.md
@@ -21,6 +21,7 @@
 - Fixed `MLRunModel` so user-supplied `load_args` are now passed to `joblib.load()` (previously silently dropped). Added a deserialization warning to the docstring.
 - Hardened `TensorFlowModelDataset`: `safe_mode=True` is now the default for `load_model()` to prevent arbitrary code execution from untrusted model files. Fixed a bug where `tf_device` was lost from `load_args` after the first load call.
 - Added deserialization risk warnings to docstrings of datasets that can execute arbitrary code when loading untrusted files.
+- Updated the Python 3.14 test dependency to require `dill~=0.4.1`, fixing Hugging Face dataset doctests with Python 3.14's Pickler API.
 
 ## Community contributions
 - [samiat4911](https://github.com/samiat4911)

--- a/kedro-datasets/RELEASE.md
+++ b/kedro-datasets/RELEASE.md
@@ -21,7 +21,6 @@
 - Fixed `MLRunModel` so user-supplied `load_args` are now passed to `joblib.load()` (previously silently dropped). Added a deserialization warning to the docstring.
 - Hardened `TensorFlowModelDataset`: `safe_mode=True` is now the default for `load_model()` to prevent arbitrary code execution from untrusted model files. Fixed a bug where `tf_device` was lost from `load_args` after the first load call.
 - Added deserialization risk warnings to docstrings of datasets that can execute arbitrary code when loading untrusted files.
-- Updated the Python 3.14 test dependency to require `dill~=0.4.1`, fixing Hugging Face dataset doctests with Python 3.14's Pickler API.
 
 ## Community contributions
 - [samiat4911](https://github.com/samiat4911)

--- a/kedro-datasets/pyproject.toml
+++ b/kedro-datasets/pyproject.toml
@@ -291,7 +291,8 @@ test = [
     "deltalake>=0.10.0",
     "delta-spark>=1.0, <3.0; python_version <= '3.11'",
     "delta-spark>=4.0, <4.1; python_version >= '3.12'",
-    "dill~=0.3.1",
+    "dill~=0.3.1; python_version < '3.14'",
+    "dill~=0.4.1; python_version >= '3.14'",  # Python 3.14 Pickler compatibility
     "duckdb>=1.4.0",
     "filelock>=3.4.0, <4.0",
     "fiona>=1.8, <2.0; python_version < '3.14'",


### PR DESCRIPTION
## Description
Fixes #1468 by using `dill~=0.4.1` on Python 3.14, resolving the Hugging Face dataset doctest failures.

## Test
- All four affected doctests pass on Python 3.14.6.
- Dependency resolution verified for Python 3.13 and 3.14.

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Updated `jsonschema/kedro-catalog-X.XX.json` if necessary
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
- [ ] Received approvals from at least half of the TSC (required for adding a new, non-experimental dataset)
