### PR TITLE
feat(datasets): add PathLike support for SVMLightDataset

### DIFF
--- a/kedro-datasets/RELEASE.md
+++ b/kedro-datasets/RELEASE.md
@@ -25,6 +25,7 @@
 - Added `os.PathLike` support for `SVMLightDataset`.
 
 ## Community contributions
+- [JokeGbenro](https://github.com/JokeGbenro)
 - [samiat4911](https://github.com/samiat4911)
 - [Laurens Vijnck](https://github.com/lvijnck)
 

--- a/kedro-datasets/RELEASE.md
+++ b/kedro-datasets/RELEASE.md
@@ -22,6 +22,7 @@
 - Hardened `TensorFlowModelDataset`: `safe_mode=True` is now the default for `load_model()` to prevent arbitrary code execution from untrusted model files. Fixed a bug where `tf_device` was lost from `load_args` after the first load call.
 - Added deserialization risk warnings to docstrings of datasets that can execute arbitrary code when loading untrusted files.
 - Added `os.PathLike` support for NetworkX datasets.
+- Added `os.PathLike` support for `SVMLightDataset`.
 
 ## Community contributions
 - [samiat4911](https://github.com/samiat4911)

--- a/kedro-datasets/kedro_datasets/svmlight/svmlight_dataset.py
+++ b/kedro-datasets/kedro_datasets/svmlight/svmlight_dataset.py
@@ -4,6 +4,7 @@ underlying filesystem (e.g.: local, S3, GCS). It uses sklearn functions
 """
 from __future__ import annotations
 
+import os
 from copy import deepcopy
 from pathlib import PurePosixPath
 from typing import Any
@@ -94,7 +95,7 @@ class SVMLightDataset(AbstractVersionedDataset[_DI, _DO]):
     def __init__(  # noqa: PLR0913
         self,
         *,
-        filepath: str,
+        filepath: str | os.PathLike,
         load_args: dict[str, Any] | None = None,
         save_args: dict[str, Any] | None = None,
         version: Version | None = None,
@@ -108,6 +109,7 @@ class SVMLightDataset(AbstractVersionedDataset[_DI, _DO]):
             filepath: Filepath in POSIX format to a text file prefixed with a protocol like `s3://`.
                 If prefix is not provided, `file` protocol (local filesystem) will be used.
                 The prefix should be any protocol supported by ``fsspec``.
+                Can be a string or a PathLike object.
             load_args: Arguments passed on to ``load_svmlight_file``.
                 See the details in
                 https://scikit-learn.org/stable/modules/generated/sklearn.datasets.load_svmlight_file.html

--- a/kedro-datasets/tests/svmlight/test_svmlight_dataset.py
+++ b/kedro-datasets/tests/svmlight/test_svmlight_dataset.py
@@ -55,6 +55,16 @@ class TestSVMLightDataset:
         svm_dataset.save(dummy_data)
         assert svm_dataset.exists()
 
+    def test_pathlike_filepath(self, tmp_path, dummy_data):
+        """Test that an ``os.PathLike`` filepath is supported."""
+        filepath = tmp_path / "test.svm"
+        dataset = SVMLightDataset(filepath=filepath)
+        dataset.save(dummy_data)
+        reloaded_features, reloaded_label = dataset.load()
+        original_features, original_label = dummy_data
+        assert (original_features == reloaded_features).all()
+        assert (original_label == reloaded_label).all()
+
     @pytest.mark.parametrize(
         "save_args", [{"zero_based": False, "comment": "comment"}], indirect=True
     )


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->

Adds `os.PathLike` support for `SVMLightDataset` as part of #1316.

## Development notes
<!-- What have you changed, and how has this been tested? -->

- Updated `SVMLightDataset` to accept `str | os.PathLike` filepaths.
- Documented PathLike filepath support in the dataset docstring.
- Added a test that saves and loads SVMLight data using a `pathlib.Path`.
- Added a `RELEASE.md` entry for the change.

Validation:
- `git diff --check` passed.
- Python syntax compilation passed.


## Developer Certificate of Origin
 All commits were signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).



## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Updated `jsonschema/kedro-catalog-X.XX.json` if necessary
- [x] Added a description of this change in the relevant `RELEASE.md` file
- [x] Added tests to cover my changes
- [ ] Received approvals from at least half of the TSC (required for adding a new, non-experimental dataset)