### PR TITLE
feat(datasets): add generated catalog schema workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,7 +13,6 @@ If your PR is blocked due to unsigned commits, then you must follow the instruct
 
 - [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
 - [ ] Updated the documentation to reflect the code changes
-- [ ] Updated `jsonschema/kedro-catalog-X.XX.json` if necessary
 - [ ] Added a description of this change in the relevant `RELEASE.md` file
 - [ ] Added tests to cover my changes
 - [ ] Received approvals from at least half of the TSC (required for adding a new, non-experimental dataset)

--- a/.github/workflows/kedro-datasets.yml
+++ b/.github/workflows/kedro-datasets.yml
@@ -79,6 +79,27 @@ jobs:
           args: --max-concurrency 32 --exclude "@.lycheeignore" site/
           workingDirectory: kedro-datasets
 
+  check-schema:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: "latest"
+          python-version: "3.10"
+          activate-environment: true
+      - name: Install dependencies
+        run: |
+          uv pip install "kedro @ git+https://github.com/kedro-org/kedro@main"
+          uv pip install -e kedro-datasets
+      - name: Check generated catalog schema
+        working-directory: kedro-datasets
+        run: python -m kedro_datasets._generate_catalog_schema --check
+
   detect-secrets:
     uses: ./.github/workflows/detect-secrets.yml
     with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,6 +43,14 @@ repos:
         stages: [ manual ]
         entry: ruff check kedro-datasets --fix --exit-non-zero-on-fix
 
+      - id: generate-kedro-catalog-schema
+        name: "Generate Kedro catalog JSON schema"
+        language: system
+        files: ^kedro-datasets/(kedro_datasets/|static/jsonschema/kedro-catalog-1\.0\.0\.json)
+        pass_filenames: false
+        stages: [ manual ]
+        entry: python -c "import subprocess, sys; sys.exit(subprocess.call([sys.executable, '-m', 'kedro_datasets._generate_catalog_schema'], cwd='kedro-datasets'))"
+
       - id: ruff-kedro-airflow
         name: "Ruff on kedro_airflow/*"
         language: system

--- a/kedro-datasets/RELEASE.md
+++ b/kedro-datasets/RELEASE.md
@@ -1,14 +1,7 @@
 # Upcoming release
 
 ## Major features and improvements
-## Breaking changes
-## Breaking changes to experimental datasets
-## Bug fixes and other changes
-## Community contributions
-
-# Release 9.6.0
-
-## Major features and improvements
+- Added source-based generation and CI validation for the Kedro catalog JSON schema.
 * Added `vectorstore_base.AbstractVectorStoreDataset` and `vectorstore_base.VectorStoreHandle`, backend-agnostic abstract base classes for vector store datasets.
 - Added the following new **experimental** datasets:
 

--- a/kedro-datasets/kedro_datasets/_generate_catalog_schema.py
+++ b/kedro-datasets/kedro_datasets/_generate_catalog_schema.py
@@ -276,6 +276,8 @@ def _submodule_attrs_for(subpackage: str) -> dict[str, str]:
                 continue
             class_to_module: dict[str, str] = {}
             for key, value in zip(keyword.value.keys, keyword.value.values):
+                if key is None:
+                    continue
                 module_name = ast.literal_eval(key)
                 for class_name in ast.literal_eval(value):
                     class_to_module[class_name] = module_name

--- a/kedro-datasets/kedro_datasets/_generate_catalog_schema.py
+++ b/kedro-datasets/kedro_datasets/_generate_catalog_schema.py
@@ -48,6 +48,7 @@ _NAME_TYPE_MAP: dict[str, str] = {
     "tuple": "array",
     "Version": "object",
     "PathLike": "string",
+    "os.PathLike": "string",
     "Path": "string",
     "PurePath": "string",
     "PurePosixPath": "string",
@@ -271,8 +272,15 @@ def _dataset_spec_from_source(
                     parameters=_parameters_from_init(child),
                     docstring=ast.get_docstring(child),
                 )
+        type_id = f"{subpackage}.{class_name}"
+        if type_id not in SCHEMA_OVERRIDES:
+            raise ValueError(
+                f"{type_id} defines no __init__ method (likely inherited). "
+                "You must add a manual schema override for it in _schema_overrides.py "
+                "so that it does not silently get an empty catalog schema."
+            )
         return DatasetSpec(
-            type_id=f"{subpackage}.{class_name}",
+            type_id=type_id,
             parameters=[],
             docstring=None,
         )

--- a/kedro-datasets/kedro_datasets/_generate_catalog_schema.py
+++ b/kedro-datasets/kedro_datasets/_generate_catalog_schema.py
@@ -1,0 +1,519 @@
+"""Generate the versioned Kedro catalog JSON schema by introspection.
+
+Run as a module::
+
+    python -m kedro_datasets._generate_catalog_schema          # write the schema
+    python -m kedro_datasets._generate_catalog_schema --check  # verify it is current
+
+The schema is derived from the source-level ``__init__`` signature and docstring
+of every public dataset class exported by the ``kedro_datasets`` subpackages.
+This module is the source of truth for ``static/jsonschema/<SCHEMA_FILENAME>``;
+hand edits to that file are overwritten. Genuinely non-introspectable facts
+belong in :mod:`kedro_datasets._schema_overrides`.
+
+Generation reads Python source files instead of importing dataset classes, so it
+does not require optional dataset dependencies such as PySpark or Dask.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import inspect
+import json
+import os
+import pkgutil
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from types import UnionType
+from typing import Any, Union, get_args, get_origin, get_type_hints
+
+import kedro_datasets
+from kedro_datasets._schema_overrides import EXCLUDED_SUBPACKAGES, SCHEMA_OVERRIDES
+
+# The catalog schema is versioned by Kedro *core* version. Only the latest file
+# is auto-generated; older files are frozen. Bump this when Kedro releases a new
+# schema-affecting version.
+SCHEMA_FILENAME = "kedro-catalog-1.0.0.json"
+
+_NoneType = type(None)
+
+# Exact-type -> JSON type. Matched by identity first, then ``issubclass``.
+_TYPE_MAP: dict[type, str] = {
+    str: "string",
+    bool: "boolean",
+    int: "integer",
+    float: "number",
+    dict: "object",
+    list: "array",
+    os.PathLike: "string",
+}
+
+# Fallback keyed by annotation ``__name__`` for common non-builtin types that
+# cannot be matched by identity (e.g. Kedro's ``Version``).
+_NAME_TYPE_MAP: dict[str, str] = {
+    "str": "string",
+    "bool": "boolean",
+    "int": "integer",
+    "float": "number",
+    "dict": "object",
+    "list": "array",
+    "tuple": "array",
+    "Version": "object",
+    "PathLike": "string",
+    "Path": "string",
+    "PurePath": "string",
+    "PurePosixPath": "string",
+}
+
+# Sentinel for "no JSON type could be determined" -> renders as {"pattern": ".*"}.
+_UNKNOWN = object()
+
+
+@dataclass(frozen=True)
+class DatasetParameter:
+    """Constructor parameter details needed for schema generation."""
+
+    name: str
+    annotation: Any
+    required: bool
+
+
+@dataclass(frozen=True)
+class DatasetSpec:
+    """Source-level description of a public dataset class."""
+
+    type_id: str
+    parameters: list[DatasetParameter]
+    docstring: str | None
+
+
+def _is_union_annotation(annotation: Any) -> bool:
+    origin = get_origin(annotation)
+    return origin is Union or origin is UnionType
+
+
+def _split_union_members(annotation: str) -> list[str]:
+    """Split a PEP 604 union annotation string on top-level ``|`` tokens."""
+    members: list[str] = []
+    depth = 0
+    start = 0
+    for index, char in enumerate(annotation):
+        if char == "[":
+            depth += 1
+        elif char == "]":
+            depth -= 1
+        elif char == "|" and depth == 0:
+            members.append(annotation[start:index].strip())
+            start = index + 1
+    members.append(annotation[start:].strip())
+    return members
+
+
+def _json_type_for_annotation_text(annotation: str) -> Any:
+    """Map an annotation string from source code to a JSON Schema type."""
+    if "|" in annotation:
+        json_types: list[str] = []
+        nullable = False
+        for member in _split_union_members(annotation):
+            if member == "None":
+                nullable = True
+                continue
+            mapped = _json_type_for_annotation_text(member)
+            if mapped is _UNKNOWN:
+                return _UNKNOWN
+            json_types.extend(mapped if isinstance(mapped, list) else [mapped])
+        ordered = list(dict.fromkeys(json_types))
+        if nullable and "null" not in ordered:
+            ordered.append("null")
+        return ordered[0] if len(ordered) == 1 else ordered
+
+    base_name = annotation.split("[", 1)[0].rsplit(".", 1)[-1]
+    return _NAME_TYPE_MAP.get(base_name, _UNKNOWN)
+
+
+def _json_type_for_union(annotation: Any) -> Any:
+    """Map Optional / Union annotations to a JSON Schema ``type`` value."""
+    members = get_args(annotation)
+    nullable = _NoneType in members
+    json_types: list[str] = []
+
+    for member in members:
+        if member is _NoneType:
+            continue
+        mapped = _json_type_for(member)
+        if mapped is _UNKNOWN:
+            # A union with an unmappable member cannot be typed reliably.
+            return _UNKNOWN
+        json_types.extend(mapped if isinstance(mapped, list) else [mapped])
+
+    if not json_types:
+        return _UNKNOWN
+
+    # De-duplicate preserving order.
+    ordered = list(dict.fromkeys(json_types))
+    if nullable and "null" not in ordered:
+        ordered.append("null")
+    return ordered[0] if len(ordered) == 1 else ordered
+
+
+def _json_type_for_concrete(annotation: Any) -> Any:
+    """Map a non-union annotation to a JSON Schema ``type`` value."""
+    origin = get_origin(annotation)
+    lookup = origin if origin is not None else annotation
+
+    if isinstance(lookup, type):
+        mapped = _TYPE_MAP.get(lookup)
+        if mapped is not None:
+            return mapped
+        for base, json_type in _TYPE_MAP.items():
+            try:
+                if issubclass(lookup, base):
+                    return json_type
+            except TypeError:
+                continue
+        by_name = _NAME_TYPE_MAP.get(getattr(lookup, "__name__", ""))
+        if by_name is not None:
+            return by_name
+
+    # Fall back to the annotation's bare name for unresolved / string annotations.
+    name = getattr(annotation, "__name__", None) or str(annotation)
+    return _NAME_TYPE_MAP.get(name, _UNKNOWN)
+
+
+def _json_type_for(annotation: Any) -> Any:
+    """Map a resolved Python annotation to a JSON Schema ``type`` value.
+
+    Returns a JSON type string (e.g. ``"string"``), a list of type strings for
+    nullable/union annotations (e.g. ``["object", "null"]``), or the ``_UNKNOWN``
+    sentinel when no type can be determined.
+    """
+    if annotation is inspect.Parameter.empty or annotation is None:
+        return _UNKNOWN
+    if isinstance(annotation, str):
+        return _json_type_for_annotation_text(annotation)
+    if _is_union_annotation(annotation):
+        return _json_type_for_union(annotation)
+    return _json_type_for_concrete(annotation)
+
+
+_ARGS_HEADER_RE = re.compile(r"^(\s*)Args:\s*$")
+# A new parameter entry looks like ``name:`` or ``name (type):`` at the block indent.
+_PARAM_RE = re.compile(r"^(\s*)(\*{0,2}\w+)\s*(?:\([^)]*\))?\s*:\s?(.*)$")
+
+
+def _parse_docstring_args(doc: str | None) -> dict[str, str]:
+    """Extract per-parameter descriptions from a Google-style ``Args:`` section.
+
+    Continuation lines (indented further than the parameter name) are joined onto
+    the parameter's description with a literal ``\\n`` separator, matching the
+    formatting of the committed schema.
+    """
+    if not doc:
+        return {}
+
+    lines = doc.splitlines()
+    # Locate the ``Args:`` header and the indent it sits at.
+    start = None
+    header_indent = 0
+    for idx, line in enumerate(lines):
+        match = _ARGS_HEADER_RE.match(line)
+        if match:
+            start = idx + 1
+            header_indent = len(match.group(1))
+            break
+    if start is None:
+        return {}
+
+    descriptions: dict[str, str] = {}
+    current: str | None = None
+    param_indent = None
+    for line in lines[start:]:
+        stripped = line.strip()
+        indent = len(line) - len(line.lstrip())
+        # A blank line does not terminate the block (descriptions may wrap), but
+        # a non-indented line at/above the header indent starts a new section.
+        if stripped and indent <= header_indent:
+            break
+        param_match = _PARAM_RE.match(line)
+        if param_match and (param_indent is None or indent == param_indent):
+            param_indent = indent
+            current = param_match.group(2)
+            descriptions[current] = param_match.group(3).strip()
+        elif current is not None and stripped:
+            descriptions[current] = f"{descriptions[current]}\n{stripped}".strip()
+    return {name: desc for name, desc in descriptions.items() if desc}
+
+
+def _iter_subpackages() -> list[str]:
+    """Return the names of importable ``kedro_datasets`` subpackages to introspect."""
+    names = []
+    for info in pkgutil.iter_modules(kedro_datasets.__path__):
+        if not info.ispkg:
+            continue
+        if info.name.startswith("_") or info.name in EXCLUDED_SUBPACKAGES:
+            continue
+        names.append(info.name)
+    return sorted(names)
+
+
+def _package_root() -> Path:
+    return Path(kedro_datasets.__file__).parent
+
+
+def _submodule_attrs_for(subpackage: str) -> dict[str, str]:
+    """Return ``ClassName -> module_name`` from a subpackage's lazy exports."""
+    init_path = _package_root() / subpackage / "__init__.py"
+    module = ast.parse(init_path.read_text(encoding="utf-8"))
+
+    for node in ast.walk(module):
+        if not isinstance(node, ast.Call):
+            continue
+        for keyword in node.keywords:
+            if keyword.arg != "submod_attrs" or not isinstance(keyword.value, ast.Dict):
+                continue
+            class_to_module: dict[str, str] = {}
+            for key, value in zip(keyword.value.keys, keyword.value.values):
+                module_name = ast.literal_eval(key)
+                for class_name in ast.literal_eval(value):
+                    class_to_module[class_name] = module_name
+            return class_to_module
+
+    raise SystemExit(f"Cannot find lazy exports for kedro_datasets.{subpackage}.")
+
+
+def _annotation_for(arg: ast.arg) -> Any:
+    if arg.annotation is None:
+        return inspect.Parameter.empty
+    return ast.unparse(arg.annotation)
+
+
+def _parameters_from_init(init_node: ast.FunctionDef) -> list[DatasetParameter]:
+    """Extract constructor parameters from an AST ``__init__`` method."""
+    parameters: list[DatasetParameter] = []
+    positional_args = [
+        arg
+        for arg in [*init_node.args.posonlyargs, *init_node.args.args]
+        if arg.arg != "self"
+    ]
+    positional_defaults = [None] * (
+        len(positional_args) - len(init_node.args.defaults)
+    ) + list(init_node.args.defaults)
+
+    for arg, default in zip(positional_args, positional_defaults):
+        parameters.append(
+            DatasetParameter(
+                name=arg.arg,
+                annotation=_annotation_for(arg),
+                required=default is None,
+            )
+        )
+
+    for arg, default in zip(init_node.args.kwonlyargs, init_node.args.kw_defaults):
+        parameters.append(
+            DatasetParameter(
+                name=arg.arg,
+                annotation=_annotation_for(arg),
+                required=default is None,
+            )
+        )
+
+    return parameters
+
+
+def _dataset_spec_from_source(
+    subpackage: str, module_name: str, class_name: str
+) -> DatasetSpec:
+    """Build a dataset spec from the source file that defines ``class_name``."""
+    source_path = _package_root() / subpackage / f"{module_name}.py"
+    module = ast.parse(source_path.read_text(encoding="utf-8"))
+
+    for node in module.body:
+        if not isinstance(node, ast.ClassDef) or node.name != class_name:
+            continue
+        for child in node.body:
+            if isinstance(child, ast.FunctionDef) and child.name == "__init__":
+                return DatasetSpec(
+                    type_id=f"{subpackage}.{class_name}",
+                    parameters=_parameters_from_init(child),
+                    docstring=ast.get_docstring(child),
+                )
+        return DatasetSpec(
+            type_id=f"{subpackage}.{class_name}",
+            parameters=[],
+            docstring=None,
+        )
+
+    raise SystemExit(f"Cannot find {class_name} in {source_path}.")
+
+
+def _iter_dataset_specs() -> list[DatasetSpec]:
+    """Enumerate every public dataset class without importing optional deps."""
+    specs: list[DatasetSpec] = []
+    for subpackage in _iter_subpackages():
+        class_to_module = _submodule_attrs_for(subpackage)
+        for class_name in sorted(class_to_module):
+            specs.append(
+                _dataset_spec_from_source(
+                    subpackage, class_to_module[class_name], class_name
+                )
+            )
+    return specs
+
+
+def _deep_merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
+    """Recursively merge ``override`` into ``base`` and return ``base``."""
+    for key, value in override.items():
+        if isinstance(value, dict) and isinstance(base.get(key), dict):
+            _deep_merge(base[key], value)
+        else:
+            base[key] = value
+    return base
+
+
+def _property_schema(annotation: Any, description: str | None) -> dict[str, Any]:
+    """Build a JSON Schema property fragment for one constructor parameter."""
+    json_type = _json_type_for(annotation)
+    if json_type is _UNKNOWN:
+        schema: dict[str, Any] = {"pattern": ".*"}
+    else:
+        schema = {"type": json_type}
+
+    if description:
+        schema["description"] = description
+    return schema
+
+
+def _resolved_type_hints(init: Any) -> dict[str, Any]:
+    """Return resolved annotations for ``init``.
+
+    Dataset modules use ``from __future__ import annotations``. ``inspect`` keeps
+    those annotations as strings, so resolve them explicitly. Some exotic
+    annotations may still fail to resolve; in that case the generator falls back
+    to the raw signature annotations and unknown values render permissively.
+    """
+    try:
+        return get_type_hints(init)
+    except (AttributeError, NameError, TypeError):
+        return {}
+
+
+def _dataset_then_schema(spec: DatasetSpec) -> dict[str, Any]:
+    """Build the ``then`` schema fragment for a single dataset class."""
+    descriptions = _parse_docstring_args(spec.docstring)
+
+    required: list[str] = []
+    properties: dict[str, dict[str, Any]] = {}
+
+    for parameter in spec.parameters:
+        properties[parameter.name] = _property_schema(
+            parameter.annotation, descriptions.get(parameter.name)
+        )
+        if parameter.required:
+            required.append(parameter.name)
+
+    then: dict[str, Any] = {"properties": properties}
+    if required:
+        then = {"required": required, **then}
+
+    override = SCHEMA_OVERRIDES.get(spec.type_id)
+    if override:
+        then = _deep_merge(then, override.copy())
+    return then
+
+
+def _dataset_condition(spec: DatasetSpec) -> dict[str, Any]:
+    """Build one ``if``/``then`` entry for the catalog item's ``allOf``."""
+    return {
+        "if": {
+            "properties": {
+                "type": {
+                    "const": spec.type_id,
+                }
+            }
+        },
+        "then": _dataset_then_schema(spec),
+    }
+
+
+def build_schema() -> dict[str, Any]:
+    """Build the complete Kedro catalog JSON schema."""
+    dataset_specs = _iter_dataset_specs()
+    dataset_types = [spec.type_id for spec in dataset_specs]
+
+    return {
+        "type": "object",
+        "patternProperties": {
+            "^[a-z0-9-_]+$": {
+                "required": [
+                    "type",
+                ],
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "enum": dataset_types,
+                    }
+                },
+                "allOf": [_dataset_condition(spec) for spec in dataset_specs],
+            }
+        },
+    }
+
+
+def _schema_path() -> Path:
+    return (
+        Path(kedro_datasets.__file__).parent.parent
+        / "static"
+        / "jsonschema"
+        / SCHEMA_FILENAME
+    )
+
+
+def _format_schema(schema: dict[str, Any]) -> str:
+    return f"{json.dumps(schema, indent=2)}\n"
+
+
+def write_schema() -> None:
+    """Write the generated schema to disk."""
+    _schema_path().write_text(_format_schema(build_schema()), encoding="utf-8")
+
+
+def check_schema() -> bool:
+    """Return whether the committed schema matches generated output."""
+    path = _schema_path()
+    if not path.exists():
+        return False
+    expected = _format_schema(build_schema())
+    return path.read_text(encoding="utf-8") == expected
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="verify the committed schema is current without writing it",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    if args.check:
+        if check_schema():
+            return 0
+        print(  # noqa: T201
+            f"{_schema_path()} is not up to date. "
+            "Run `python -m kedro_datasets._generate_catalog_schema`.",
+            file=sys.stderr,
+        )
+        return 1
+
+    write_schema()
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/kedro-datasets/kedro_datasets/_generate_catalog_schema.py
+++ b/kedro-datasets/kedro_datasets/_generate_catalog_schema.py
@@ -21,14 +21,12 @@ import argparse
 import ast
 import inspect
 import json
-import os
 import pkgutil
 import re
 import sys
 from dataclasses import dataclass
 from pathlib import Path
-from types import UnionType
-from typing import Any, Union, get_args, get_origin, get_type_hints
+from typing import Any
 
 import kedro_datasets
 from kedro_datasets._schema_overrides import EXCLUDED_SUBPACKAGES, SCHEMA_OVERRIDES
@@ -38,21 +36,8 @@ from kedro_datasets._schema_overrides import EXCLUDED_SUBPACKAGES, SCHEMA_OVERRI
 # schema-affecting version.
 SCHEMA_FILENAME = "kedro-catalog-1.0.0.json"
 
-_NoneType = type(None)
-
-# Exact-type -> JSON type. Matched by identity first, then ``issubclass``.
-_TYPE_MAP: dict[type, str] = {
-    str: "string",
-    bool: "boolean",
-    int: "integer",
-    float: "number",
-    dict: "object",
-    list: "array",
-    os.PathLike: "string",
-}
-
-# Fallback keyed by annotation ``__name__`` for common non-builtin types that
-# cannot be matched by identity (e.g. Kedro's ``Version``).
+# Mapping keyed by the final name in source annotation strings for common
+# non-builtin types (e.g. Kedro's ``Version``).
 _NAME_TYPE_MAP: dict[str, str] = {
     "str": "string",
     "bool": "boolean",
@@ -88,11 +73,6 @@ class DatasetSpec:
     type_id: str
     parameters: list[DatasetParameter]
     docstring: str | None
-
-
-def _is_union_annotation(annotation: Any) -> bool:
-    origin = get_origin(annotation)
-    return origin is Union or origin is UnionType
 
 
 def _split_union_members(annotation: str) -> list[str]:
@@ -134,57 +114,8 @@ def _json_type_for_annotation_text(annotation: str) -> Any:
     return _NAME_TYPE_MAP.get(base_name, _UNKNOWN)
 
 
-def _json_type_for_union(annotation: Any) -> Any:
-    """Map Optional / Union annotations to a JSON Schema ``type`` value."""
-    members = get_args(annotation)
-    nullable = _NoneType in members
-    json_types: list[str] = []
-
-    for member in members:
-        if member is _NoneType:
-            continue
-        mapped = _json_type_for(member)
-        if mapped is _UNKNOWN:
-            # A union with an unmappable member cannot be typed reliably.
-            return _UNKNOWN
-        json_types.extend(mapped if isinstance(mapped, list) else [mapped])
-
-    if not json_types:
-        return _UNKNOWN
-
-    # De-duplicate preserving order.
-    ordered = list(dict.fromkeys(json_types))
-    if nullable and "null" not in ordered:
-        ordered.append("null")
-    return ordered[0] if len(ordered) == 1 else ordered
-
-
-def _json_type_for_concrete(annotation: Any) -> Any:
-    """Map a non-union annotation to a JSON Schema ``type`` value."""
-    origin = get_origin(annotation)
-    lookup = origin if origin is not None else annotation
-
-    if isinstance(lookup, type):
-        mapped = _TYPE_MAP.get(lookup)
-        if mapped is not None:
-            return mapped
-        for base, json_type in _TYPE_MAP.items():
-            try:
-                if issubclass(lookup, base):
-                    return json_type
-            except TypeError:
-                continue
-        by_name = _NAME_TYPE_MAP.get(getattr(lookup, "__name__", ""))
-        if by_name is not None:
-            return by_name
-
-    # Fall back to the annotation's bare name for unresolved / string annotations.
-    name = getattr(annotation, "__name__", None) or str(annotation)
-    return _NAME_TYPE_MAP.get(name, _UNKNOWN)
-
-
 def _json_type_for(annotation: Any) -> Any:
-    """Map a resolved Python annotation to a JSON Schema ``type`` value.
+    """Map a source-level annotation string to a JSON Schema ``type`` value.
 
     Returns a JSON type string (e.g. ``"string"``), a list of type strings for
     nullable/union annotations (e.g. ``["object", "null"]``), or the ``_UNKNOWN``
@@ -192,11 +123,9 @@ def _json_type_for(annotation: Any) -> Any:
     """
     if annotation is inspect.Parameter.empty or annotation is None:
         return _UNKNOWN
-    if isinstance(annotation, str):
-        return _json_type_for_annotation_text(annotation)
-    if _is_union_annotation(annotation):
-        return _json_type_for_union(annotation)
-    return _json_type_for_concrete(annotation)
+    if not isinstance(annotation, str):
+        return _UNKNOWN
+    return _json_type_for_annotation_text(annotation)
 
 
 _ARGS_HEADER_RE = re.compile(r"^(\s*)Args:\s*$")
@@ -386,20 +315,6 @@ def _property_schema(annotation: Any, description: str | None) -> dict[str, Any]
     if description:
         schema["description"] = description
     return schema
-
-
-def _resolved_type_hints(init: Any) -> dict[str, Any]:
-    """Return resolved annotations for ``init``.
-
-    Dataset modules use ``from __future__ import annotations``. ``inspect`` keeps
-    those annotations as strings, so resolve them explicitly. Some exotic
-    annotations may still fail to resolve; in that case the generator falls back
-    to the raw signature annotations and unknown values render permissively.
-    """
-    try:
-        return get_type_hints(init)
-    except (AttributeError, NameError, TypeError):
-        return {}
 
 
 def _dataset_then_schema(spec: DatasetSpec) -> dict[str, Any]:

--- a/kedro-datasets/kedro_datasets/_schema_overrides.py
+++ b/kedro-datasets/kedro_datasets/_schema_overrides.py
@@ -1,0 +1,24 @@
+"""Hand-maintained overrides for the auto-generated Kedro catalog JSON schema.
+
+The schema is produced by :mod:`kedro_datasets._generate_catalog_schema` from
+dataset ``__init__`` signatures. Source introspection cannot recover genuinely
+non-introspectable facts (for example, the closed set of allowed values for a
+string parameter). Such facts live here and are deep-merged into the generated
+``then`` block for the matching dataset type id.
+
+Keep this file as small as possible: prefer improving the generator over adding
+an override. An entry maps a dataset type id (``"<subpackage>.<ClassName>"``) to
+a partial ``then`` fragment that is deep-merged on top of the generated one.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# Subpackages under ``kedro_datasets`` that are intentionally excluded from the
+# catalog schema (e.g. langchain datasets are not configured through the
+# catalog in the usual way).
+EXCLUDED_SUBPACKAGES: set[str] = {"langchain"}
+
+# Dataset type id -> partial ``then`` fragment (deep-merged over generated output).
+SCHEMA_OVERRIDES: dict[str, dict[str, Any]] = {}

--- a/kedro-datasets/kedro_datasets/_schema_overrides.py
+++ b/kedro-datasets/kedro_datasets/_schema_overrides.py
@@ -33,7 +33,7 @@ _HF_FS_DATASET_OVERRIDE: dict[str, Any] = {
         },
         "data_files": {
             "type": ["object", "null"],
-            "description": "Mapping of split name to filename for loading and saving a ``DatasetDict`` from a directory (e.g. ``{\"train\": \"train.csv\"}``). The keys must match the split names of the ``DatasetDict`` being saved, and the filenames must use the correct extension for the format (e.g. ``.csv`` for ``CSVDataset``).",
+            "description": 'Mapping of split name to filename for loading and saving a ``DatasetDict`` from a directory (e.g. ``{"train": "train.csv"}``). The keys must match the split names of the ``DatasetDict`` being saved, and the filenames must use the correct extension for the format (e.g. ``.csv`` for ``CSVDataset``).',
         },
         "load_args": {
             "type": ["object", "null"],

--- a/kedro-datasets/kedro_datasets/_schema_overrides.py
+++ b/kedro-datasets/kedro_datasets/_schema_overrides.py
@@ -20,5 +20,48 @@ from typing import Any
 # catalog in the usual way).
 EXCLUDED_SUBPACKAGES: set[str] = {"langchain"}
 
+_HF_FS_DATASET_OVERRIDE: dict[str, Any] = {
+    "required": ["path"],
+    "properties": {
+        "path": {
+            "type": "string",
+            "description": "Path to a file or directory for persisting Hugging Face datasets. Supports local paths, ``os.PathLike`` objects, and remote URIs (e.g. ``s3://bucket/data``).",
+        },
+        "version": {
+            "type": ["object", "null"],
+            "description": "Optional versioning configuration (see :class:`~kedro.io.core.Version`).",
+        },
+        "data_files": {
+            "type": ["object", "null"],
+            "description": "Mapping of split name to filename for loading and saving a ``DatasetDict`` from a directory (e.g. ``{\"train\": \"train.csv\"}``). The keys must match the split names of the ``DatasetDict`` being saved, and the filenames must use the correct extension for the format (e.g. ``.csv`` for ``CSVDataset``).",
+        },
+        "load_args": {
+            "type": ["object", "null"],
+            "description": "Additional keyword arguments passed to the underlying load function. This cannot include ``data_files``; use the top-level ``data_files`` argument instead.",
+        },
+        "save_args": {
+            "type": ["object", "null"],
+            "description": "Additional keyword arguments passed to the underlying save function. This cannot include ``data_files``; use the top-level ``data_files`` argument instead.",
+        },
+        "credentials": {
+            "type": ["object", "null"],
+            "description": "Credentials for the underlying filesystem (e.g. ``key``/``secret`` for S3). Passed to the ``storage_options`` parameter in the underlying ``datasets`` implementation.",
+        },
+        "fs_args": {
+            "type": ["object", "null"],
+            "description": "Extra arguments passed to the ``fsspec`` filesystem initialiser. Passed to the ``storage_options`` parameter in the underlying ``datasets`` implementation.",
+        },
+        "metadata": {
+            "type": ["object", "null"],
+            "description": "Any arbitrary metadata. This is ignored by Kedro but may be consumed by users or external plugins.",
+        },
+    },
+}
+
 # Dataset type id -> partial ``then`` fragment (deep-merged over generated output).
-SCHEMA_OVERRIDES: dict[str, dict[str, Any]] = {}
+SCHEMA_OVERRIDES: dict[str, dict[str, Any]] = {
+    "huggingface.ArrowDataset": _HF_FS_DATASET_OVERRIDE,
+    "huggingface.CSVDataset": _HF_FS_DATASET_OVERRIDE,
+    "huggingface.JSONDataset": _HF_FS_DATASET_OVERRIDE,
+    "huggingface.ParquetDataset": _HF_FS_DATASET_OVERRIDE,
+}

--- a/kedro-datasets/static/jsonschema/kedro-catalog-1.0.0.json
+++ b/kedro-datasets/static/jsonschema/kedro-catalog-1.0.0.json
@@ -2965,7 +2965,7 @@
             "properties": {
               "key": {
                 "type": "string",
-                "description": "The key to use for saving/loading object to Redis."
+                "description": "The key to use for saving/loading object to Redis. Can be a\nstring or a PathLike object."
               },
               "backend": {
                 "type": "string",

--- a/kedro-datasets/static/jsonschema/kedro-catalog-1.0.0.json
+++ b/kedro-datasets/static/jsonschema/kedro-catalog-1.0.0.json
@@ -1,2231 +1,3385 @@
 {
-    "type": "object",
-    "patternProperties": {
-      "^[a-z0-9-_]+$": {
-        "required": [
-          "type"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "api.APIDataset",
-              "biosequence.BioSequenceDataset",
-              "dask.CSVDataset",
-              "dask.ParquetDataset",
-              "databricks.ManagedTableDataset",
-              "email.EmailMessageDataset",
-              "geopandas.GenericDataset",
-              "holoviews.HoloviewsWriter",
-              "huggingface.ArrowDataset",
-              "huggingface.CSVDataset",
-              "huggingface.HFDataset",
-              "huggingface.HFTransformerPipelineDataset",
-              "huggingface.JSONDataset",
-              "huggingface.ParquetDataset",
-              "ibis.FileDataset",
-              "ibis.TableDataset",
-              "json.JSONDataset",
-              "matlab.MatlabDataset",
-              "matplotlib.MatplotlibDataset",
-              "networkx.GMLDataset",
-              "networkx.GraphMLDataset",
-              "networkx.JSONDataset",
-              "openxml.DocxDataset",
-              "pandas.CSVDataset",
-              "pandas.DeltaTableDataset",
-              "pandas.ExcelDataset",
-              "pandas.FeatherDataset",
-              "pandas.GBQQueryDataset",
-              "pandas.GBQTableDataset",
-              "pandas.GenericDataset",
-              "pandas.HDFDataset",
-              "pandas.JSONDataset",
-              "pandas.ParquetDataset",
-              "pandas.SQLQueryDataset",
-              "pandas.SQLTableDataset",
-              "pandas.XMLDataset",
-              "partitions.IncrementalDataset",
-              "partitions.PartitionedDataset",
-              "pickle.PickleDataset",
-              "pillow.ImageDataset",
-              "plotly.HTMLDataset",
-              "plotly.JSONDataset",
-              "plotly.PlotlyDataset",
-              "polars.CSVDataset",
-              "polars.EagerPolarsDataset",
-              "polars.LazyPolarsDataset",
-              "redis.PickleDataset",
-              "snowflake.SnowparkTableDataset",
-              "spark.DeltaTableDataset",
-              "spark.GBQQueryDataset",
-              "spark.SparkDataset",
-              "spark.SparkHiveDataset",
-              "spark.SparkJDBCDataset",
-              "spark.SparkStreamingDataset",
-              "svmlight.SVMLightDataset",
-              "tensorflow.TensorFlowModelDataset",
-              "text.TextDataset",
-              "yaml.YAMLDataset"
-            ]
+  "type": "object",
+  "patternProperties": {
+    "^[a-z0-9-_]+$": {
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "api.APIDataset",
+            "biosequence.BioSequenceDataset",
+            "dask.CSVDataset",
+            "dask.ParquetDataset",
+            "databricks.ManagedTableDataset",
+            "email.EmailMessageDataset",
+            "geopandas.GenericDataset",
+            "holoviews.HoloviewsWriter",
+            "huggingface.ArrowDataset",
+            "huggingface.CSVDataset",
+            "huggingface.HFDataset",
+            "huggingface.HFTransformerPipelineDataset",
+            "huggingface.JSONDataset",
+            "huggingface.ParquetDataset",
+            "ibis.FileDataset",
+            "ibis.TableDataset",
+            "json.JSONDataset",
+            "matlab.MatlabDataset",
+            "matplotlib.MatplotlibDataset",
+            "networkx.GMLDataset",
+            "networkx.GraphMLDataset",
+            "networkx.JSONDataset",
+            "openxml.DocxDataset",
+            "openxml.PptxDataset",
+            "pandas.CSVDataset",
+            "pandas.DeltaTableDataset",
+            "pandas.ExcelDataset",
+            "pandas.FeatherDataset",
+            "pandas.GBQQueryDataset",
+            "pandas.GBQTableDataset",
+            "pandas.GenericDataset",
+            "pandas.HDFDataset",
+            "pandas.JSONDataset",
+            "pandas.ParquetDataset",
+            "pandas.SQLQueryDataset",
+            "pandas.SQLTableDataset",
+            "pandas.XMLDataset",
+            "partitions.IncrementalDataset",
+            "partitions.PartitionedDataset",
+            "pickle.PickleDataset",
+            "pillow.ImageDataset",
+            "plotly.HTMLDataset",
+            "plotly.JSONDataset",
+            "plotly.PlotlyDataset",
+            "polars.CSVDataset",
+            "polars.EagerPolarsDataset",
+            "polars.LazyPolarsDataset",
+            "redis.PickleDataset",
+            "snowflake.SnowparkTableDataset",
+            "spark.DeltaTableDataset",
+            "spark.GBQQueryDataset",
+            "spark.SparkDataset",
+            "spark.SparkHiveDataset",
+            "spark.SparkJDBCDataset",
+            "spark.SparkStreamingDataset",
+            "svmlight.SVMLightDataset",
+            "tensorflow.TensorFlowModelDataset",
+            "text.TextDataset",
+            "yaml.YAMLDataset"
+          ]
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "api.APIDataset"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "url"
+            ],
+            "properties": {
+              "url": {
+                "type": "string",
+                "description": "The API URL endpoint."
+              },
+              "method": {
+                "type": "string",
+                "description": "The method of the request. GET, POST, PUT are the only supported\nmethods"
+              },
+              "load_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Additional parameters to be fed to requests.request.\nhttps://requests.readthedocs.io/en/latest/api.html#requests.request"
+              },
+              "save_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Options for saving data on server. Includes all parameters used\nduring load method. Adds an optional parameter, ``chunk_size`` which\ndetermines the size of the package sent at each request, and\n``send_individually`` to send list items as individual requests."
+              },
+              "credentials": {
+                "pattern": ".*",
+                "description": "Allows specifying secrets in credentials.yml.\nExpected format is ``('login', 'password')`` if given as a tuple or\nlist. An ``AuthBase`` instance can be provided for more complex cases."
+              },
+              "metadata": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Any arbitrary metadata.\nThis is ignored by Kedro, but may be consumed by users or external plugins."
+              },
+              "response_dataset": {
+                "pattern": ".*",
+                "description": "Optional dataset to automatically store API responses.\nThe API response is stored based on the dataset type:\n- `JSONDataset`: Stores `response.json()` (parsed JSON data)\n- `TextDataset`: Stores `response.text` (response body as string)\n- Other datasets (e.g., `PickleDataset`, `MemoryDataset`): Stores the\nfull `requests.Response` object\nCan be specified as:\n- A string type identifier: `\"json.JSONDataset\"`\n- A dict with `\"type\"` key: `{\"type\": \"json.JSONDataset\", \"filepath\": \"...\"}`\n- A dataset class (advanced usage)\nIf `None` (default), responses are not automatically stored."
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "biosequence.BioSequenceDataset"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "filepath"
+            ],
+            "properties": {
+              "filepath": {
+                "type": "string",
+                "description": "Filepath in POSIX format to sequence file prefixed with a protocol like\n`s3://`. If prefix is not provided, `file` protocol (local filesystem) will be used.\nThe prefix should be any protocol supported by ``fsspec``."
+              },
+              "load_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Options for parsing sequence files by Biopython ``SeqIO.parse()``."
+              },
+              "save_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "file format supported by Biopython ``SeqIO.write()``.\nE.g. `{\"format\": \"fasta\"}`."
+              },
+              "credentials": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Credentials required to get access to the underlying filesystem.\nE.g. for ``GCSFileSystem`` it should look like `{\"token\": None}`."
+              },
+              "fs_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Extra arguments to pass into underlying filesystem class constructor\n(e.g. `{\"project\": \"my-project\"}` for ``GCSFileSystem``), as well as\nto pass to the filesystem's `open` method through nested keys\n`open_args_load` and `open_args_save`.\nHere you can find all available arguments for `open`:\nhttps://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.spec.AbstractFileSystem.open\nAll defaults are preserved, except `mode`, which is set to `r` when loading\nand to `w` when saving."
+              },
+              "metadata": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Any arbitrary metadata.\nThis is ignored by Kedro, but may be consumed by users or external plugins."
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "dask.CSVDataset"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "filepath"
+            ],
+            "properties": {
+              "filepath": {
+                "type": "string",
+                "description": "Filepath in POSIX format to a CSV file\nCSV collection or the directory of a multipart CSV."
+              },
+              "load_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Additional loading options `dask.dataframe.read_csv`:\nhttps://docs.dask.org/en/stable/generated/dask.dataframe.read_csv.html"
+              },
+              "save_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Additional saving options for `dask.dataframe.to_csv`:\nhttps://docs.dask.org/en/stable/generated/dask.dataframe.to_csv.html"
+              },
+              "credentials": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Credentials required to get access to the underlying filesystem.\nE.g. for ``GCSFileSystem`` it should look like `{\"token\": None}`."
+              },
+              "fs_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Optional parameters to the backend file system driver:\nhttps://docs.dask.org/en/stable/how-to/connect-to-remote-data.html#optional-parameters"
+              },
+              "metadata": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Any arbitrary metadata.\nThis is ignored by Kedro, but may be consumed by users or external plugins."
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "dask.ParquetDataset"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "filepath"
+            ],
+            "properties": {
+              "filepath": {
+                "type": "string",
+                "description": "Filepath in POSIX format to a parquet file\nparquet collection or the directory of a multipart parquet."
+              },
+              "load_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Additional loading options `dask.dataframe.read_parquet`:\nhttps://docs.dask.org/en/stable/generated/dask.dataframe.read_parquet.html"
+              },
+              "save_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Additional saving options for `dask.dataframe.to_parquet`:\nhttps://docs.dask.org/en/stable/generated/dask.dataframe.to_parquet.html"
+              },
+              "credentials": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Credentials required to get access to the underlying filesystem.\nE.g. for ``GCSFileSystem`` it should look like `{\"token\": None}`."
+              },
+              "fs_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Optional parameters to the backend file system driver:\nhttps://docs.dask.org/en/stable/how-to/connect-to-remote-data.html#optional-parameters"
+              },
+              "metadata": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Any arbitrary metadata.\nThis is ignored by Kedro, but may be consumed by users or external plugins."
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "databricks.ManagedTableDataset"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "table"
+            ],
+            "properties": {
+              "table": {
+                "type": "string",
+                "description": "The name of the table."
+              },
+              "catalog": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "The name of the catalog in Unity.\nDefaults to None."
+              },
+              "database": {
+                "type": "string",
+                "description": "The name of the database.\n(also referred to as schema). Defaults to \"default\"."
+              },
+              "write_mode": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "the mode to write the data into the table. If not\npresent, the dataset is read-only.\nOptions are:[\"overwrite\", \"append\", \"upsert\"].\n\"upsert\" mode requires primary_key field to be populated.\nDefaults to None."
+              },
+              "dataframe_type": {
+                "type": "string",
+                "description": "\"pandas\" or \"spark\" dataframe.\nDefaults to \"spark\"."
+              },
+              "primary_key": {
+                "type": [
+                  "string",
+                  "array",
+                  "null"
+                ],
+                "description": "The primary key of the table.\nCan be in the form of a list. Defaults to None."
+              },
+              "version": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "kedro.io.core.Version instance to load the data.\nDefaults to None."
+              },
+              "schema": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "The schema of the table in JSON form.\nDataframes will be truncated to match the schema if provided.\nUsed by the hooks to create the table if the schema is provided.\nDefaults to None."
+              },
+              "partition_columns": {
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "description": "The columns to use for partitioning the table.\nUsed by the hooks. Defaults to None."
+              },
+              "owner_group": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "If table access control is enabled in your workspace,\nspecifying owner_group will transfer ownership of the table and database to\nthis owner. All databases should have the same owner_group. Defaults to None."
+              },
+              "metadata": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Any arbitrary metadata.\nThis is ignored by Kedro, but may be consumed by users or external plugins."
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "email.EmailMessageDataset"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "filepath"
+            ],
+            "properties": {
+              "filepath": {
+                "type": "string",
+                "description": "Filepath in POSIX format to a text file prefixed with a protocol like `s3://`.\nIf prefix is not provided, `file` protocol (local filesystem) will be used.\nThe prefix should be any protocol supported by ``fsspec``.\nNote: `http(s)` doesn't support versioning."
+              },
+              "load_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "``email`` options for parsing email messages (arguments passed\ninto ``email.parser.Parser.parse``). Here you can find all available arguments:\nhttps://docs.python.org/3/library/email.parser.html#email.parser.Parser.parse\nIf you would like to specify options for the `Parser`,\nyou can include them under the \"parser\" key. Here you can\nfind all available arguments:\nhttps://docs.python.org/3/library/email.parser.html#email.parser.Parser\nAll defaults are preserved, but \"policy\", which is set to ``email.policy.default``."
+              },
+              "save_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "``email`` options for generating MIME documents (arguments passed into\n``email.generator.Generator.flatten``). Here you can find all available arguments:\nhttps://docs.python.org/3/library/email.generator.html#email.generator.Generator.flatten\nIf you would like to specify options for the `Generator`,\nyou can include them under the \"generator\" key. Here you can\nfind all available arguments:\nhttps://docs.python.org/3/library/email.generator.html#email.generator.Generator\nAll defaults are preserved."
+              },
+              "version": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "If specified, should be an instance of\n``kedro.io.core.Version``. If its ``load`` attribute is\nNone, the latest version will be loaded. If its ``save``\nattribute is None, save version will be autogenerated."
+              },
+              "credentials": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Credentials required to get access to the underlying filesystem.\nE.g. for ``GCSFileSystem`` it should look like `{\"token\": None}`."
+              },
+              "fs_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Extra arguments to pass into underlying filesystem class constructor\n(e.g. `{\"project\": \"my-project\"}` for ``GCSFileSystem``), as well as\nto pass to the filesystem's `open` method through nested keys\n`open_args_load` and `open_args_save`.\nHere you can find all available arguments for `open`:\nhttps://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.spec.AbstractFileSystem.open\nAll defaults are preserved, except `mode`, which is set to `r` when loading\nand to `w` when saving."
+              },
+              "metadata": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Any arbitrary metadata.\nThis is ignored by Kedro, but may be consumed by users or external plugins."
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "geopandas.GenericDataset"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "filepath"
+            ],
+            "properties": {
+              "filepath": {
+                "type": "string",
+                "description": "Filepath in POSIX format to a file prefixed with a protocol like\n`s3://`. If prefix is not provided `file` protocol (local filesystem) will be used.\nThe prefix should be any protocol supported by ``fsspec``.\nNote: `http(s)` doesn't support versioning."
+              },
+              "file_format": {
+                "type": "string",
+                "description": "String which is used to match the appropriate load/save method on a best\neffort basis. For example if 'parquet' is passed in the `geopandas.read_parquet` and\n`geopandas.DataFrame.to_parquet` will be identified. An error will be raised unless\nat least one matching `read_{file_format}` or `to_{file_format}` method is\nidentified. Defaults to 'file'."
+              },
+              "load_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "GeoPandas options for loading files.\nHere you can find all available arguments:\nhttps://geopandas.org/en/stable/docs/reference/api/geopandas.read_file.html"
+              },
+              "save_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "GeoPandas options for saving files.\nHere you can find all available arguments:\nhttps://geopandas.org/en/stable/docs/reference/api/geopandas.GeoDataFrame.to_file.html"
+              },
+              "version": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "If specified, should be an instance of\n``kedro.io.core.Version``. If its ``load`` attribute is\nNone, the latest version will be loaded. If its ``save``"
+              },
+              "credentials": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "credentials required to access the underlying filesystem.\nEg. for ``GCFileSystem`` it would look like `{'token': None}`."
+              },
+              "fs_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Extra arguments to pass into underlying filesystem class constructor\n(e.g. `{\"project\": \"my-project\"}` for ``GCSFileSystem``), as well as\nto pass to the filesystem's `open` method through nested keys\n`open_args_load` and `open_args_save`.\nHere you can find all available arguments for `open`:\nhttps://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.spec.AbstractFileSystem.open\nAll defaults are preserved, except `mode`, which is set to `wb` when saving."
+              },
+              "metadata": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Any arbitrary metadata.\nThis is ignored by Kedro, but may be consumed by users or external plugins."
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "holoviews.HoloviewsWriter"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "filepath"
+            ],
+            "properties": {
+              "filepath": {
+                "type": "string",
+                "description": "Filepath in POSIX format to a text file prefixed with a protocol like `s3://`.\nIf prefix is not provided, `file` protocol (local filesystem) will be used.\nThe prefix should be any protocol supported by ``fsspec``.\nNote: `http(s)` doesn't support versioning.\nCan be a string or a PathLike object."
+              },
+              "fs_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Extra arguments to pass into underlying filesystem class constructor\n(e.g. `{\"project\": \"my-project\"}` for ``GCSFileSystem``), as well as\nto pass to the filesystem's `open` method through nested key `open_args_save`.\nHere you can find all available arguments for `open`:\nhttps://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.spec.AbstractFileSystem.open\nAll defaults are preserved, except `mode`, which is set to `wb` when saving."
+              },
+              "credentials": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Credentials required to get access to the underlying filesystem.\nE.g. for ``S3FileSystem`` it should look like:\n`{'key': '<id>', 'secret': '<key>'}}`"
+              },
+              "save_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Extra save args passed to `holoviews.save()`. See\nhttps://holoviews.org/reference_manual/holoviews.util.html#holoviews.util.save"
+              },
+              "version": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "If specified, should be an instance of\n``kedro.io.core.Version``. If its ``load`` attribute is\nNone, the latest version will be loaded. If its ``save``\nattribute is None, save version will be autogenerated."
+              },
+              "metadata": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Any arbitrary metadata.\nThis is ignored by Kedro, but may be consumed by users or external plugins."
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "huggingface.ArrowDataset"
+              }
+            }
+          },
+          "then": {
+            "properties": {}
           }
         },
-        "allOf": [
-          {
-            "if": {
-              "properties": {
-                "type": {
-                  "const": "api.APIDataset"
-                }
-              }
-            },
-            "then": {
-              "required": [
-                "url"
-              ],
-              "properties": {
-                "url": {
-                  "type": "string",
-                  "description": "The API URL endpoint."
-                },
-                "method": {
-                  "type": "string",
-                  "description": "The Method of the request, GET, POST, PUT, DELETE, HEAD, etc..."
-                },
-                "data": {
-                  "pattern": ".*",
-                  "description": "The request payload, used for POST, PUT, etc requests\nhttps://requests.readthedocs.io/en/master/user/quickstart/#more-complicated-post-requests"
-                },
-                "params": {
-                  "type": "object",
-                  "description": "The url parameters of the API.\nhttps://requests.readthedocs.io/en/master/user/quickstart/#passing-parameters-in-urls"
-                },
-                "headers": {
-                  "type": "object",
-                  "description": "The HTTP headers.\nhttps://requests.readthedocs.io/en/master/user/quickstart/#custom-headers"
-                },
-                "auth": {
-                  "pattern": ".*",
-                  "description": "Anything ``requests`` accepts. Normally it's either ``('login', 'password')``,\nor ``AuthBase``, ``HTTPBasicAuth`` instance for more complex cases."
-                },
-                "json": {
-                  "pattern": ".*",
-                  "description": "The request payload, used for POST, PUT, etc requests, passed in\nto the json kwarg in the requests object.\nhttps://requests.readthedocs.io/en/master/user/quickstart/#more-complicated-post-requests"
-                },
-                "timeout": {
-                  "type": "integer",
-                  "description": "The wait time in seconds for a response, defaults to 1 minute.\nhttps://requests.readthedocs.io/en/master/user/quickstart/#timeouts"
-                }
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "huggingface.CSVDataset"
               }
             }
           },
-          {
-            "if": {
-              "properties": {
-                "type": {
-                  "const": "biosequence.BioSequenceDataset"
-                }
-              }
-            },
-            "then": {
-              "required": [
-                "filepath"
-              ],
-              "properties": {
-                "filepath": {
-                  "type": "string",
-                  "description": "Filepath in POSIX format to sequence file prefixed with a protocol like\n`s3://`. If prefix is not provided, `file` protocol (local filesystem) will be used.\nThe prefix should be any protocol supported by ``fsspec``."
-                },
-                "load_args": {
-                  "type": "object",
-                  "description": "Options for parsing sequence files by Biopython ``SeqIO.parse()``."
-                },
-                "save_args": {
-                  "type": "object",
-                  "description": "file format supported by Biopython ``SeqIO.write()``.\nE.g. `{\"format\": \"fasta\"}`."
-                },
-                "credentials": {
-                  "type": [
-                    "object",
-                    "string"
-                  ],
-                  "description": "Credentials required to get access to the underlying filesystem.\nE.g. for ``GCSFileSystem`` it should look like `{\"token\": None}`."
-                },
-                "fs_args": {
-                  "type": "object",
-                  "description": "Extra arguments to pass into underlying filesystem class constructor\n(e.g. `{\"project\": \"my-project\"}` for ``GCSFileSystem``), as well as\n        to pass to the filesystem's `open` method through nested keys\n        `open_args_load` and `open_args_save`.\n        Here you can find all available arguments for `open`:\n        https://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.spec.AbstractFileSystem.open\n        All defaults are preserved, except `mode`, which is set to `r` when loading\n        and to `w` when saving.\n\nNote: Here you can find all supported file formats: https://biopython.org/wiki/SeqIO"
-                }
+          "then": {
+            "properties": {}
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "huggingface.HFDataset"
               }
             }
           },
-          {
-            "if": {
-              "properties": {
-                "type": { "const": "dask.CSVDataset" }
-              }
-            },
-            "then": {
-              "required": ["filepath"],
-              "properties": {
-                "filepath": {
-                  "type": "string",
-                  "description": "Filepath in POSIX format to a CSV file, CSV collection, or directory of a multipart CSV. Supports protocols like `s3://`, `gcs://`, etc."
-                },
-                "load_args": {
-                  "type": "object",
-                  "description": "Additional options for `dask.dataframe.read_csv`. See: https://docs.dask.org/en/stable/generated/dask.dataframe.read_csv.html"
-                },
-                "save_args": {
-                  "type": "object",
-                  "description": "Additional options for `dask.dataframe.to_csv`. See: https://docs.dask.org/en/stable/generated/dask.dataframe.to_csv.html"
-                },
-                "credentials": {
-                  "type": ["object", "null"],
-                  "description": "Credentials required to access the underlying filesystem. E.g., for `GCSFileSystem`: {\"token\": None}."
-                },
-                "fs_args": {
-                  "type": "object",
-                  "description": "Optional parameters for the backend file system driver. See: https://docs.dask.org/en/stable/how-to/connect-to-remote-data.html#optional-parameters"
-                },
-                "metadata": {
-                  "type": ["object", "null"],
-                  "description": "Arbitrary metadata, ignored by Kedro but may be used by users or external plugins."
-                }
-              }
-            }
-          },
-          {
-            "if": {
-              "properties": {
-                "type": {
-                  "const": "dask.ParquetDataset"
-                }
-              }
-            },
-            "then": {
-              "required": [
-                "filepath"
-              ],
-              "properties": {
-                "filepath": {
-                  "type": "string",
-                  "description": "Filepath in POSIX format to a parquet file\nparquet collection or the directory of a multipart parquet."
-                },
-                "load_args": {
-                  "type": "object",
-                  "description": "Additional loading options `dask.dataframe.read_parquet`:\nhttps://docs.dask.org/en/latest/dataframe-api.html#dask.dataframe.read_parquet"
-                },
-                "save_args": {
-                  "type": "object",
-                  "description": "Additional saving options for `dask.dataframe.to_parquet`:\nhttps://docs.dask.org/en/latest/dataframe-api.html#dask.dataframe.to_parquet"
-                },
-                "credentials": {
-                  "type": [
-                    "object",
-                    "string"
-                  ],
-                  "description": "Credentials required to get access to the underlying filesystem.\nE.g. for ``GCSFileSystem`` it should look like `{\"token\": None}`."
-                },
-                "fs_args": {
-                  "type": "object",
-                  "description": "Optional parameters to the backend file system driver:\nhttps://docs.dask.org/en/latest/remote-data-services.html#optional-parameters"
-                }
-              }
-            }
-          },
-          {
-            "if": {
-              "properties": {
-                "type": { "const": "databricks.ManagedTableDataset" }
-              }
-            },
-            "then": {
-              "required": ["table"],
-              "properties": {
-                "table": {
-                  "type": "string",
-                  "description": "The name of the managed table in Databricks."
-                },
-                "catalog": {
-                  "type": ["string", "null"],
-                  "description": "The name of the catalog in Unity. Optional."
-                },
-                "database": {
-                  "type": "string",
-                  "description": "The name of the database (schema). Defaults to 'default'."
-                },
-                "write_mode": {
-                  "type": ["string", "null"],
-                  "enum": ["overwrite", "append", "upsert", null],
-                  "description": "Mode to write data: overwrite, append, or upsert. Upsert requires primary_key."
-                },
-                "dataframe_type": {
-                  "type": "string",
-                  "enum": ["spark", "pandas"],
-                  "description": "Type of dataframe to use. Defaults to 'spark'."
-                },
-                "primary_key": {
-                  "type": ["string", "array", "null"],
-                  "description": "Primary key column(s) for upsert mode."
-                },
-                "version": {
-                  "type": ["object", "null"],
-                  "description": "kedro.io.core.Version instance for versioned data."
-                },
-                "schema": {
-                  "type": ["object", "null"],
-                  "description": "Table schema in JSON form. Used to create the table if provided."
-                },
-                "partition_columns": {
-                  "type": ["array", "null"],
-                  "items": { "type": "string" },
-                  "description": "Columns to use for partitioning the table."
-                },
-                "owner_group": {
-                  "type": ["string", "null"],
-                  "description": "Owner group for table access control."
-                },
-                "metadata": {
-                  "type": ["object", "null"],
-                  "description": "Arbitrary metadata, ignored by Kedro but may be used by external plugins."
-                }
-              }
-            }
-          },
-          {
-            "if": {
-              "properties": {
-                "type": {
-                  "const": "email.EmailMessageDataset"
-                }
-              }
-            },
-            "then": {
-              "required": [
-                "filepath"
-              ],
-              "properties": {
-                "filepath": {
-                  "type": "string",
-                  "description": "Filepath in POSIX format to a text file prefixed with a protocol like `s3://`.\nIf prefix is not provided, `file` protocol (local filesystem) will be used.\nThe prefix should be any protocol supported by ``fsspec``.\nNote: `http(s)` doesn't support versioning."
-                },
-                "load_args": {
-                  "type": "object",
-                  "description": "``email`` options for parsing email messages (arguments passed\ninto ``email.parser.Parser.parse``). Here you can find all available arguments:\nhttps://docs.python.org/3/library/email.parser.html#email.parser.Parser.parse\nIf you would like to specify options for the `Parser`,\nyou can include them under the \"parser\" key. Here you can\nfind all available arguments:\nhttps://docs.python.org/3/library/email.parser.html#email.parser.Parser\nAll defaults are preserved, but \"policy\", which is set to ``email.policy.default``."
-                },
-                "save_args": {
-                  "type": "object",
-                  "description": "``email`` options for generating MIME documents (arguments passed into\n``email.generator.Generator.flatten``). Here you can find all available arguments:\nhttps://docs.python.org/3/library/email.generator.html#email.generator.Generator.flatten\nIf you would like to specify options for the `Generator`,\nyou can include them under the \"generator\" key. Here you can\nfind all available arguments:\nhttps://docs.python.org/3/library/email.generator.html#email.generator.Generator\nAll defaults are preserved."
-                },
-                "credentials": {
-                  "type": [
-                    "object",
-                    "string"
-                  ],
-                  "description": "Credentials required to get access to the underlying filesystem.\nE.g. for ``GCSFileSystem`` it should look like `{\"token\": None}`."
-                },
-                "fs_args": {
-                  "type": "object",
-                  "description": "Extra arguments to pass into underlying filesystem class constructor\n(e.g. `{\"project\": \"my-project\"}` for ``GCSFileSystem``), as well as\nto pass to the filesystem's `open` method through nested keys\n`open_args_load` and `open_args_save`.\nHere you can find all available arguments for `open`:\nhttps://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.spec.AbstractFileSystem.open\nAll defaults are preserved, except `mode`, which is set to `r` when loading\nand to `w` when saving."
-                }
-              }
-            }
-          },
-          {
-            "if": {
-              "properties": {
-                "type": { "const": "geopandas.GenericDataset" }
-              }
-            },
-            "then": {
-              "required": ["filepath"],
-              "properties": {
-                "filepath": {
-                  "type": "string",
-                  "description": "Filepath in POSIX format to a file prefixed with a protocol like `s3://`. If prefix is not provided, `file` protocol (local filesystem) will be used. The prefix should be any protocol supported by fsspec. Note: `http(s)` doesn't support versioning."
-                },
-                "file_format": {
-                  "type": "string",
-                  "description": "String used to match the appropriate load/save method (e.g. 'parquet', 'geojson'). Defaults to 'file'."
-                },
-                "load_args": {
-                  "type": "object",
-                  "description": "GeoPandas options for loading files. See: https://geopandas.org/en/stable/docs/reference/api/geopandas.read_file.html"
-                },
-                "save_args": {
-                  "type": "object",
-                  "description": "GeoPandas options for saving files. See: https://geopandas.org/en/stable/docs/reference/api/geopandas.GeoDataFrame.to_file.html"
-                },
-                "version": {
-                  "type": ["object", "null"],
-                  "description": "kedro.io.core.Version instance for versioned data."
-                },
-                "credentials": {
-                  "type": ["object", "null"],
-                  "description": "Credentials required to access the underlying filesystem. E.g. for GCSFileSystem: {'token': None}."
-                },
-                "fs_args": {
-                  "type": "object",
-                  "description": "Extra arguments for the filesystem class constructor and open method. See: https://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.spec.AbstractFileSystem.open"
-                },
-                "metadata": {
-                  "type": ["object", "null"],
-                  "description": "Arbitrary metadata, ignored by Kedro but may be used by users or external plugins."
-                }
-              }
-            }
-          },
-          {
-            "if": {
-              "properties": {
-                "type": {
-                  "const": "holoviews.HoloviewsWriter"
-                }
-              }
-            },
-            "then": {
-              "required": [
-                "filepath"
-              ],
-              "properties": {
-                "filepath": {
-                  "type": "string",
-                  "description": "Filepath in POSIX format to a text file prefixed with a protocol like `s3://`.\nIf prefix is not provided, `file` protocol (local filesystem) will be used.\nThe prefix should be any protocol supported by ``fsspec``.\nNote: `http(s)` doesn't support versioning."
-                },
-                "fs_args": {
-                  "type": "object",
-                  "description": "Extra arguments to pass into underlying filesystem class constructor\n(e.g. `{\"project\": \"my-project\"}` for ``GCSFileSystem``), as well as\nto pass to the filesystem's `open` method through nested key `open_args_save`.\nHere you can find all available arguments for `open`:\nhttps://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.spec.AbstractFileSystem.open\nAll defaults are preserved, except `mode`, which is set to `wb` when saving."
-                },
-                "credentials": {
-                  "type": [
-                    "object",
-                    "string"
-                  ],
-                  "description": "Credentials required to get access to the underlying filesystem.\nE.g. for ``S3FileSystem`` it should look like:\n`{'key': '<id>', 'secret': '<key>'}}`"
-                },
-                "save_args": {
-                  "type": "object",
-                  "description": "Extra save args passed to `holoviews.save()`. See\nhttps://holoviews.org/reference_manual/holoviews.util.html#holoviews.util.save"
-                }
-              }
-            }
-          },
-          {
-            "if": {
-              "properties": {
-                "type": {
-                  "const": "huggingface.HFDataset"
-                }
-              }
-            },
-            "then": {
-              "required": [
-                "dataset_name"
-              ],
-              "properties": {
-                "dataset_name": {
-                  "type": "string",
-                  "description": "Huggingface dataset name"
-                }
-              }
-            }
-          },
-          {
-            "if": {
-              "properties": {
-                "type": {
-                  "const": "huggingface.HFTransformerPipelineDataset"
-                }
-              }
-            },
-            "then": {
-              "properties": {
-                "task": {
-                  "type": "string",
-                  "description": "Huggingface pipeline task name"
-                },
-                "model_name": {
-                  "type": "string",
-                  "description": "Huggingface model name"
-                },
-                "pipeline_kwargs": {
-                  "type": "object",
-                  "description": "Additional kwargs to be passed into the pipeline"
-                }
-              }
-            }
-          },
-          {
-            "if": {
-              "properties": {
-                "type": {
-                  "enum": [
-                    "huggingface.ArrowDataset",
-                    "huggingface.ParquetDataset",
-                    "huggingface.JSONDataset",
-                    "huggingface.CSVDataset"
-                  ]
-                }
-              }
-            },
-            "then": {
-              "required": ["path"],
-              "properties": {
-                "path": {
-                  "type": "string",
-                  "description": "Path to a directory or file for persisting Hugging Face datasets. Supports local and remote filesystems (e.g. s3://)."
-                },
-                "data_files": {
-                  "type": "object",
-                  "description": "Mapping of split name to filename for loading and saving a DatasetDict from a directory."
-                },
-                "load_args": {
-                  "type": "object",
-                  "description": "Additional arguments passed to the `datasets.load_dataset` function."
-                },
-                "save_args": {
-                  "type": "object",
-                  "description": "Additional arguments passed to the underlying dataset's save method."
-                }
-              }
-            }
-          },
-          {
-            "if": {
-              "properties": {
-                "type": { "const": "ibis.FileDataset" }
-              }
-            },
-            "then": {
-              "required": ["filepath", "file_format"],
-              "properties": {
-                "filepath": {
-                  "type": "string",
-                  "description": "Path to a file to register as a table. Supports local and remote filesystems (e.g. s3://)."
-                },
-                "file_format": {
-                  "type": "string",
-                  "description": "String specifying the file format (e.g. 'csv', 'parquet', 'delta')."
-                },
-                "table_name": {
-                  "type": ["string", "null"],
-                  "description": "The name to use for the created table (on load)."
-                },
-                "credentials": {
-                  "type": ["object", "null"],
-                  "description": "Credentials required to get access to the underlying database."
-                },
-                "connection": {
-                  "type": "object",
-                  "description": "Configuration for connecting to an Ibis backend. E.g. {\"backend\": \"duckdb\", \"database\": \"company.db\"}. If not provided, defaults to DuckDB in in-memory mode."
-                },
-                "load_args": {
-                  "type": "object",
-                  "description": "Additional arguments passed to the Ibis backend's read_{file_format} method."
-                },
-                "save_args": {
-                  "type": "object",
-                  "description": "Additional arguments passed to the Ibis backend's to_{file_format} method."
-                },
-                "fs_args": {
-                  "type": ["object", "null"],
-                  "description": "Extra arguments (e.g. credentials) for the fsspec filesystem used for version discovery and existence checks on a remote filepath. Data reading/writing is delegated to the Ibis backend."
-                },
-                "version": {
-                  "type": ["object", "null"],
-                  "description": "kedro.io.core.Version instance for versioned data."
-                },
-                "metadata": {
-                  "type": ["object", "null"],
-                  "description": "Arbitrary metadata, ignored by Kedro but may be used by users or external plugins."
-                }
-              }
-            }
-          },
-          {
-            "if": {
-              "properties": {
-                "type": { "const": "ibis.TableDataset" }
-              }
-            },
-            "then": {
-              "required": ["table_name"],
-              "properties": {
-                "table_name": {
-                  "type": "string",
-                  "description": "The name of the table or view to read or create."
-                },
-                "database": {
-                  "type": ["string", "null"],
-                  "description": "The name of the database to read from or create in. Can be a dotted string or tuple for multi-level hierarchy."
-                },
-                "credentials": {
-                  "type": ["object", "null"],
-                  "description": "Credentials required to get access to the underlying database."
-                },
-                "connection": {
-                  "type": "object",
-                  "description": "Configuration for connecting to an Ibis backend. E.g. {\"backend\": \"duckdb\", \"database\": \"company.db\"}. If not provided, defaults to DuckDB in in-memory mode."
-                },
-                "load_args": {
-                  "type": "object",
-                  "description": "Additional arguments passed to the Ibis backend's table loading method."
-                },
-                "save_args": {
-                  "type": "object",
-                  "description": "Additional arguments passed to the Ibis backend's create_{materialized} method. By default, materialized as views."
-                },
-                "metadata": {
-                  "type": ["object", "null"],
-                  "description": "Arbitrary metadata, ignored by Kedro but may be used by users or external plugins."
-                }
-              }
-            }
-          },
-          {
-            "if": {
-              "properties": {
-                "type": {
-                  "const": "json.JSONDataset"
-                }
-              }
-            },
-            "then": {
-              "required": [
-                "filepath"
-              ],
-              "properties": {
-                "filepath": {
-                  "type": "string",
-                  "description": "Filepath in POSIX format to a JSON file prefixed with a protocol like `s3://`.\nIf prefix is not provided, `file` protocol (local filesystem) will be used.\nThe prefix should be any protocol supported by ``fsspec``.\nNote: `http(s)` doesn't support versioning."
-                },
-                "save_args": {
-                  "type": "object",
-                  "description": "json options for saving JSON files (arguments passed\ninto ```json.dump``). Here you can find all available arguments:\nhttps://docs.python.org/3/library/json.html\nAll defaults are preserved, but \"default_flow_style\", which is set to False."
-                },
-                "credentials": {
-                  "type": [
-                    "object",
-                    "string"
-                  ],
-                  "description": "Credentials required to get access to the underlying filesystem.\nE.g. for ``GCSFileSystem`` it should look like `{\"token\": None}`."
-                },
-                "fs_args": {
-                  "type": "object",
-                  "description": "Extra arguments to pass into underlying filesystem class constructor\n(e.g. `{\"project\": \"my-project\"}` for ``GCSFileSystem``), as well as\nto pass to the filesystem's `open` method through nested keys\n`open_args_load` and `open_args_save`.\nHere you can find all available arguments for `open`:\nhttps://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.spec.AbstractFileSystem.open\nAll defaults are preserved, except `mode`, which is set to `r` when loading\nand to `w` when saving."
-                }
-              }
-            }
-          },
-          {
-            "if": {
-              "properties": {
-                "type": { "const": "matlab.MatlabDataset" }
-              }
-            },
-            "then": {
-              "required": ["filepath"],
-              "properties": {
-                "filepath": {
-                  "type": "string",
-                  "description": "Filepath in POSIX format to a Matlab file prefixed with a protocol like `s3://`. If prefix is not provided, `file` protocol (local filesystem) will be used. The prefix should be any protocol supported by fsspec. Note: `http(s)` doesn't support versioning."
-                },
-                "save_args": {
-                  "type": "object",
-                  "description": "Options for saving .mat files using scipy.io.savemat."
-                },
-                "version": {
-                  "type": ["object", "null"],
-                  "description": "kedro.io.core.Version instance for versioned data."
-                },
-                "credentials": {
-                  "type": ["object", "null"],
-                  "description": "Credentials required to get access to the underlying filesystem. E.g. for GCSFileSystem: {\"token\": None}."
-                },
-                "fs_args": {
-                  "type": "object",
-                  "description": "Extra arguments for the filesystem class constructor and open method. See: https://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.spec.AbstractFileSystem.open"
-                },
-                "metadata": {
-                  "type": ["object", "null"],
-                  "description": "Arbitrary metadata, ignored by Kedro but may be used by users or external plugins."
-                }
-              }
-            }
-          },
-          {
-            "if": {
-              "properties": {
-                "type": { "const": "matplotlib.MatplotlibDataset" }
-              }
-            },
-            "then": {
-              "required": ["filepath"],
-              "properties": {
-                "filepath": {
-                  "type": "string",
-                  "description": "Filepath in POSIX format to save Matplotlib objects to, prefixed with a protocol like `s3://`. If prefix is not provided, `file` protocol (local filesystem) will be used. The prefix should be any protocol supported by fsspec."
-                },
-                "fs_args": {
-                  "type": "object",
-                  "description": "Extra arguments for the filesystem class constructor and open method. See: https://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.spec.AbstractFileSystem.open"
-                },
-                "credentials": {
-                  "type": ["object", "null"],
-                  "description": "Credentials required to get access to the underlying filesystem. E.g. for S3FileSystem: {'key': '<id>', 'secret': '<key>'}."
-                },
-                "save_args": {
-                  "type": "object",
-                  "description": "Arguments passed to `matplotlib.pyplot.savefig`. See: https://matplotlib.org/api/_as_gen/matplotlib.pyplot.savefig.html"
-                },
-                "version": {
-                  "type": ["object", "null"],
-                  "description": "kedro.io.core.Version instance for versioned data."
-                },
-                "overwrite": {
-                  "type": "boolean",
-                  "description": "If True, any existing image files will be removed. Only relevant when saving multiple Matplotlib objects at once."
-                },
-                "metadata": {
-                  "type": ["object", "null"],
-                  "description": "Arbitrary metadata, ignored by Kedro but may be used by users or external plugins."
-                }
-              }
-            }
-          },
-          {
-            "if": {
-              "properties": {
-                "type": { "const": "networkx.GMLDataset" }
-              }
-            },
-            "then": {
-              "required": ["filepath"],
-              "properties": {
-                "filepath": {
-                  "type": "string",
-                  "description": "Filepath in POSIX format to a GML file prefixed with a protocol like `s3://`. If prefix is not provided, `file` protocol (local filesystem) will be used. The prefix should be any protocol supported by fsspec. Note: `http(s)` doesn't support versioning."
-                },
-                "load_args": {
-                  "type": "object",
-                  "description": "Arguments passed to `networkx.read_gml`. See: https://networkx.org/documentation/stable/reference/readwrite/generated/networkx.readwrite.gml.read_gml.html"
-                },
-                "save_args": {
-                  "type": "object",
-                  "description": "Arguments passed to `networkx.write_gml`. See: https://networkx.org/documentation/stable/reference/readwrite/generated/networkx.readwrite.gml.write_gml.html"
-                },
-                "version": {
-                  "type": ["object", "null"],
-                  "description": "kedro.io.core.Version instance for versioned data."
-                },
-                "credentials": {
-                  "type": ["object", "null"],
-                  "description": "Credentials required to get access to the underlying filesystem. E.g. for GCSFileSystem: {\"token\": None}."
-                },
-                "fs_args": {
-                  "type": "object",
-                  "description": "Extra arguments for the filesystem class constructor and open method. All defaults are preserved, except `mode`, which is set to `rb` when loading and to `wb` when saving. See: https://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.spec.AbstractFileSystem.open"
-                },
-                "metadata": {
-                  "type": ["object", "null"],
-                  "description": "Arbitrary metadata, ignored by Kedro but may be used by users or external plugins."
-                }
-              }
-            }
-          },
-          {
-            "if": {
-              "properties": {
-                "type": { "const": "networkx.GraphMLDataset" }
-              }
-            },
-            "then": {
-              "required": ["filepath"],
-              "properties": {
-                "filepath": {
-                  "type": "string",
-                  "description": "Filepath in POSIX format to a GraphML file prefixed with a protocol like `s3://`. If prefix is not provided, `file` protocol (local filesystem) will be used. The prefix should be any protocol supported by fsspec. Note: `http(s)` doesn't support versioning."
-                },
-                "load_args": {
-                  "type": "object",
-                  "description": "Arguments passed to `networkx.read_graphml`. See: https://networkx.org/documentation/stable/reference/readwrite/generated/networkx.readwrite.graphml.read_graphml.html"
-                },
-                "save_args": {
-                  "type": "object",
-                  "description": "Arguments passed to `networkx.write_graphml`. See: https://networkx.org/documentation/stable/reference/readwrite/generated/networkx.readwrite.graphml.write_graphml.html"
-                },
-                "version": {
-                  "type": ["object", "null"],
-                  "description": "kedro.io.core.Version instance for versioned data."
-                },
-                "credentials": {
-                  "type": ["object", "null"],
-                  "description": "Credentials required to get access to the underlying filesystem. E.g. for GCSFileSystem: {\"token\": None}."
-                },
-                "fs_args": {
-                  "type": "object",
-                  "description": "Extra arguments for the filesystem class constructor and open method. All defaults are preserved, except `mode`, which is set to `rb` when loading and to `wb` when saving. See: https://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.spec.AbstractFileSystem.open"
-                },
-                "metadata": {
-                  "type": ["object", "null"],
-                  "description": "Arbitrary metadata, ignored by Kedro but may be used by users or external plugins."
-                }
-              }
-            }
-          },
-          {
-            "if": {
-              "properties": {
-                "type": { "const": "networkx.JSONDataset" }
-              }
-            },
-            "then": {
-              "required": ["filepath"],
-              "properties": {
-                "filepath": {
-                  "type": "string",
-                  "description": "Filepath in POSIX format to a NetworkX graph JSON file prefixed with a protocol like `s3://`. If prefix is not provided, `file` protocol (local filesystem) will be used. The prefix should be any protocol supported by fsspec. Note: `http(s)` doesn't support versioning."
-                },
-                "load_args": {
-                  "type": "object",
-                  "description": "Arguments passed to `networkx.node_link_graph`. See: https://networkx.org/documentation/stable/reference/readwrite/generated/networkx.readwrite.json_graph.node_link_graph.html"
-                },
-                "save_args": {
-                  "type": "object",
-                  "description": "Arguments passed to `networkx.node_link_data`. See: https://networkx.org/documentation/stable/reference/readwrite/generated/networkx.readwrite.json_graph.node_link_data.html"
-                },
-                "version": {
-                  "type": ["object", "null"],
-                  "description": "kedro.io.core.Version instance for versioned data."
-                },
-                "credentials": {
-                  "type": ["object", "null"],
-                  "description": "Credentials required to get access to the underlying filesystem. E.g. for GCSFileSystem: {\"token\": None}."
-                },
-                "fs_args": {
-                  "type": "object",
-                  "description": "Extra arguments for the filesystem class constructor and open method. All defaults are preserved, except `mode`, which is set to `w` when saving. See: https://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.spec.AbstractFileSystem.open"
-                },
-                "metadata": {
-                  "type": ["object", "null"],
-                  "description": "Arbitrary metadata, ignored by Kedro but may be used by users or external plugins."
-                }
-              }
-            }
-          },
-          {
-            "if": {
-              "properties": {
-                "type": { "const": "openxml.DocxDataset" }
-              }
-            },
-            "then": {
-              "required": ["filepath"],
-              "properties": {
-                "filepath": {
-                  "type": "string",
-                  "description": "Filepath in POSIX format to a .docx file prefixed with a protocol like `s3://`. If prefix is not provided, `file` protocol (local filesystem) will be used. The prefix should be any protocol supported by fsspec. Note: `http(s)` doesn't support versioning."
-                },
-                "version": {
-                  "type": ["object", "null"],
-                  "description": "kedro.io.core.Version instance for versioned data."
-                },
-                "credentials": {
-                  "type": ["object", "null"],
-                  "description": "Credentials required to get access to the underlying filesystem. E.g. for GCSFileSystem: {\"token\": None}."
-                },
-                "fs_args": {
-                  "type": "object",
-                  "description": "Extra arguments for the filesystem class constructor and open method. See: https://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.spec.AbstractFileSystem.open"
-                },
-                "metadata": {
-                  "type": ["object", "null"],
-                  "description": "Arbitrary metadata, ignored by Kedro but may be used by users or external plugins."
-                }
-              }
-            }
-          },
-          {
-            "if": {
-              "properties": {
-                "type": {
-                  "const": "pandas.CSVDataset"
-                }
-              }
-            },
-            "then": {
-              "required": [
-                "filepath"
-              ],
-              "properties": {
-                "filepath": {
-                  "type": "string",
-                  "description": "Filepath in POSIX format to a CSV file prefixed with a protocol like `s3://`.\nIf prefix is not provided, `file` protocol (local filesystem) will be used.\nThe prefix should be any protocol supported by ``fsspec``.\nNote: `http(s)` doesn't support versioning."
-                },
-                "load_args": {
-                  "type": "object",
-                  "description": "Pandas options for loading CSV files.\nHere you can find all available arguments:\nhttps://pandas.pydata.org/pandas-docs/stable/generated/pandas.read_csv.html\nAll defaults are preserved."
-                },
-                "save_args": {
-                  "type": "object",
-                  "description": "Pandas options for saving CSV files.\nHere you can find all available arguments:\nhttps://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.to_csv.html\nAll defaults are preserved, but \"index\", which is set to False."
-                },
-                "credentials": {
-                  "type": [
-                    "object",
-                    "string"
-                  ],
-                  "description": "Credentials required to get access to the underlying filesystem.\nE.g. for ``GCSFileSystem`` it should look like `{\"token\": None}`."
-                },
-                "fs_args": {
-                  "type": "object",
-                  "description": "Extra arguments to pass into underlying filesystem class constructor\n(e.g. `{\"project\": \"my-project\"}` for ``GCSFileSystem``), as well as\nto pass to the filesystem's `open` method through nested keys\n`open_args_load` and `open_args_save`.\nHere you can find all available arguments for `open`:\nhttps://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.spec.AbstractFileSystem.open\nAll defaults are preserved, except `mode`, which is set to `r` when loading\nand to `w` when saving."
-                }
-              }
-            }
-          },
-          {
-            "if": {
-              "properties": {
-                "type": { "const": "pandas.DeltaTableDataset" }
-              }
-            },
-            "then": {
-              "properties": {
-                "filepath": {
-                  "type": ["string", "null"],
-                  "description": "Filepath to a Delta Lake table. Supports protocols like s3://, az://, gs://, or local file. If not provided, catalog_type must be set."
-                },
-                "catalog_type": {
-                  "type": ["string", "null"],
-                  "enum": ["AWS", "UNITY", null],
-                  "description": "Type of catalog to use if not loading from filepath. Must be 'AWS' or 'UNITY'."
-                },
-                "catalog_name": {
-                  "type": ["string", "null"],
-                  "description": "Name of the catalog in AWS Glue or Databricks Unity."
-                },
-                "database": {
-                  "type": ["string", "null"],
-                  "description": "Name of the database (schema) in the catalog."
-                },
-                "table": {
-                  "type": ["string", "null"],
-                  "description": "Name of the table in the catalog."
-                },
-                "load_args": {
-                  "type": "object",
-                  "description": "Additional options for loading, e.g. {'version': 7} to load a specific version."
-                },
-                "save_args": {
-                  "type": "object",
-                  "description": "Additional options for saving, e.g. {'mode': 'overwrite'}. See: https://delta-io.github.io/delta-rs/python/api_reference.html#writing-deltatables"
-                },
-                "credentials": {
-                  "type": ["object", "null"],
-                  "description": "Credentials required to access the underlying filesystem. E.g. for GCSFileSystem: {\"token\": None}."
-                },
-                "fs_args": {
-                  "type": "object",
-                  "description": "Extra arguments for the filesystem class constructor. E.g. {'project': 'my-project'} for GCSFileSystem."
-                },
-                "version": {
-                  "type": ["integer", "null"],
-                  "description": "Version of the Delta table to load. Used in load_args."
-                },
-                "metadata": {
-                  "type": ["object", "null"],
-                  "description": "Arbitrary metadata, ignored by Kedro but may be used by users or external plugins."
-                }
+          "then": {
+            "required": [
+              "dataset_name"
+            ],
+            "properties": {
+              "dataset_name": {
+                "type": "string"
               },
-              "oneOf": [
-                {
-                  "required": ["filepath"]
-                },
-                {
-                  "required": ["catalog_type", "database", "table"]
-                }
-              ]
-            }
-          },
-          {
-            "if": {
-              "properties": {
-                "type": {
-                  "const": "pandas.ExcelDataset"
-                }
-              }
-            },
-            "then": {
-              "required": [
-                "filepath"
-              ],
-              "properties": {
-                "filepath": {
-                  "type": "string",
-                  "description": "Filepath in POSIX format to a Excel file prefixed with a protocol like\n`s3://`. If prefix is not provided, `file` protocol (local filesystem) will be used.\nThe prefix should be any protocol supported by ``fsspec``.\nNote: `http(s)` doesn't support versioning."
-                },
-                "engine": {
-                  "type": "string",
-                  "description": "The engine used to write to excel files. The default\nengine is 'xlsxwriter'."
-                },
-                "load_args": {
-                  "type": "object",
-                  "description": "Pandas options for loading Excel files.\nHere you can find all available arguments:\nhttps://pandas.pydata.org/pandas-docs/stable/generated/pandas.read_excel.html\nAll defaults are preserved, but \"engine\", which is set to \"xlrd\"."
-                },
-                "save_args": {
-                  "type": "object",
-                  "description": "Pandas options for saving Excel files.\nHere you can find all available arguments:\nhttps://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.to_excel.html\nAll defaults are preserved, but \"index\", which is set to False.\nIf you would like to specify options for the `ExcelWriter`,\nyou can include them under the \"writer\" key. Here you can\nfind all available arguments:\nhttps://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.ExcelWriter.html"
-                },
-                "credentials": {
-                  "type": [
-                    "object",
-                    "string"
-                  ],
-                  "description": "Credentials required to get access to the underlying filesystem.\nE.g. for ``GCSFileSystem`` it should look like `{\"token\": None}`."
-                },
-                "fs_args": {
-                  "type": "object",
-                  "description": "Extra arguments to pass into underlying filesystem class constructor\n(e.g. `{\"project\": \"my-project\"}` for ``GCSFileSystem``), as well as\nto pass to the filesystem's `open` method through nested keys\n`open_args_load` and `open_args_save`.\nHere you can find all available arguments for `open`:\nhttps://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.spec.AbstractFileSystem.open\nAll defaults are preserved, except `mode`, which is set to `wb` when saving."
-                }
-              }
-            }
-          },
-          {
-            "if": {
-              "properties": {
-                "type": {
-                  "const": "pandas.FeatherDataset"
-                }
-              }
-            },
-            "then": {
-              "required": [
-                "filepath"
-              ],
-              "properties": {
-                "filepath": {
-                  "type": "string",
-                  "description": "Filepath in POSIX format to a feather file prefixed with a protocol like\n`s3://`. If prefix is not provided, `file` protocol (local filesystem) will be used.\nThe prefix should be any protocol supported by ``fsspec``.\nNote: `http(s)` doesn't support versioning."
-                },
-                "load_args": {
-                  "type": "object",
-                  "description": "Pandas options for loading feather files.\nHere you can find all available arguments:\nhttps://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_feather.html\nAll defaults are preserved."
-                },
-                "credentials": {
-                  "type": [
-                    "object",
-                    "string"
-                  ],
-                  "description": "Credentials required to get access to the underlying filesystem.\nE.g. for ``GCSFileSystem`` it should look like `{\"token\": None}`."
-                },
-                "fs_args": {
-                  "type": "object",
-                  "description": "Extra arguments to pass into underlying filesystem class constructor\n(e.g. `{\"project\": \"my-project\"}` for ``GCSFileSystem``), as well as\nto pass to the filesystem's `open` method through nested keys\n`open_args_load` and `open_args_save`.\nHere you can find all available arguments for `open`:\nhttps://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.spec.AbstractFileSystem.open\nAll defaults are preserved, except `mode`, which is set to `wb` when saving."
-                }
-              }
-            }
-          },
-          {
-            "if": {
-              "properties": {
-                "type": { "const": "pandas.GBQQueryDataset" }
-              }
-            },
-            "then": {
-              "required": ["sql"],
-              "properties": {
-                "sql": {
-                  "type": "string",
-                  "description": "The SQL query statement to execute on Google BigQuery."
-                },
-                "project": {
-                  "type": ["string", "null"],
-                  "description": "Google BigQuery Account project ID. Optional if available from the environment."
-                },
-                "credentials": {
-                  "type": ["object", "string", "null"],
-                  "description": "Credentials for accessing Google APIs. Can be a dictionary, a path to a service account key JSON file, or a `google.auth.credentials.Credentials` object."
-                },
-                "load_args": {
-                  "type": "object",
-                  "description": "Pandas options for loading BigQuery table into a DataFrame. See: https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_gbq.html"
-                },
-                "fs_args": {
-                  "type": "object",
-                  "description": "Extra arguments for the filesystem class constructor (e.g., `{\"project\": \"my-project\"}` for `GCSFileSystem`)."
-                },
-                "filepath": {
-                  "type": ["string", "null"],
-                  "description": "Path to a file containing the SQL query statement. If provided, `sql` must not be set."
-                },
-                "metadata": {
-                  "type": ["object", "null"],
-                  "description": "Arbitrary metadata, ignored by Kedro but may be used by users or external plugins."
-                }
+              "dataset_kwargs": {
+                "type": [
+                  "object",
+                  "null"
+                ]
               },
-              "oneOf": [
-                {
-                  "required": ["sql"]
-                },
-                {
-                  "required": ["filepath"]
-                }
-              ]
-            }
-          },
-          {
-            "if": {
-              "properties": {
-                "type": {
-                  "const": "pandas.GBQTableDataset"
-                }
-              }
-            },
-            "then": {
-              "required": [
-                "dataset",
-                "table_name"
-              ],
-              "properties": {
-                "dataset": {
-                  "type": "string",
-                  "description": "Google BigQuery dataset."
-                },
-                "table_name": {
-                  "type": "string",
-                  "description": "Google BigQuery table name."
-                },
-                "project": {
-                  "type": "string",
-                  "description": "Google BigQuery Account project ID.\nOptional when available from the environment.\nhttps://cloud.google.com/resource-manager/docs/creating-managing-projects"
-                },
-                "credentials": {
-                  "pattern": ".*",
-                  "description": "Credentials for accessing Google APIs.\nEither ``google.auth.credentials.Credentials`` object or dictionary with\nparameters required to instantiate ``google.oauth2.credentials.Credentials``.\nHere you can find all the arguments:\nhttps://google-auth.readthedocs.io/en/latest/reference/google.oauth2.credentials.html"
-                },
-                "load_args": {
-                  "type": "object",
-                  "description": "Pandas options for loading BigQuery table into DataFrame.\nHere you can find all available arguments:\nhttps://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_gbq.html\nAll defaults are preserved."
-                },
-                "save_args": {
-                  "type": "object",
-                  "description": "Pandas options for saving DataFrame to BigQuery table.\nHere you can find all available arguments:\nhttps://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.to_gbq.html\nAll defaults are preserved, but \"progress_bar\", which is set to False."
-                }
-              }
-            }
-          },
-          {
-            "if": {
-              "properties": {
-                "type": {
-                  "const": "pandas.HDFDataset"
-                }
-              }
-            },
-            "then": {
-              "required": [
-                "filepath",
-                "key"
-              ],
-              "properties": {
-                "filepath": {
-                  "type": "string",
-                  "description": "Filepath in POSIX format to a hdf file prefixed with a protocol like `s3://`.\nIf prefix is not provided, `file` protocol (local filesystem) will be used.\nThe prefix should be any protocol supported by ``fsspec``.\nNote: `http(s)` doesn't support versioning."
-                },
-                "key": {
-                  "type": "string",
-                  "description": "Identifier to the group in the HDF store."
-                },
-                "load_args": {
-                  "type": "object",
-                  "description": "PyTables options for loading hdf files.\nYou can find all available arguments at:\nhttps://www.pytables.org/usersguide/libref/top_level.html#tables.open_file\nAll defaults are preserved."
-                },
-                "save_args": {
-                  "type": "object",
-                  "description": "PyTables options for saving hdf files.\nYou can find all available arguments at:\nhttps://www.pytables.org/usersguide/libref/top_level.html#tables.open_file\nAll defaults are preserved."
-                },
-                "credentials": {
-                  "type": [
-                    "object",
-                    "string"
-                  ],
-                  "description": "Credentials required to get access to the underlying filesystem.\nE.g. for ``GCSFileSystem`` it should look like `{\"token\": None}`."
-                },
-                "fs_args": {
-                  "type": "object",
-                  "description": "Extra arguments to pass into underlying filesystem class constructor\n(e.g. `{\"project\": \"my-project\"}` for ``GCSFileSystem``), as well as\nto pass to the filesystem's `open` method through nested keys\n`open_args_load` and `open_args_save`.\nHere you can find all available arguments for `open`:\nhttps://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.spec.AbstractFileSystem.open\nAll defaults are preserved, except `mode`, which is set `wb` when saving."
-                }
-              }
-            }
-          },
-          {
-            "if": {
-              "properties": {
-                "type": {
-                  "const": "pandas.JSONDataset"
-                }
-              }
-            },
-            "then": {
-              "required": [
-                "filepath"
-              ],
-              "properties": {
-                "filepath": {
-                  "type": "string",
-                  "description": "Filepath in POSIX format to a JSON file prefixed with a protocol like `s3://`.\nIf prefix is not provided `file` protocol (local filesystem) will be used.\nThe prefix should be any protocol supported by ``fsspec``.\nNote: `http(s)` doesn't support versioning."
-                },
-                "load_args": {
-                  "type": "object",
-                  "description": "Pandas options for loading JSON files.\nHere you can find all available arguments:\nhttps://pandas.pydata.org/pandas-docs/stable/generated/pandas.read_json.html\nAll defaults are preserved."
-                },
-                "save_args": {
-                  "type": "object",
-                  "description": "Pandas options for saving JSON files.\nHere you can find all available arguments:\nhttps://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.to_json.html\nAll defaults are preserved, but \"index\", which is set to False."
-                },
-                "credentials": {
-                  "type": [
-                    "object",
-                    "string"
-                  ],
-                  "description": "Credentials required to get access to the underlying filesystem.\nE.g. for ``GCSFileSystem`` it should look like `{'token': None}`."
-                },
-                "fs_args": {
-                  "type": "object",
-                  "description": "Extra arguments to pass into underlying filesystem class constructor\n(e.g. `{\"project\": \"my-project\"}` for ``GCSFileSystem``), as well as\nto pass to the filesystem's `open` method through nested keys\n`open_args_load` and `open_args_save`.\nHere you can find all available arguments for `open`:\nhttps://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.spec.AbstractFileSystem.open\nAll defaults are preserved, except `mode`, which is set to `r` when loading\nand to `w` when saving."
-                }
-              }
-            }
-          },
-          {
-            "if": {
-              "properties": {
-                "type": {
-                  "const": "pandas.ParquetDataset"
-                }
-              }
-            },
-            "then": {
-              "required": [
-                "filepath"
-              ],
-              "properties": {
-                "filepath": {
-                  "type": "string",
-                  "description": "Filepath in POSIX format to a Parquet file prefixed with a protocol like\n`s3://`. If prefix is not provided, `file` protocol (local filesystem) will be used.\nThe prefix should be any protocol supported by ``fsspec``.\nIt can also be a path to a directory. If the directory is\nprovided then it can be used for reading partitioned parquet files.\nNote: `http(s)` doesn't support versioning."
-                },
-                "load_args": {
-                  "type": "object",
-                  "description": "Additional options for loading Parquet file(s).\nHere you can find all available arguments when reading single file:\nhttps://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_parquet.html\nHere you can find all available arguments when reading partitioned datasets:\nhttps://arrow.apache.org/docs/python/generated/pyarrow.parquet.ParquetDataset.html#pyarrow.parquet.ParquetDataset.read\nAll defaults are preserved."
-                },
-                "save_args": {
-                  "type": "object",
-                  "description": "Additional saving options for `pyarrow.parquet.write_table` and\n`pyarrow.Table.from_pandas`.\nHere you can find all available arguments for `write_table()`:\nhttps://arrow.apache.org/docs/python/generated/pyarrow.parquet.write_table.html?highlight=write_table#pyarrow.parquet.write_table\nThe arguments for `from_pandas()` should be passed through a nested\nkey: `from_pandas`. E.g.: `save_args = {\"from_pandas\": {\"preserve_index\": False}}`\nHere you can find all available arguments for `from_pandas()`:\nhttps://arrow.apache.org/docs/python/generated/pyarrow.Table.html#pyarrow.Table.from_pandas"
-                },
-                "credentials": {
-                  "type": [
-                    "object",
-                    "string"
-                  ],
-                  "description": "Credentials required to get access to the underlying filesystem.\nE.g. for ``GCSFileSystem`` it should look like `{\"token\": None}`."
-                },
-                "fs_args": {
-                  "type": "object",
-                  "description": "Extra arguments to pass into underlying filesystem class constructor\n(e.g. `{\"project\": \"my-project\"}` for ``GCSFileSystem``), as well as\nto pass to the filesystem's `open` method through nested keys\n`open_args_load` and `open_args_save`.\nHere you can find all available arguments for `open`:\nhttps://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.spec.AbstractFileSystem.open\nAll defaults are preserved."
-                }
-              }
-            }
-          },
-          {
-            "if": {
-              "properties": {
-                "type": {
-                  "const": "pandas.SQLTableDataset"
-                }
-              }
-            },
-            "then": {
-              "required": [
-                "table_name",
-                "credentials"
-              ],
-              "properties": {
-                "table_name": {
-                  "type": "string",
-                  "description": "The table name to load or save data to. It\noverwrites name in ``save_args`` and ``table_name``\nparameters in ``load_args``."
-                },
-                "credentials": {
-                  "type": [
-                    "object",
-                    "string"
-                  ],
-                  "description": "A dictionary with a ``SQLAlchemy`` connection string.\nUsers are supposed to provide the connection string 'con'\nthrough credentials. It overwrites `con` parameter in\n``load_args`` and ``save_args`` in case it is provided. To find\nall supported connection string formats, see here:\nhttps://docs.sqlalchemy.org/en/13/core/engines.html#database-urls"
-                },
-                "load_args": {
-                  "type": "object",
-                  "description": "Provided to underlying pandas ``read_sql_table``\nfunction along with the connection string.\nTo find all supported arguments, see here:\nhttps://pandas.pydata.org/pandas-docs/stable/generated/pandas.read_sql_table.html\nTo find all supported connection string formats, see here:\nhttps://docs.sqlalchemy.org/en/13/core/engines.html#database-urls"
-                },
-                "save_args": {
-                  "type": "object",
-                  "description": "Provided to underlying pandas ``to_sql`` function along\nwith the connection string.\nTo find all supported arguments, see here:\nhttps://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.to_sql.html\nTo find all supported connection string formats, see here:\nhttps://docs.sqlalchemy.org/en/13/core/engines.html#database-urls\nIt has ``index=False`` in the default parameters."
-                }
-              }
-            }
-          },
-          {
-            "if": {
-              "properties": {
-                "type": {
-                  "const": "pandas.SQLQueryDataset"
-                }
-              }
-            },
-            "then": {
-              "required": [
-                "sql",
-                "credentials"
-              ],
-              "properties": {
-                "sql": {
-                  "type": "string",
-                  "description": "The sql query statement."
-                },
-                "credentials": {
-                  "type": [
-                    "object",
-                    "string"
-                  ],
-                  "description": "A dictionary with a ``SQLAlchemy`` connection string.\nUsers are supposed to provide the connection string 'con'\nthrough credentials. It overwrites `con` parameter in\n``load_args`` and ``save_args`` in case it is provided. To find\nall supported connection string formats, see here:\nhttps://docs.sqlalchemy.org/en/13/core/engines.html#database-urls"
-                },
-                "load_args": {
-                  "type": "object",
-                  "description": "Provided to underlying pandas ``read_sql_query``\nfunction along with the connection string.\nTo find all supported arguments, see here:\nhttps://pandas.pydata.org/pandas-docs/stable/generated/pandas.read_sql_query.html\nTo find all supported connection string formats, see here:\nhttps://docs.sqlalchemy.org/en/13/core/engines.html#database-urls"
-                },
-                "execution_options": {
-                  "type": "object",
-                  "description": "A dictionary with non-SQL options for the connection\nto be applied to the underlying engine.\nTo find all supported execution options, see here:\nhttps://docs.sqlalchemy.org/en/12/core/connections.html#sqlalchemy.engine.Connection.execution_options \nNote that this is not a standard argument supported by pandas API, but could be useful for handling large datasets."
-                }
-              }
-            }
-          },
-          {
-            "if": {
-              "properties": {
-                "type": {
-                  "const": "pandas.XMLDataset"
-                }
-              }
-            },
-            "then": {
-              "required": [
-                "filepath"
-              ],
-              "properties": {
-                "filepath": {
-                  "type": "string",
-                  "description": "Filepath in POSIX format to a XML file prefixed with a protocol like `s3://`.\nIf prefix is not provided, `file` protocol (local filesystem) will be used.\nThe prefix should be any protocol supported by ``fsspec``.\nNote: `http(s)` doesn't support versioning."
-                },
-                "load_args": {
-                  "type": "object",
-                  "description": "Pandas options for loading XML files.\nHere you can find all available arguments:\nhttps://pandas.pydata.org/pandas-docs/stable/generated/pandas.read_xml.html\nAll defaults are preserved."
-                },
-                "save_args": {
-                  "type": "object",
-                  "description": "Pandas options for saving XML files.\nHere you can find all available arguments:\nhttps://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.to_xml.html\nAll defaults are preserved, but \"index\", which is set to False."
-                },
-                "credentials": {
-                  "type": [
-                    "object",
-                    "string"
-                  ],
-                  "description": "Credentials required to get access to the underlying filesystem.\nE.g. for ``GCSFileSystem`` it should look like `{\"token\": None}`."
-                },
-                "fs_args": {
-                  "type": "object",
-                  "description": "Extra arguments to pass into underlying filesystem class constructor\n(e.g. `{\"project\": \"my-project\"}` for ``GCSFileSystem``), as well as\nto pass to the filesystem's `open` method through nested keys\n`open_args_load` and `open_args_save`.\nHere you can find all available arguments for `open`:\nhttps://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.spec.AbstractFileSystem.open\nAll defaults are preserved, except `mode`, which is set to `r` when loading\nand to `w` when saving."
-                }
-              }
-            }
-          },
-                    {
-            "if": {
-              "properties": {
-                "type": {
-                  "const": "partitions.IncrementalDataset"
-                }
-              }
-            },
-            "then": {
-              "required": [
-                "path",
-                "dataset"
-              ],
-              "properties": {
-                "path": {
-                  "type": "string",
-                  "description": "Path to the folder containing partitioned data.\nIf path starts with the protocol (e.g., ``s3://``) then the\ncorresponding ``fsspec`` concrete filesystem implementation will\nbe used. If protocol is not specified,\n``fsspec.implementations.local.LocalFileSystem`` will be used.\n**Note:** Some concrete implementations are bundled with ``fsspec``,\nwhile others (like ``s3`` or ``gcs``) must be installed separately\nprior to usage of the ``PartitionedDataset``."
-                },
-                "dataset": {
-                  "pattern": ".*",
-                  "description": "Underlying dataset definition. This is used to instantiate\nthe dataset for each file located inside the ``path``.\nAccepted formats are:\na) object of a class that inherits from ``AbstractDataset``\nb) a string representing a fully qualified class name to such class\nc) a dictionary with ``type`` key pointing to a string from b),\nother keys are passed to the Dataset initializer.\nCredentials for the dataset can be explicitly specified in\nthis configuration."
-                },
-                "checkpoint": {
-                  "pattern": "object",
-                  "description": "Optional checkpoint configuration. Accepts a dictionary\nwith the corresponding dataset definition including ``filepath``\n(unlike ``dataset`` argument). Checkpoint configuration is\ndescribed here:\nhttps://kedro.readthedocs.io/en/0.19.0/data/kedro_io.html#checkpoint-configuration\nCredentials for the checkpoint can be explicitly specified\nin this configuration."
-                },
-                "filepath_arg": {
-                  "type": "string",
-                  "description": "Underlying dataset initializer argument that will\ncontain a path to each corresponding partition file.\nIf unspecified, defaults to \"filepath\"."
-                },
-                "filename_suffix": {
-                  "type": "string",
-                  "description": "If specified, only partitions that end with this\nstring will be processed."
-                },
-                "credentials": {
-                  "type": [
-                    "object",
-                    "string"
-                  ],
-                  "description": "Protocol-specific options that will be passed to\n``fsspec.filesystem``\nhttps://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.filesystem\nand the dataset initializer. If the dataset config contains\nexplicit credentials spec, then such spec will take precedence.\nAll possible credentials management scenarios are documented here:\nhttps://kedro.readthedocs.io/en/0.19.0/data/kedro_io.html#partitioned-dataset-credentials"
-                },
-                "load_args": {
-                  "type": "object",
-                  "description": "Keyword arguments to be passed into ``find()`` method of\nthe filesystem implementation."
-                },
-                "fs_args": {
-                  "type": "object",
-                  "description": "Extra arguments to pass into underlying filesystem class constructor\n(e.g. `{\"project\": \"my-project\"}` for ``GCSFileSystem``)"
-                }
-              }
-            }
-          },
-          {
-            "if": {
-              "properties": {
-                "type": {
-                  "const": "partitions.PartitionedDataset"
-                }
-              }
-            },
-            "then": {
-              "required": [
-                "path",
-                "dataset"
-              ],
-              "properties": {
-                "path": {
-                  "type": "string",
-                  "description": "Path to the folder containing partitioned data.\nIf path starts with the protocol (e.g., ``s3://``) then the\ncorresponding ``fsspec`` concrete filesystem implementation will\nbe used. If protocol is not specified,\n``fsspec.implementations.local.LocalFileSystem`` will be used.\n**Note:** Some concrete implementations are bundled with ``fsspec``,\nwhile others (like ``s3`` or ``gcs``) must be installed separately\nprior to usage of the ``PartitionedDataset``."
-                },
-                "dataset": {
-                  "pattern": ".*",
-                  "description": "Underlying dataset definition. This is used to instantiate\nthe dataset for each file located inside the ``path``.\nAccepted formats are:\na) object of a class that inherits from ``AbstractDataset``\nb) a string representing a fully qualified class name to such class\nc) a dictionary with ``type`` key pointing to a string from b),\nother keys are passed to the Dataset initializer.\nCredentials for the dataset can be explicitly specified in\nthis configuration."
-                },
-                "filepath_arg": {
-                  "type": "string",
-                  "description": "Underlying dataset initializer argument that will\ncontain a path to each corresponding partition file.\nIf unspecified, defaults to \"filepath\"."
-                },
-                "filename_suffix": {
-                  "type": "string",
-                  "description": "If specified, only partitions that end with this\nstring will be processed."
-                },
-                "credentials": {
-                  "type": [
-                    "object",
-                    "string"
-                  ],
-                  "description": "Protocol-specific options that will be passed to\n``fsspec.filesystem``\nhttps://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.filesystem\nand the dataset initializer. If the dataset config contains\nexplicit credentials spec, then such spec will take precedence.\nAll possible credentials management scenarios are documented here:\nhttps://kedro.readthedocs.io/en/0.19.0/data/kedro_io.html#partitioned-dataset-credentials"
-                },
-                "load_args": {
-                  "type": "object",
-                  "description": "Keyword arguments to be passed into ``find()`` method of\nthe filesystem implementation."
-                },
-                "fs_args": {
-                  "type": "object",
-                  "description": "Extra arguments to pass into underlying filesystem class constructor\n(e.g. `{\"project\": \"my-project\"}` for ``GCSFileSystem``)"
-                }
-              }
-            }
-          },
-          {
-            "if": {
-              "properties": {
-                "type": {
-                  "const": "pickle.PickleDataset"
-                }
-              }
-            },
-            "then": {
-              "required": [
-                "filepath"
-              ],
-              "properties": {
-                "filepath": {
-                  "type": "string",
-                  "description": "Filepath in POSIX format to a Pickle file prefixed with a protocol like\n`s3://`. If prefix is not provided, `file` protocol (local filesystem) will be used.\nThe prefix should be any protocol supported by ``fsspec``.\nNote: `http(s)` doesn't support versioning."
-                },
-                "backend": {
-                  "type": "string",
-                  "description": "Backend to use, must be one of ['pickle', 'joblib']. Defaults to 'pickle'."
-                },
-                "load_args": {
-                  "type": "object",
-                  "description": "Pickle options for loading pickle files.\nHere you can find all available arguments for different backends:\npickle.load: https://docs.python.org/3/library/pickle.html#pickle.load\njoblib.load: https://joblib.readthedocs.io/en/latest/generated/joblib.load.html\nAll defaults are preserved."
-                },
-                "save_args": {
-                  "type": "object",
-                  "description": "Pickle options for saving pickle files.\nHere you can find all available arguments for different backends:\npickle.dump: https://docs.python.org/3/library/pickle.html#pickle.dump\njoblib.dump: https://joblib.readthedocs.io/en/latest/generated/joblib.dump.html\nAll defaults are preserved."
-                },
-                "credentials": {
-                  "type": [
-                    "object",
-                    "string"
-                  ],
-                  "description": "Credentials required to get access to the underlying filesystem.\nE.g. for ``GCSFileSystem`` it should look like `{\"token\": None}`."
-                },
-                "fs_args": {
-                  "type": "object",
-                  "description": "Extra arguments to pass into underlying filesystem class constructor\n(e.g. `{\"project\": \"my-project\"}` for ``GCSFileSystem``), as well as\nto pass to the filesystem's `open` method through nested keys\n`open_args_load` and `open_args_save`.\nHere you can find all available arguments for `open`:\nhttps://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.spec.AbstractFileSystem.open\nAll defaults are preserved, except `mode`, which is set to `wb` when saving."
-                }
-              }
-            }
-          },
-          {
-            "if": {
-              "properties": {
-                "type": { "const": "plotly.HTMLDataset" }
-              }
-            },
-            "then": {
-              "required": ["filepath"],
-              "properties": {
-                "filepath": {
-                  "type": "string",
-                  "description": "Filepath in POSIX format to an HTML file prefixed with a protocol like `s3://`. If prefix is not provided, `file` protocol (local filesystem) will be used. The prefix should be any protocol supported by fsspec. Note: `http(s)` doesn't support versioning."
-                },
-                "save_args": {
-                  "type": "object",
-                  "description": "Plotly options for saving HTML files. See: https://plotly.com/python-api-reference/generated/plotly.io.write_html.html"
-                },
-                "version": {
-                  "type": ["object", "null"],
-                  "description": "kedro.io.core.Version instance for versioned data."
-                },
-                "credentials": {
-                  "type": ["object", "null"],
-                  "description": "Credentials required to get access to the underlying filesystem. E.g. for GCSFileSystem: {\"token\": None}."
-                },
-                "fs_args": {
-                  "type": "object",
-                  "description": "Extra arguments for the filesystem class constructor and open method. See: https://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.spec.AbstractFileSystem.open"
-                },
-                "metadata": {
-                  "type": ["object", "null"],
-                  "description": "Arbitrary metadata, ignored by Kedro but may be used by users or external plugins."
-                }
-              }
-            }
-          },
-          {
-            "if": {
-              "properties": {
-                "type": { "const": "plotly.JSONDataset" }
-              }
-            },
-            "then": {
-              "required": ["filepath"],
-              "properties": {
-                "filepath": {
-                  "type": "string",
-                  "description": "Filepath in POSIX format to a JSON file prefixed with a protocol like `s3://`. If prefix is not provided, `file` protocol (local filesystem) will be used. The prefix should be any protocol supported by fsspec. Note: `http(s)` doesn't support versioning."
-                },
-                "load_args": {
-                  "type": "object",
-                  "description": "Plotly options for loading JSON files. See: https://plotly.com/python-api-reference/generated/plotly.io.from_json.html"
-                },
-                "save_args": {
-                  "type": "object",
-                  "description": "Plotly options for saving JSON files. See: https://plotly.com/python-api-reference/generated/plotly.io.write_json.html"
-                },
-                "version": {
-                  "type": ["object", "null"],
-                  "description": "kedro.io.core.Version instance for versioned data."
-                },
-                "credentials": {
-                  "type": ["object", "null"],
-                  "description": "Credentials required to get access to the underlying filesystem. E.g. for GCSFileSystem: {\"token\": None}."
-                },
-                "fs_args": {
-                  "type": "object",
-                  "description": "Extra arguments for the filesystem class constructor and open method. See: https://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.spec.AbstractFileSystem.open"
-                },
-                "metadata": {
-                  "type": ["object", "null"],
-                  "description": "Arbitrary metadata, ignored by Kedro but may be used by users or external plugins."
-                }
-              }
-            }
-          },
-          {
-            "if": {
-              "properties": {
-                "type": {
-                  "const": "plotly.PlotlyDataset"
-                }
-              }
-            },
-            "then": {
-              "required": [
-                "filepath",
-                "plotly_args"
-              ],
-              "properties": {
-                "filepath": {
-                  "type": "string",
-                  "description": "Filepath in POSIX format to a JSON file prefixed with a protocol like `s3://`.\nIf prefix is not provided `file` protocol (local filesystem) will be used.\nThe prefix should be any protocol supported by ``fsspec``.\nNote: `http(s)` doesn't support versioning."
-                },
-                "plotly_args": {
-                  "type": "object",
-                  "description": "Plotly configuration for generating a plotly graph object Figure\nrepresenting the plotted data."
-                },
-                "load_args": {
-                  "type": "object",
-                  "description": "Plotly options for loading JSON files.\nHere you can find all available arguments:\nhttps://plotly.com/python-api-reference/generated/plotly.io.from_json.html#plotly.io.from_json\nAll defaults are preserved."
-                },
-                "save_args": {
-                  "type": "object",
-                  "description": "Plotly options for saving JSON files.\nHere you can find all available arguments:\nhttps://plotly.com/python-api-reference/generated/plotly.io.write_json.html\nAll defaults are preserved, but \"index\", which is set to False."
-                },
-                "credentials": {
-                  "type": [
-                    "object",
-                    "string"
-                  ],
-                  "description": "Credentials required to get access to the underlying filesystem.\nE.g. for ``GCSFileSystem`` it should look like `{'token': None}`."
-                },
-                "fs_args": {
-                  "type": "object",
-                  "description": "Extra arguments to pass into underlying filesystem class constructor\n(e.g. `{\"project\": \"my-project\"}` for ``GCSFileSystem``), as well as\nto pass to the filesystem's `open` method through nested key `open_args_save`.\nHere you can find all available arguments for `open`:\nhttps://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.spec.AbstractFileSystem.open\nAll defaults are preserved, except `mode`, which is set to `wb` when saving."
-                }
-              }
-            }
-          },
-          {
-            "if": {
-              "properties": {
-                "type": {
-                  "const": "pillow.ImageDataset"
-                }
-              }
-            },
-            "then": {
-              "required": [
-                "filepath"
-              ],
-              "properties": {
-                "filepath": {
-                  "type": "string",
-                  "description": "Filepath in POSIX format to an image file prefixed with a protocol like\n`s3://`. If prefix is not provided, `file` protocol (local filesystem) will be used.\nThe prefix should be any protocol supported by ``fsspec``.\nNote: `http(s)` doesn't support versioning."
-                },
-                "save_args": {
-                  "type": "object",
-                  "description": "Pillow options for saving image files.\nHere you can find all available arguments:\nhttps://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.save\nAll defaults are preserved."
-                },
-                "credentials": {
-                  "type": [
-                    "object",
-                    "string"
-                  ],
-                  "description": "Credentials required to get access to the underlying filesystem.\nE.g. for ``GCSFileSystem`` it should look like `{\"token\": None}`."
-                },
-                "fs_args": {
-                  "type": "object",
-                  "description": "Extra arguments to pass into underlying filesystem class constructor\n(e.g. `{\"project\": \"my-project\"}` for ``GCSFileSystem``), as well as\nto pass to the filesystem's `open` method through nested keys\n`open_args_load` and `open_args_save`.\nHere you can find all available arguments for `open`:\nhttps://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.spec.AbstractFileSystem.open\nAll defaults are preserved, except `mode`, which is set to `r` when loading\nand to `w` when saving."
-                }
-              }
-            }
-          },
-          {
-            "if": {
-              "properties": {
-                "type": { "const": "polars.CSVDataset" }
-              }
-            },
-            "then": {
-              "required": ["filepath"],
-              "properties": {
-                "filepath": {
-                  "type": "string",
-                  "description": "Filepath in POSIX format to a CSV file prefixed with a protocol like `s3://`. If prefix is not provided, `file` protocol (local filesystem) will be used. The prefix should be any protocol supported by fsspec. Note: `http(s)` doesn't support versioning."
-                },
-                "load_args": {
-                  "type": "object",
-                  "description": "Polars options for loading CSV files. See: https://pola-rs.github.io/polars/py-polars/html/reference/api/polars.read_csv.html"
-                },
-                "save_args": {
-                  "type": "object",
-                  "description": "Polars options for saving CSV files. See: https://pola-rs.github.io/polars/py-polars/html/reference/api/polars.DataFrame.write_csv.html"
-                },
-                "version": {
-                  "type": ["object", "null"],
-                  "description": "kedro.io.core.Version instance for versioned data."
-                },
-                "credentials": {
-                  "type": ["object", "null"],
-                  "description": "Credentials required to get access to the underlying filesystem. E.g. for GCSFileSystem: {\"token\": None}."
-                },
-                "fs_args": {
-                  "type": "object",
-                  "description": "Extra arguments for the filesystem class constructor and open method. See: https://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.spec.AbstractFileSystem.open"
-                },
-                "metadata": {
-                  "type": ["object", "null"],
-                  "description": "Arbitrary metadata, ignored by Kedro but may be used by users or external plugins."
-                }
-              }
-            }
-          },
-          {
-            "if": {
-              "properties": {
-                "type": { "const": "polars.EagerPolarsDataset" }
-              }
-            },
-            "then": {
-              "required": ["filepath", "file_format"],
-              "properties": {
-                "filepath": {
-                  "type": "string",
-                  "description": "Filepath in POSIX format to a file prefixed with a protocol like `s3://`. If prefix is not provided, `file` protocol (local filesystem) will be used. The prefix should be any protocol supported by fsspec. Note: `http(s)` doesn't support versioning."
-                },
-                "file_format": {
-                  "type": "string",
-                  "description": "String used to match the appropriate Polars load/save method (e.g. 'csv', 'parquet')."
-                },
-                "load_args": {
-                  "type": "object",
-                  "description": "Polars options for loading files. See: https://pola-rs.github.io/polars/py-polars/html/reference/io.html"
-                },
-                "save_args": {
-                  "type": "object",
-                  "description": "Polars options for saving files. See: https://pola-rs.github.io/polars/py-polars/html/reference/io.html"
-                },
-                "version": {
-                  "type": ["object", "null"],
-                  "description": "kedro.io.core.Version instance for versioned data."
-                },
-                "credentials": {
-                  "type": ["object", "null"],
-                  "description": "Credentials required to get access to the underlying filesystem. E.g. for GCSFileSystem: {\"token\": None}."
-                },
-                "fs_args": {
-                  "type": "object",
-                  "description": "Extra arguments for the filesystem class constructor and open method. See: https://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.spec.AbstractFileSystem.open"
-                },
-                "metadata": {
-                  "type": ["object", "null"],
-                  "description": "Arbitrary metadata, ignored by Kedro but may be used by users or external plugins."
-                }
-              }
-            }
-          },
-          {
-            "if": {
-              "properties": {
-                "type": { "const": "polars.LazyPolarsDataset" }
-              }
-            },
-            "then": {
-              "required": ["filepath", "file_format"],
-              "properties": {
-                "filepath": {
-                  "type": "string",
-                  "description": "Filepath in POSIX format to a file prefixed with a protocol like `s3://`. If prefix is not provided, `file` protocol (local filesystem) will be used. The prefix should be any protocol supported by fsspec. Note: `http(s)` doesn't support versioning."
-                },
-                "file_format": {
-                  "type": "string",
-                  "enum": ["csv", "parquet"],
-                  "description": "String used to match the appropriate Polars load/save method (e.g. 'csv', 'parquet')."
-                },
-                "load_args": {
-                  "type": "object",
-                  "description": "Polars options for loading files. See: https://pola-rs.github.io/polars/py-polars/html/reference/io.html"
-                },
-                "save_args": {
-                  "type": "object",
-                  "description": "Polars options for saving files. See: https://pola-rs.github.io/polars/py-polars/html/reference/io.html"
-                },
-                "version": {
-                  "type": ["object", "null"],
-                  "description": "kedro.io.core.Version instance for versioned data."
-                },
-                "credentials": {
-                  "type": ["object", "null"],
-                  "description": "Credentials required to get access to the underlying filesystem. E.g. for GCSFileSystem: {\"token\": None}."
-                },
-                "fs_args": {
-                  "type": "object",
-                  "description": "Extra arguments for the filesystem class constructor and open method. See: https://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.spec.AbstractFileSystem.open"
-                },
-                "metadata": {
-                  "type": ["object", "null"],
-                  "description": "Arbitrary metadata, ignored by Kedro but may be used by users or external plugins."
-                }
-              }
-            }
-          },
-          {
-            "if": {
-              "properties": {
-                "type": {
-                  "const": "redis.PickleDataset"
-                }
-              }
-            },
-            "then": {
-              "required": [
-                "key"
-              ],
-              "properties": {
-                "key": {
-                  "type": "string",
-                  "description": "The key to use for saving/loading object to Redis."
-                },
-                "backend": {
-                  "type": "string",
-                  "description": "Backend to use, must be an import path to a module which satisfies the ``pickle`` interface.\nThat is, contains a `loads` and `dumps` function. Defaults to 'pickle'."
-                },
-                "load_args": {
-                  "type": "object",
-                  "description": "Pickle options for loading pickle files.\nHere you can find all available arguments:\nhttps://docs.python.org/3/library/pickle.html#pickle.loads\nAll defaults are preserved."
-                },
-                "save_args": {
-                  "type": "object",
-                  "description": "Pickle options for saving pickle files.\nHere you can find all available arguments:\nhttps://docs.python.org/3/library/pickle.html#pickle.dumps\nAll defaults are preserved."
-                },
-                "credentials": {
-                  "type": "object",
-                  "description": "Credentials required to get access to the redis server."
-                },
-                "redis_args": {
-                  "type": "object",
-                  "description": "Extra arguments to pass into the redis client constructor ``redis.StrictRedis.from_url``, as well as to pass to the ``redis.StrictRedis.set``"
-                }
-              }
-            }
-          },
-          {
-            "if": {
-              "properties": {
-                "type": { "const": "snowflake.SnowparkTableDataset" }
-              }
-            },
-            "then": {
-              "required": ["table_name", "credentials"],
-              "properties": {
-                "table_name": {
-                  "type": "string",
-                  "description": "The name of the table to load or save data to."
-                },
-                "schema": {
-                  "type": ["string", "null"],
-                  "description": "Name of the schema where the table is. Optional if provided in credentials."
-                },
-                "database": {
-                  "type": ["string", "null"],
-                  "description": "Name of the database where the schema is. Optional if provided in credentials."
-                },
-                "load_args": {
-                  "type": "object",
-                  "description": "Arguments for loading data. Currently not used."
-                },
-                "save_args": {
-                  "type": "object",
-                  "description": "Arguments for Snowpark DataFrameWriter.save_as_table. See: https://docs.snowflake.com/en/developer-guide/snowpark/reference/python/api/snowflake.snowpark.DataFrameWriter.saveAsTable.html"
-                },
-                "credentials": {
-                  "type": "object",
-                  "description": "Dictionary with Snowflake connection parameters. See: https://docs.snowflake.com/en/user-guide/python-connector-api.html#connect"
-                },
-                "session": {
-                  "type": ["object", "null"],
-                  "description": "Optional Snowpark session object. Usually not set in YAML."
-                },
-                "metadata": {
-                  "type": ["object", "null"],
-                  "description": "Arbitrary metadata, ignored by Kedro but may be used by users or external plugins."
-                }
-              }
-            }
-          },
-          {
-            "if": {
-              "properties": {
-                "type": { "const": "spark.DeltaTableDataset" }
-              }
-            },
-            "then": {
-              "required": ["filepath"],
-              "properties": {
-                "filepath": {
-                  "type": "string",
-                  "description": "Filepath in POSIX format to a Delta table. When using Databricks, specify paths starting with `/dbfs/mnt` for mount points."
-                },
-                "metadata": {
-                  "type": ["object", "null"],
-                  "description": "Arbitrary metadata, ignored by Kedro but may be used by users or external plugins."
-                }
-              }
-            }
-          },
-          {
-            "if": {
-              "properties": {
-                "type": { "const": "spark.GBQQueryDataset" }
-              }
-            },
-            "then": {
-              "required": ["materialization_dataset"],
-              "properties": {
-                "materialization_dataset": {
-                  "type": "string",
-                  "description": "The name of the dataset to materialize the query results."
-                },
-                "sql": {
-                  "type": ["string", "null"],
-                  "description": "The SQL query to execute on Google BigQuery."
-                },
-                "filepath": {
-                  "type": ["string", "null"],
-                  "description": "Path to a file containing the SQL query statement. If provided, `sql` must not be set."
-                },
-                "materialization_project": {
-                  "type": ["string", "null"],
-                  "description": "The name of the project to materialize the query results. Optional if set in credentials."
-                },
-                "load_args": {
-                  "type": "object",
-                  "description": "Arguments passed to Spark DataFrameReader load method. See: https://spark.apache.org/docs/latest/api/python/getting_started/quickstart_df.html"
-                },
-                "bq_credentials": {
-                  "type": "object",
-                  "description": "Credentials to authenticate Spark session with Google BigQuery. Must contain one of the keys: 'base64', 'file', or 'json'."
-                },
-                "fs_credentials": {
-                  "type": "object",
-                  "description": "Credentials to authenticate with the filesystem. Passed directly to `fsspec.filesystem` constructor."
-                },
-                "fs_args": {
-                  "type": "object",
-                  "description": "Extra arguments for the filesystem class constructor."
-                },
-                "metadata": {
-                  "type": ["object", "null"],
-                  "description": "Arbitrary metadata, ignored by Kedro but may be used by users or external plugins."
-                }
-              },
-              "oneOf": [
-                {
-                  "required": ["sql"]
-                },
-                {
-                  "required": ["filepath"]
-                }
-              ]
-            }
-          },
-          {
-            "if": {
-              "properties": {
-                "type": {
-                  "const": "spark.SparkDataset"
-                }
-              }
-            },
-            "then": {
-              "required": [
-                "filepath"
-              ],
-              "properties": {
-                "filepath": {
-                  "type": "string",
-                  "description": "Filepath in POSIX format to a Spark dataframe. When using Databricks\nand working with data written to mount path points,\nspecify ``filepath``s for (versioned) ``SparkDataset``s\nstarting with ``/dbfs/mnt``."
-                },
-                "file_format": {
-                  "type": "string",
-                  "description": "File format used during load and save\noperations. These are formats supported by the running\nSparkContext include parquet, csv. For a list of supported\nformats please refer to Apache Spark documentation at\nhttps://spark.apache.org/docs/latest/sql-programming-guide.html"
-                },
-                "load_args": {
-                  "type": "object",
-                  "description": "Load args passed to Spark DataFrameReader load method.\nIt is dependent on the selected file format. You can find\na list of read options for each supported format\nin Spark DataFrame read documentation:\nhttps://spark.apache.org/docs/latest/api/python/reference/api/pyspark.sql.DataFrame.html"
-                },
-                "save_args": {
-                  "type": "object",
-                  "description": "Save args passed to Spark DataFrame write options.\nSimilar to load_args this is dependent on the selected file\nformat. You can pass ``mode`` and ``partitionBy`` to specify\nyour overwrite mode and partitioning respectively. You can find\na list of options for each format in Spark DataFrame\nwrite documentation:\nhttps://spark.apache.org/docs/latest/api/python/reference/api/pyspark.sql.DataFrame.html"
-                },
-                "credentials": {
-                  "type": [
-                    "object",
-                    "string"
-                  ],
-                  "description": "Credentials to access the S3 bucket, such as\n``key``, ``secret``, if ``filepath`` prefix is ``s3a://`` or ``s3n://``.\nOptional keyword arguments passed to ``hdfs.client.InsecureClient``\nif ``filepath`` prefix is ``hdfs://``. Ignored otherwise."
-                }
-              }
-            }
-          },
-          {
-            "if": {
-              "properties": {
-                "type": {
-                  "const": "spark.SparkHiveDataset"
-                }
-              }
-            },
-            "then": {
-              "required": [
-                "database",
-                "table",
-                "write_mode"
-              ],
-              "properties": {
-                "database": {
-                  "type": "string",
-                  "description": "The name of the hive database."
-                },
-                "table": {
-                  "type": "string",
-                  "description": "The name of the table within the database."
-                },
-                "write_mode": {
-                  "type": "string",
-                  "description": "``insert``, ``upsert`` or ``overwrite`` are supported."
-                },
-                "table_pk": {
-                  "type": "array",
-                  "description": "If performing an upsert, this identifies the primary key columns used to\nresolve preexisting data. Is required for ``write_mode=\"upsert\"``."
-                }
-              }
-            }
-          },
-          {
-            "if": {
-              "properties": {
-                "type": {
-                  "const": "spark.SparkJDBCDataset"
-                }
-              }
-            },
-            "then": {
-              "required": [
-                "url",
-                "table"
-              ],
-              "properties": {
-                "url": {
-                  "type": "string",
-                  "description": "A JDBC URL of the form ``jdbc:subprotocol:subname``."
-                },
-                "table": {
-                  "type": "string",
-                  "description": "The name of the table to load or save data to."
-                },
-                "credentials": {
-                  "type": [
-                    "object",
-                    "string"
-                  ],
-                  "description": "A dictionary of JDBC database connection arguments.\nNormally at least properties ``user`` and ``password`` with\ntheir corresponding values.  It updates ``properties``\nparameter in ``load_args`` and ``save_args`` in case it is\nprovided."
-                },
-                "load_args": {
-                  "type": "object",
-                  "description": "Provided to underlying PySpark ``jdbc`` function along\nwith the JDBC URL and the name of the table. To find all\nsupported arguments, see here:\nhttps://spark.apache.org/docs/latest/api/python/reference/api/pyspark.sql.DataFrameReader.jdbc.html"
-                },
-                "save_args": {
-                  "type": "object",
-                  "description": "Provided to underlying PySpark ``jdbc`` function along\nwith the JDBC URL and the name of the table. To find all\nsupported arguments, see here:\nhttps://spark.apache.org/docs/latest/api/python/reference/api/pyspark.sql.DataFrameWriter.jdbc.html"
-                }
-              }
-            }
-          },
-          {
-            "if": {
-              "properties": {
-                "type": { "const": "spark.SparkStreamingDataset" }
-              }
-            },
-            "then": {
-              "required": ["file_format"],
-              "properties": {
-                "filepath": {
-                  "type": "string",
-                  "description": "Filepath in POSIX format to a Spark dataframe. For Databricks, use paths starting with `/dbfs/`. For message brokers (e.g. Kafka), filepath is not required."
-                },
-                "file_format": {
-                  "type": "string",
-                  "description": "File format used during load and save operations (e.g. 'json', 'parquet', 'csv', 'delta'). Must be supported by the running SparkContext."
-                },
-                "load_args": {
-                  "type": "object",
-                  "description": "Arguments passed to Spark DataFrameReader.load. Dependent on file format. See: https://spark.apache.org/docs/latest/structured-streaming-programming-guide.html"
-                },
-                "save_args": {
-                  "type": "object",
-                  "description": "Arguments passed to Spark DataFrameWriter.writeStream.options. Dependent on file format. See: https://spark.apache.org/docs/latest/structured-streaming-programming-guide.html"
-                },
-                "metadata": {
-                  "type": ["object", "null"],
-                  "description": "Arbitrary metadata, ignored by Kedro but may be used by users or external plugins."
-                }
-              }
-            }
-          },
-          {
-            "if": {
-              "properties": {
-                "type": { "const": "svmlight.SVMLightDataset" }
-              }
-            },
-            "then": {
-              "required": ["filepath"],
-              "properties": {
-                "filepath": {
-                  "type": "string",
-                  "description": "Filepath in POSIX format to a svmlight/libsvm file prefixed with a protocol like `s3://`. If prefix is not provided, `file` protocol (local filesystem) will be used. The prefix should be any protocol supported by fsspec. Note: `http(s)` doesn't support versioning."
-                },
-                "load_args": {
-                  "type": "object",
-                  "description": "Arguments passed to `sklearn.datasets.load_svmlight_file`. See: https://scikit-learn.org/stable/modules/generated/sklearn.datasets.load_svmlight_file.html"
-                },
-                "save_args": {
-                  "type": "object",
-                  "description": "Arguments passed to `sklearn.datasets.dump_svmlight_file`. See: https://scikit-learn.org/stable/modules/generated/sklearn.datasets.dump_svmlight_file.html"
-                },
-                "version": {
-                  "type": ["object", "null"],
-                  "description": "kedro.io.core.Version instance for versioned data."
-                },
-                "credentials": {
-                  "type": ["object", "null"],
-                  "description": "Credentials required to get access to the underlying filesystem. E.g. for GCSFileSystem: {\"token\": None}."
-                },
-                "fs_args": {
-                  "type": "object",
-                  "description": "Extra arguments for the filesystem class constructor and open method. All defaults are preserved, except `mode`, which is set to `rb` when loading and to `wb` when saving. See: https://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.spec.AbstractFileSystem.open"
-                },
-                "metadata": {
-                  "type": ["object", "null"],
-                  "description": "Arbitrary metadata, ignored by Kedro but may be used by users or external plugins."
-                }
-              }
-            }
-          },
-          {
-            "if": {
-              "properties": {
-                "type": {
-                  "const": "tensorflow.TensorFlowModelDataset"
-                }
-              }
-            },
-            "then": {
-              "required": [
-                "filepath"
-              ],
-              "properties": {
-                "filepath": {
-                  "type": "string",
-                  "description": "Filepath in POSIX format to a TensorFlow model directory prefixed with a\nprotocol like `s3://`. If prefix is not provided `file` protocol (local filesystem)\nwill be used. The prefix should be any protocol supported by ``fsspec``.\nNote: `http(s)` doesn't support versioning."
-                },
-                "load_args": {
-                  "type": "object",
-                  "description": "TensorFlow options for loading models.\nHere you can find all available arguments:\nhttps://www.tensorflow.org/api_docs/python/tf/keras/models/load_model\nAll defaults are preserved."
-                },
-                "save_args": {
-                  "type": "object",
-                  "description": "TensorFlow options for saving models.\nHere you can find all available arguments:\nhttps://www.tensorflow.org/api_docs/python/tf/keras/models/save_model\nAll defaults are preserved, except for \"save_format\", which is set to \"tf\"."
-                },
-                "credentials": {
-                  "type": [
-                    "object",
-                    "string"
-                  ],
-                  "description": "Credentials required to get access to the underlying filesystem.\nE.g. for ``GCSFileSystem`` it should look like `{'token': None}`."
-                },
-                "fs_args": {
-                  "type": "object",
-                  "description": "Extra arguments to pass into underlying filesystem class constructor\n(e.g. `{\"project\": \"my-project\"}` for ``GCSFileSystem``)."
-                }
-              }
-            }
-          },
-          {
-            "if": {
-              "properties": {
-                "type": {
-                  "const": "text.TextDataset"
-                }
-              }
-            },
-            "then": {
-              "required": [
-                "filepath"
-              ],
-              "properties": {
-                "filepath": {
-                  "type": "string",
-                  "description": "Filepath in POSIX format to a text file prefixed with a protocol like `s3://`.\nIf prefix is not provided, `file` protocol (local filesystem) will be used.\nThe prefix should be any protocol supported by ``fsspec``.\nNote: `http(s)` doesn't support versioning."
-                },
-                "credentials": {
-                  "type": [
-                    "object",
-                    "string"
-                  ],
-                  "description": "Credentials required to get access to the underlying filesystem.\nE.g. for ``GCSFileSystem`` it should look like `{\"token\": None}`."
-                },
-                "fs_args": {
-                  "type": "object",
-                  "description": "Extra arguments to pass into underlying filesystem class constructor\n(e.g. `{\"project\": \"my-project\"}` for ``GCSFileSystem``), as well as\nto pass to the filesystem's `open` method through nested keys\n`open_args_load` and `open_args_save`.\nHere you can find all available arguments for `open`:\nhttps://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.spec.AbstractFileSystem.open\nAll defaults are preserved, except `mode`, which is set to `r` when loading\nand to `w` when saving."
-                }
-              }
-            }
-          },
-          {
-            "if": {
-              "properties": {
-                "type": {
-                  "const": "yaml.YAMLDataset"
-                }
-              }
-            },
-            "then": {
-              "required": [
-                "filepath"
-              ],
-              "properties": {
-                "filepath": {
-                  "type": "string",
-                  "description": "Filepath in POSIX format to a YAML file prefixed with a protocol like `s3://`.\nIf prefix is not provided, `file` protocol (local filesystem) will be used.\nThe prefix should be any protocol supported by ``fsspec``.\nNote: `http(s)` doesn't support versioning."
-                },
-                "save_args": {
-                  "type": "object",
-                  "description": "PyYAML options for saving YAML files (arguments passed\ninto ```yaml.dump``). Here you can find all available arguments:\nhttps://pyyaml.org/wiki/PyYAMLDocumentation\nAll defaults are preserved, but \"default_flow_style\", which is set to False."
-                },
-                "credentials": {
-                  "type": [
-                    "object",
-                    "string"
-                  ],
-                  "description": "Credentials required to get access to the underlying filesystem.\nE.g. for ``GCSFileSystem`` it should look like `{\"token\": None}`."
-                },
-                "fs_args": {
-                  "type": "object",
-                  "description": "Extra arguments to pass into underlying filesystem class constructor\n(e.g. `{\"project\": \"my-project\"}` for ``GCSFileSystem``), as well as\nto pass to the filesystem's `open` method through nested keys\n`open_args_load` and `open_args_save`.\nHere you can find all available arguments for `open`:\nhttps://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.spec.AbstractFileSystem.open\nAll defaults are preserved, except `mode`, which is set to `r` when loading\nand to `w` when saving."
-                }
+              "metadata": {
+                "type": [
+                  "object",
+                  "null"
+                ]
               }
             }
           }
-        ]
-      }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "huggingface.HFTransformerPipelineDataset"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "task": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "model_name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "pipeline_kwargs": {
+                "type": [
+                  "object",
+                  "null"
+                ]
+              },
+              "metadata": {
+                "type": [
+                  "object",
+                  "null"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "huggingface.JSONDataset"
+              }
+            }
+          },
+          "then": {
+            "properties": {}
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "huggingface.ParquetDataset"
+              }
+            }
+          },
+          "then": {
+            "properties": {}
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "ibis.FileDataset"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "filepath"
+            ],
+            "properties": {
+              "filepath": {
+                "type": "string",
+                "description": "Path to a file to register as a table. Most useful\nfor loading data into your data warehouse (for testing).\nOn save, the backend exports data to the specified path."
+              },
+              "file_format": {
+                "type": "string",
+                "description": "String specifying the file format for the file.\nDefaults to writing execution results to a Parquet file."
+              },
+              "table_name": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "The name to use for the created table (on load)."
+              },
+              "connection": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Configuration for connecting to an Ibis backend.\nIf not provided, connect to DuckDB in in-memory mode."
+              },
+              "credentials": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Credentials or additional configuration used to\nconnect (e.g. user, password, token, account). If given,\nthese values override the base connection configuration."
+              },
+              "load_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Additional arguments passed to the Ibis backend's\n`read_{file_format}` method."
+              },
+              "save_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Additional arguments passed to the Ibis backend's\n`to_{file_format}` method."
+              },
+              "fs_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Extra arguments to pass into underlying filesystem class\nconstructor (e.g. ``{\"project\": \"my-project\"}`` for\n``GCSFileSystem``). Used only to discover versions and check\nexistence of a remote ``filepath``; reading and writing is left\nto the Ibis backend. Note that fsspec credentials go here, not\nin ``credentials`` (which configures the Ibis connection)."
+              },
+              "version": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "If specified, should be an instance of\n``kedro.io.core.Version``. If its ``load`` attribute is\nNone, the latest version will be loaded. If its ``save``\nattribute is None, save version will be autogenerated."
+              },
+              "metadata": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Any arbitrary metadata. This is ignored by Kedro,\nbut may be consumed by users or external plugins."
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "ibis.TableDataset"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "table_name"
+            ],
+            "properties": {
+              "table_name": {
+                "type": "string",
+                "description": "The name of the table or view to read or create."
+              },
+              "database": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "The name of the database to read the table or view\nfrom or create the table or view in. If not passed, then\nthe current database is used. Provide a tuple of strings\n(e.g. `(\"catalog\", \"database\")`) or a dotted string path\n(e.g. `\"catalog.database\"`) to reference a table or view\nin a multi-level table hierarchy."
+              },
+              "connection": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Configuration for connecting to an Ibis backend.\nIf not provided, connect to DuckDB in in-memory mode."
+              },
+              "credentials": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Credentials or additional configuration used to\nconnect (e.g. user, password, token, account). If given,\nthese values override the base connection configuration."
+              },
+              "load_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Additional arguments passed to the Ibis backend's\n`table` method."
+              },
+              "save_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Additional arguments passed to the Ibis backend's\n`create_{materialized}` method. By default, ``ir.Table``\nobjects are materialized as views. To save a table using\na different materialization strategy, supply a value for\n`materialized` in `save_args`. The `mode` parameter controls\nthe behavior when saving data:\n- _\"overwrite\"_: Overwrite existing data in the table.\n- _\"append\"_: Append contents of the new data to the existing table (does not overwrite).\n- _\"error\"_ or _\"errorifexists\"_: Throw an exception if the table already exists.\n- _\"ignore\"_: Silently ignore the operation if the table already exists.\n- _\"upsert\"_: Update existing rows and insert new rows."
+              },
+              "metadata": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Any arbitrary metadata. This is ignored by Kedro,\nbut may be consumed by users or external plugins."
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "json.JSONDataset"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "filepath"
+            ],
+            "properties": {
+              "filepath": {
+                "type": "string",
+                "description": "Filepath in POSIX format to a JSON file prefixed with a protocol like `s3://`.\nIf prefix is not provided, `file` protocol (local filesystem) will be used.\nThe prefix should be any protocol supported by ``fsspec``.\nNote: `http(s)` doesn't support versioning."
+              },
+              "save_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "json options for saving JSON files (arguments passed\ninto ```json.dump``). Here you can find all available arguments:\nhttps://docs.python.org/3/library/json.html\nAll defaults are preserved, but \"default_flow_style\", which is set to False."
+              },
+              "version": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "If specified, should be an instance of\n``kedro.io.core.Version``. If its ``load`` attribute is\nNone, the latest version will be loaded. If its ``save``\nattribute is None, save version will be autogenerated."
+              },
+              "credentials": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Credentials required to get access to the underlying filesystem.\nE.g. for ``GCSFileSystem`` it should look like `{\"token\": None}`."
+              },
+              "fs_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Extra arguments to pass into underlying filesystem class constructor\n(e.g. `{\"project\": \"my-project\"}` for ``GCSFileSystem``), as well as\nto pass to the filesystem's `open` method through nested keys\n`open_args_load` and `open_args_save`.\nHere you can find all available arguments for `open`:\nhttps://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.spec.AbstractFileSystem.open\nAll defaults are preserved, except `mode`, which is set to `w` when saving."
+              },
+              "metadata": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Any arbitrary metadata.\nThis is ignored by Kedro, but may be consumed by users or external plugins."
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "matlab.MatlabDataset"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "filepath"
+            ],
+            "properties": {
+              "filepath": {
+                "type": "string",
+                "description": "Filepath in POSIX format to a Matlab file prefixed with a protocol like `s3://`.\nIf prefix is not provided, `file` protocol (local filesystem) will be used.\nThe prefix should be any protocol supported by ``fsspec``.\nNote: `http(s)` doesn't support versioning."
+              },
+              "save_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": ".mat options for saving .mat files."
+              },
+              "version": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "If specified, should be an instance of\n``kedro.io.core.Version``. If its ``load`` attribute is\nNone, the latest version will be loaded. If its ``save``\nattribute is None, save version will be autogenerated."
+              },
+              "credentials": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Credentials required to get access to the underlying filesystem.\nE.g. for ``GCSFileSystem`` it should look like `{\"token\": None}`."
+              },
+              "fs_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Extra arguments to pass into underlying filesystem class constructor\n(e.g. `{\"project\": \"my-project\"}` for ``GCSFileSystem``), as well as\nto pass to the filesystem's `open` method through nested keys\n`open_args_load` and `open_args_save`.\nHere you can find all available arguments for `open`:\nhttps://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.spec.AbstractFileSystem.open\nAll defaults are preserved, except `mode`, which is set to `wb` when saving."
+              },
+              "metadata": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Any arbitrary metadata.\nThis is ignored by Kedro, but may be consumed by users or external plugins."
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "matplotlib.MatplotlibDataset"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "filepath"
+            ],
+            "properties": {
+              "filepath": {
+                "type": "string",
+                "description": "Filepath in POSIX format to save Matplotlib objects to, prefixed with a\nprotocol like `s3://`. If prefix is not provided, `file` protocol (local filesystem)\nwill be used. The prefix should be any protocol supported by ``fsspec``."
+              },
+              "fs_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Extra arguments to pass into underlying filesystem class constructor\n(e.g. `{\"project\": \"my-project\"}` for ``GCSFileSystem``), as well as\nto pass to the filesystem's `open` method through nested key `open_args_save`.\nHere you can find all available arguments for `open`:\nhttps://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.spec.AbstractFileSystem.open\nAll defaults are preserved, except `mode`, which is set to `wb` when saving."
+              },
+              "credentials": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Credentials required to get access to the underlying filesystem.\nE.g. for ``S3FileSystem`` it should look like:\n`{'key': '<id>', 'secret': '<key>'}}`"
+              },
+              "save_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Save args passed to `plt.savefig`. See\nhttps://matplotlib.org/api/_as_gen/matplotlib.pyplot.savefig.html"
+              },
+              "version": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "If specified, should be an instance of\n``kedro.io.core.Version``. If its ``load`` attribute is\nNone, the latest version will be loaded. If its ``save``\nattribute is None, save version will be autogenerated."
+              },
+              "overwrite": {
+                "type": "boolean",
+                "description": "If True, any existing image files will be removed.\nOnly relevant when saving multiple Matplotlib objects at\nonce."
+              },
+              "metadata": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Any arbitrary Any arbitrary metadata.\nThis is ignored by Kedro, but may be consumed by users or external plugins."
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "networkx.GMLDataset"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "filepath"
+            ],
+            "properties": {
+              "filepath": {
+                "type": "string",
+                "description": "Filepath in POSIX format to the NetworkX GML file.\nCan be a string or a PathLike object."
+              },
+              "load_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Arguments passed on to ``networkx.read_gml``.\nSee the details in\nhttps://networkx.org/documentation/stable/reference/readwrite/generated/networkx.readwrite.gml.read_gml.html"
+              },
+              "save_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Arguments passed on to ``networkx.write_gml``.\nSee the details in\nhttps://networkx.org/documentation/stable/reference/readwrite/generated/networkx.readwrite.gml.write_gml.html"
+              },
+              "version": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "If specified, should be an instance of\n``kedro.io.core.Version``. If its ``load`` attribute is\nNone, the latest version will be loaded. If its ``save``\nattribute is None, save version will be autogenerated."
+              },
+              "credentials": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Credentials required to get access to the underlying filesystem.\nE.g. for ``GCSFileSystem`` it should look like `{\"token\": None}`."
+              },
+              "fs_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Extra arguments to pass into underlying filesystem class constructor\n(e.g. `{\"project\": \"my-project\"}` for ``GCSFileSystem``), as well as\nto pass to the filesystem's `open` method through nested keys\n`open_args_load` and `open_args_save`.\nHere you can find all available arguments for `open`:\nhttps://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.spec.AbstractFileSystem.open\nAll defaults are preserved, except `mode`, which is set to `rb` when loading\nand to `wb` when saving."
+              },
+              "metadata": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Any arbitrary metadata.\nThis is ignored by Kedro, but may be consumed by users or external plugins."
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "networkx.GraphMLDataset"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "filepath"
+            ],
+            "properties": {
+              "filepath": {
+                "type": "string",
+                "description": "Filepath in POSIX format to the NetworkX GraphML file.\nCan be a string or a PathLike object."
+              },
+              "load_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Arguments passed on to ``networkx.read_graphml``.\nSee the details in\nhttps://networkx.org/documentation/stable/reference/readwrite/generated/networkx.readwrite.graphml.read_graphml.html"
+              },
+              "save_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Arguments passed on to ``networkx.write_graphml``.\nSee the details in\nhttps://networkx.org/documentation/stable/reference/readwrite/generated/networkx.readwrite.graphml.write_graphml.html"
+              },
+              "version": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "If specified, should be an instance of\n``kedro.io.core.Version``. If its ``load`` attribute is\nNone, the latest version will be loaded. If its ``save``\nattribute is None, save version will be autogenerated."
+              },
+              "credentials": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Credentials required to get access to the underlying filesystem.\nE.g. for ``GCSFileSystem`` it should look like `{\"token\": None}`."
+              },
+              "fs_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Extra arguments to pass into underlying filesystem class constructor\n(e.g. `{\"project\": \"my-project\"}` for ``GCSFileSystem``), as well as\nto pass to the filesystem's `open` method through nested keys\n`open_args_load` and `open_args_save`.\nHere you can find all available arguments for `open`:\nhttps://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.spec.AbstractFileSystem.open\nAll defaults are preserved, except `mode`, which is set to `rb` when loading\nand to `wb` when saving."
+              },
+              "metadata": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Any arbitrary metadata.\nThis is ignored by Kedro, but may be consumed by users or external plugins."
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "networkx.JSONDataset"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "filepath"
+            ],
+            "properties": {
+              "filepath": {
+                "type": "string",
+                "description": "Filepath in POSIX format to the NetworkX graph JSON file.\nCan be a string or a PathLike object."
+              },
+              "load_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Arguments passed on to ``networkx.node_link_graph``.\nSee the details in\nhttps://networkx.org/documentation/stable/reference/readwrite/generated/networkx.readwrite.json_graph.node_link_graph.html"
+              },
+              "save_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Arguments passed on to ``networkx.node_link_data``.\nSee the details in\nhttps://networkx.org/documentation/stable/reference/readwrite/generated/networkx.readwrite.json_graph.node_link_data.html"
+              },
+              "version": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "If specified, should be an instance of\n``kedro.io.core.Version``. If its ``load`` attribute is\nNone, the latest version will be loaded. If its ``save``\nattribute is None, save version will be autogenerated."
+              },
+              "credentials": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Credentials required to get access to the underlying filesystem.\nE.g. for ``GCSFileSystem`` it should look like `{\"token\": None}`."
+              },
+              "fs_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Extra arguments to pass into underlying filesystem class constructor\n(e.g. `{\"project\": \"my-project\"}` for ``GCSFileSystem``), as well as\nto pass to the filesystem's `open` method through nested keys\n`open_args_load` and `open_args_save`.\nHere you can find all available arguments for `open`:\nhttps://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.spec.AbstractFileSystem.open\nAll defaults are preserved, except `mode`, which is set to `w` when saving."
+              },
+              "metadata": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Any arbitrary metadata.\nThis is ignored by Kedro, but may be consumed by users or external plugins."
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "openxml.DocxDataset"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "filepath"
+            ],
+            "properties": {
+              "filepath": {
+                "type": "string",
+                "description": "Filepath in POSIX format to a .docx file prefixed with a protocol like `s3://`.\nIf prefix is not provided, `file` protocol (local filesystem) will be used.\nThe prefix should be any protocol supported by ``fsspec``.\nNote: `http(s)` doesn't support versioning."
+              },
+              "version": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "If specified, should be an instance of\n``kedro.io.core.Version``. If its ``load`` attribute is\nNone, the latest version will be loaded. If its ``save``\nattribute is None, save version will be autogenerated."
+              },
+              "credentials": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Credentials required to get access to the underlying filesystem.\nE.g. for ``GCSFileSystem`` it should look like `{\"token\": None}`."
+              },
+              "fs_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Extra arguments to pass into underlying filesystem class constructor\n(e.g. `{\"project\": \"my-project\"}` for ``GCSFileSystem``), as well as\nto pass to the filesystem's `open` method through nested keys\n`open_args_load` and `open_args_save`.\nHere you can find all available arguments for `open`:\nhttps://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.spec.AbstractFileSystem.open\nAll defaults are preserved, except `mode`, which is set to `wb` when saving."
+              },
+              "metadata": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Any arbitrary metadata.\nThis is ignored by Kedro, but may be consumed by users or external plugins."
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "openxml.PptxDataset"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "filepath"
+            ],
+            "properties": {
+              "filepath": {
+                "type": "string",
+                "description": "Filepath in POSIX format to a .pptx file prefixed with a protocol like `s3://`.\nIf prefix is not provided, `file` protocol (local filesystem) will be used.\nThe prefix should be any protocol supported by ``fsspec``.\nNote: `http(s)` doesn't support versioning."
+              },
+              "version": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "If specified, should be an instance of\n``kedro.io.core.Version``. If its ``load`` attribute is\nNone, the latest version will be loaded. If its ``save``\nattribute is None, save version will be autogenerated."
+              },
+              "credentials": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Credentials required to get access to the underlying filesystem.\nE.g. for ``GCSFileSystem`` it should look like `{\"token\": None}`."
+              },
+              "fs_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Extra arguments to pass into underlying filesystem class constructor\n(e.g. `{\"project\": \"my-project\"}` for ``GCSFileSystem``), as well as\nto pass to the filesystem's `open` method through nested keys\n`open_args_load` and `open_args_save`.\nHere you can find all available arguments for `open`:\nhttps://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.spec.AbstractFileSystem.open\nAll defaults are preserved, except `mode`, which is set to `wb` when saving."
+              },
+              "metadata": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Any arbitrary metadata.\nThis is ignored by Kedro, but may be consumed by users or external plugins."
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "pandas.CSVDataset"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "filepath"
+            ],
+            "properties": {
+              "filepath": {
+                "type": "string",
+                "description": "Filepath in POSIX format to a CSV file prefixed with a protocol like `s3://`.\nIf prefix is not provided, `file` protocol (local filesystem) will be used.\nThe prefix should be any protocol supported by ``fsspec``.\nNote: `http(s)` doesn't support versioning.\nCan be a string or a PathLike object."
+              },
+              "load_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Pandas options for loading CSV files.\nHere you can find all available arguments:\nhttps://pandas.pydata.org/pandas-docs/stable/generated/pandas.read_csv.html\nAll defaults are preserved."
+              },
+              "save_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Pandas options for saving CSV files.\nHere you can find all available arguments:\nhttps://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.to_csv.html\nDefaults are preserved, apart from \"index\", which is set to False."
+              },
+              "version": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "If specified, should be an instance of\n``kedro.io.core.Version``. If its ``load`` attribute is\nNone, the latest version will be loaded. If its ``save``\nattribute is None, save version will be autogenerated."
+              },
+              "credentials": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Credentials required to get access to the underlying filesystem.\nE.g. for ``GCSFileSystem`` it should look like `{\"token\": None}`."
+              },
+              "fs_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Extra arguments to pass into underlying filesystem class constructor\n(e.g. `{\"project\": \"my-project\"}` for ``GCSFileSystem``).\nDefaults are preserved, apart from the `open_args_save` `mode` which is set to `w`."
+              },
+              "metadata": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Any arbitrary metadata.\nThis is ignored by Kedro, but may be consumed by users or external plugins."
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "pandas.DeltaTableDataset"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "filepath": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Filepath to a delta lake file with the following accepted protocol:\n``S3``: `s3://<bucket>/<path>`, `s3a://<bucket>/<path>`\n``Azure``: `az://<container>/<path>`, `adl://<container>/<path>`,\n`abfs://<container>/<path>`\n``GCS``: `gs://<bucket>/<path>`\nIf any of the prefix above is not provided, `file` protocol (local filesystem)\nwill be used.\nCan be a string or a PathLike object."
+              },
+              "catalog_type": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "`AWS` or `UNITY` if filepath is not provided.\nDefaults to None."
+              },
+              "catalog_name": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "the name of catalog in AWS Glue or Databricks Unity.\nDefaults to None."
+              },
+              "database": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "the name of the database (also referred to as schema).\nDefaults to None."
+              },
+              "table": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "the name of the table."
+              },
+              "load_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Additional options for loading file(s)\ninto DeltaTableDataset. `load_args` accepts `version` to load the appropriate\nversion when loading from a filesystem."
+              },
+              "save_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Additional saving options for saving into\nDelta lake. Here you can find all available arguments:\nhttps://delta-io.github.io/delta-rs/python/api_reference.html#writing-deltatables"
+              },
+              "credentials": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Credentials required to get access to\nthe underlying filesystem. E.g. for ``GCSFileSystem`` it should look like\n`{\"token\": None}`."
+              },
+              "fs_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Extra arguments to pass into underlying\nfilesystem class constructor.\n(e.g. `{\"project\": \"my-project\"}` for ``GCSFileSystem``)."
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "pandas.ExcelDataset"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "filepath"
+            ],
+            "properties": {
+              "filepath": {
+                "type": "string",
+                "description": "Filepath in POSIX format to a Excel file prefixed with a protocol like\n`s3://`. If prefix is not provided, `file` protocol (local filesystem) will be used.\nThe prefix should be any protocol supported by ``fsspec``.\nNote: `http(s)` doesn't support versioning.\nCan be a string or a PathLike object."
+              },
+              "engine": {
+                "type": "string",
+                "description": "The engine used to write to Excel files. The default\nengine is 'openpyxl'."
+              },
+              "load_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Pandas options for loading Excel files.\nHere you can find all available arguments:\nhttps://pandas.pydata.org/pandas-docs/stable/generated/pandas.read_excel.html\nAll defaults are preserved, but \"engine\", which is set to \"openpyxl\".\nSupports multi-sheet Excel files (include `sheet_name = None` in `load_args`)."
+              },
+              "save_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Pandas options for saving Excel files.\nHere you can find all available arguments:\nhttps://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.to_excel.html\nAll defaults are preserved, but \"index\", which is set to False.\nIf you would like to specify options for the `ExcelWriter`,\nyou can include them under the \"writer\" key. Here you can\nfind all available arguments:\nhttps://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.ExcelWriter.html"
+              },
+              "version": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "If specified, should be an instance of\n``kedro.io.core.Version``. If its ``load`` attribute is\nNone, the latest version will be loaded. If its ``save``\nattribute is None, save version will be autogenerated."
+              },
+              "credentials": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Credentials required to get access to the underlying filesystem.\nE.g. for ``GCSFileSystem`` it should look like `{\"token\": None}`."
+              },
+              "fs_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Extra arguments to pass into underlying filesystem class constructor\n(e.g. `{\"project\": \"my-project\"}` for ``GCSFileSystem``).\nDefaults are preserved, apart from the `open_args_save` `mode` which is set to `wb`.\nNote that the save method requires bytes, so any save mode provided should include \"b\" for bytes."
+              },
+              "metadata": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Any arbitrary metadata.\nThis is ignored by Kedro, but may be consumed by users or external plugins."
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "pandas.FeatherDataset"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "filepath"
+            ],
+            "properties": {
+              "filepath": {
+                "type": "string",
+                "description": "Filepath in POSIX format to a feather file prefixed with a protocol like\n`s3://`. If prefix is not provided, `file` protocol (local filesystem) will be used.\nThe prefix should be any protocol supported by ``fsspec``.\nNote: `http(s)` doesn't support versioning.\nCan be a string or a PathLike object."
+              },
+              "load_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Pandas options for loading feather files.\nHere you can find all available arguments:\nhttps://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_feather.html\nAll defaults are preserved."
+              },
+              "save_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Pandas options for saving feather files.\nHere you can find all available arguments:\nhttps://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.to_feather.html\nAll defaults are preserved."
+              },
+              "version": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "If specified, should be an instance of\n``kedro.io.core.Version``. If its ``load`` attribute is\nNone, the latest version will be loaded. If its ``save``\nattribute is None, save version will be autogenerated."
+              },
+              "credentials": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Credentials required to get access to the underlying filesystem.\nE.g. for ``GCSFileSystem`` it should look like `{\"token\": None}`."
+              },
+              "fs_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Extra arguments to pass into underlying filesystem class constructor\n(e.g. `{\"project\": \"my-project\"}` for ``GCSFileSystem``).\nDefaults are preserved, apart from the `open_args_save` `mode` which is set to `wb`.\nNote that the save method requires bytes, so any save mode provided should include \"b\" for bytes."
+              },
+              "metadata": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Any arbitrary metadata.\nThis is ignored by Kedro, but may be consumed by users or external plugins."
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "pandas.GBQQueryDataset"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "sql": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "The sql query statement."
+              },
+              "project": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Google BigQuery Account project ID.\nOptional when available from the environment.\nhttps://cloud.google.com/resource-manager/docs/creating-managing-projects"
+              },
+              "credentials": {
+                "pattern": ".*",
+                "description": "Credentials for accessing Google APIs.\nEither a credential that bases on ``google.auth.credentials.Credentials`` OR\na service account json as a dictionary OR\na path to a service account key json file.\nhttps://googleapis.dev/python/google-auth/latest/"
+              },
+              "load_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Pandas options for loading BigQuery table into DataFrame.\nHere you can find all available arguments:\nhttps://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_gbq.html\nAll defaults are preserved."
+              },
+              "fs_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Extra arguments to pass into underlying filesystem class constructor\n(e.g. `{\"project\": \"my-project\"}` for ``GCSFileSystem``) used for reading the\nSQL query from filepath."
+              },
+              "filepath": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "A path to a file with a sql query statement. Can be a string or a PathLike object."
+              },
+              "metadata": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Any arbitrary metadata.\nThis is ignored by Kedro, but may be consumed by users or external plugins."
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "pandas.GBQTableDataset"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "dataset",
+              "table_name"
+            ],
+            "properties": {
+              "dataset": {
+                "type": "string",
+                "description": "Google BigQuery dataset."
+              },
+              "table_name": {
+                "type": "string",
+                "description": "Google BigQuery table name."
+              },
+              "project": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Google BigQuery Account project ID.\nOptional when available from the environment.\nhttps://cloud.google.com/resource-manager/docs/creating-managing-projects"
+              },
+              "credentials": {
+                "pattern": ".*",
+                "description": "Credentials for accessing Google APIs.\nEither a credential that bases on ``google.auth.credentials.Credentials`` OR\na service account json as a dictionary OR\na path to a service account key json file.\nhttps://googleapis.dev/python/google-auth/latest/"
+              },
+              "load_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Pandas options for loading BigQuery table into DataFrame.\nHere you can find all available arguments:\nhttps://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_gbq.html\nAll defaults are preserved."
+              },
+              "save_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Pandas options for saving DataFrame to BigQuery table.\nHere you can find all available arguments:\nhttps://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.to_gbq.html\nAll defaults are preserved, but \"progress_bar\", which is set to False."
+              },
+              "metadata": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Any arbitrary metadata.\nThis is ignored by Kedro, but may be consumed by users or external plugins."
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "pandas.GenericDataset"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "filepath",
+              "file_format"
+            ],
+            "properties": {
+              "filepath": {
+                "type": "string",
+                "description": "Filepath in POSIX format to a file prefixed with a protocol like `s3://`.\nIf prefix is not provided, `file` protocol (local filesystem) will be used.\nThe prefix should be any protocol supported by ``fsspec``.\nCan be a string or a PathLike object.\nKey assumption: The first argument of either load/save method points to a\nfilepath/buffer/io type location. There are some read/write targets such\nas 'clipboard' or 'records' that will fail since they do not take a\nfilepath like argument."
+              },
+              "file_format": {
+                "type": "string",
+                "description": "String which is used to match the appropriate load/save method on a best\neffort basis. For example if 'csv' is passed in the `pandas.read_csv` and\n`pandas.DataFrame.to_csv` will be identified. An error will be raised unless\nat least one matching `read_{file_format}` or `to_{file_format}` method is\nidentified."
+              },
+              "load_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Pandas options for loading files.\nHere you can find all available arguments:\nhttps://pandas.pydata.org/pandas-docs/stable/reference/io.html\nAll defaults are preserved."
+              },
+              "save_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Pandas options for saving files.\nHere you can find all available arguments:\nhttps://pandas.pydata.org/pandas-docs/stable/reference/io.html\nAll defaults are preserved, but \"index\", which is set to False."
+              },
+              "version": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "If specified, should be an instance of\n``kedro.io.core.Version``. If its ``load`` attribute is\nNone, the latest version will be loaded. If its ``save``\nattribute is None, save version will be autogenerated."
+              },
+              "credentials": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Credentials required to get access to the underlying filesystem.\nE.g. for ``GCSFileSystem`` it should look like `{\"token\": None}`."
+              },
+              "fs_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Extra arguments to pass into underlying filesystem class constructor\n(e.g. `{\"project\": \"my-project\"}` for ``GCSFileSystem``), as well as\nto pass to the filesystem's `open` method through nested keys\n`open_args_load` and `open_args_save`.\nHere you can find all available arguments for `open`:\nhttps://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.spec.AbstractFileSystem.open\nAll defaults are preserved, except `mode`, which is set to `w` when saving."
+              },
+              "metadata": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Any arbitrary metadata.\nThis is ignored by Kedro, but may be consumed by users or external plugins."
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "pandas.HDFDataset"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "filepath",
+              "key"
+            ],
+            "properties": {
+              "filepath": {
+                "type": "string",
+                "description": "Filepath in POSIX format to a hdf file prefixed with a protocol like `s3://`.\nIf prefix is not provided, `file` protocol (local filesystem) will be used.\nThe prefix should be any protocol supported by ``fsspec``.\nNote: `http(s)` doesn't support versioning.\nCan be a string or a PathLike object."
+              },
+              "key": {
+                "type": "string",
+                "description": "Identifier to the group in the HDF store."
+              },
+              "load_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "PyTables options for loading hdf files.\nYou can find all available arguments at:\nhttps://www.pytables.org/usersguide/libref/top_level.html#tables.open_file\nAll defaults are preserved."
+              },
+              "save_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "PyTables options for saving hdf files.\nYou can find all available arguments at:\nhttps://www.pytables.org/usersguide/libref/top_level.html#tables.open_file\nAll defaults are preserved."
+              },
+              "version": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "If specified, should be an instance of\n``kedro.io.core.Version``. If its ``load`` attribute is\nNone, the latest version will be loaded. If its ``save``\nattribute is None, save version will be autogenerated."
+              },
+              "credentials": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Credentials required to get access to the underlying filesystem.\nE.g. for ``GCSFileSystem`` it should look like `{\"token\": None}`."
+              },
+              "fs_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Extra arguments to pass into underlying filesystem class constructor\n(e.g. `{\"project\": \"my-project\"}` for ``GCSFileSystem``), as well as\nto pass to the filesystem's `open` method through nested keys\n`open_args_load` and `open_args_save`.\nHere you can find all available arguments for `open`:\nhttps://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.spec.AbstractFileSystem.open\nAll defaults are preserved, except `open_args_save` `mode`, which is set `wb` when saving."
+              },
+              "metadata": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Any arbitrary metadata.\nThis is ignored by Kedro, but may be consumed by users or external plugins."
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "pandas.JSONDataset"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "filepath"
+            ],
+            "properties": {
+              "filepath": {
+                "type": "string",
+                "description": "Filepath in POSIX format to a JSON file prefixed with a protocol like `s3://`.\nIf prefix is not provided `file` protocol (local filesystem) will be used.\nThe prefix should be any protocol supported by ``fsspec``.\nNote: `http(s)` doesn't support versioning.\nCan be a string or a PathLike object."
+              },
+              "load_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Pandas options for loading JSON files.\nHere you can find all available arguments:\nhttps://pandas.pydata.org/pandas-docs/stable/generated/pandas.read_json.html\nAll defaults are preserved."
+              },
+              "save_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Pandas options for saving JSON files.\nHere you can find all available arguments:\nhttps://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.to_json.html\nAll defaults are preserved."
+              },
+              "version": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "If specified, should be an instance of\n``kedro.io.core.Version``. If its ``load`` attribute is\nNone, the latest version will be loaded. If its ``save``\nattribute is None, save version will be autogenerated."
+              },
+              "credentials": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Credentials required to get access to the underlying filesystem.\nE.g. for ``GCSFileSystem`` it should look like `{'token': None}`."
+              },
+              "fs_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Extra arguments to pass into underlying filesystem class constructor\n(e.g. `{\"project\": \"my-project\"}` for ``GCSFileSystem``).\nDefaults are preserved, apart from the `open_args_save` `mode` which is set to `w`."
+              },
+              "metadata": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Any arbitrary metadata.\nThis is ignored by Kedro, but may be consumed by users or external plugins."
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "pandas.ParquetDataset"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "filepath"
+            ],
+            "properties": {
+              "filepath": {
+                "type": "string",
+                "description": "Filepath in POSIX format to a Parquet file prefixed with a protocol like\n`s3://`. If prefix is not provided, `file` protocol (local filesystem) will be used.\nThe prefix should be any protocol supported by ``fsspec``.\nIt can also be a path to a directory. If the directory is\nprovided then it can be used for reading partitioned parquet files.\nNote: `http(s)` doesn't support versioning.\nCan be a string or a PathLike object."
+              },
+              "load_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Additional options for loading Parquet file(s).\nHere you can find all available arguments when reading single file:\nhttps://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_parquet.html\nHere you can find all available arguments when reading partitioned datasets:\nhttps://arrow.apache.org/docs/python/generated/pyarrow.parquet.ParquetDataset.html#pyarrow.parquet.ParquetDataset.read\nAll defaults are preserved."
+              },
+              "save_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Additional saving options for saving Parquet file(s).\nHere you can find all available arguments:\nhttps://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.to_parquet.html\nAll defaults are preserved. ``partition_cols`` is not supported."
+              },
+              "version": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "If specified, should be an instance of ``kedro.io.core.Version``.\nIf its ``load`` attribute is None, the latest version will be loaded. If\nits ``save`` attribute is None, save version will be autogenerated."
+              },
+              "credentials": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Credentials required to get access to the underlying filesystem.\nE.g. for ``GCSFileSystem`` it should look like `{\"token\": None}`."
+              },
+              "fs_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Extra arguments to pass into underlying filesystem class constructor\n(e.g. `{\"project\": \"my-project\"}` for ``GCSFileSystem``).\nDefaults are preserved, apart from the `open_args_save` `mode` which is set to `wb`.\nNote that the save method requires bytes, so any save mode provided should include \"b\" for bytes."
+              },
+              "metadata": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Any arbitrary metadata.\nThis is ignored by Kedro, but may be consumed by users or external plugins."
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "pandas.SQLQueryDataset"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "sql": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "The sql query statement."
+              },
+              "credentials": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "A dictionary with a ``SQLAlchemy`` connection string.\nUsers are supposed to provide the connection string 'con'\nthrough credentials. It overwrites `con` parameter in\n``load_args`` and ``save_args`` in case it is provided. To find\nall supported connection string formats, see here:\nhttps://docs.sqlalchemy.org/core/engines.html#database-urls\nAdditional parameters for the sqlalchemy engine can be provided\nalongside the 'con' parameter."
+              },
+              "load_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Provided to underlying pandas ``read_sql_query``\nfunction along with the connection string.\nTo find all supported arguments, see here:\nhttps://pandas.pydata.org/pandas-docs/stable/generated/pandas.read_sql_query.html\nTo find all supported connection string formats, see here:\nhttps://docs.sqlalchemy.org/core/engines.html#database-urls"
+              },
+              "fs_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Extra arguments to pass into underlying filesystem class constructor\n(e.g. `{\"project\": \"my-project\"}` for ``GCSFileSystem``), as well as\nto pass to the filesystem's `open` method through nested keys\n`open_args_load` and `open_args_save`.\nHere you can find all available arguments for `open`:\nhttps://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.spec.AbstractFileSystem.open\nAll defaults are preserved, except `mode`, which is set to `r` when loading."
+              },
+              "filepath": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "A path to a file with a sql query statement. Can be a string or a PathLike object."
+              },
+              "execution_options": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "A dictionary with non-SQL advanced options for the connection to\nbe applied to the underlying engine. To find all supported execution\noptions, see here:\nhttps://docs.sqlalchemy.org/core/connections.html#sqlalchemy.engine.Connection.execution_options\nNote that this is not a standard argument supported by pandas API, but could be\nuseful for handling large datasets."
+              },
+              "metadata": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Any arbitrary metadata.\nThis is ignored by Kedro, but may be consumed by users or external plugins."
+              },
+              "encoding": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "pandas.SQLTableDataset"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "table_name",
+              "credentials"
+            ],
+            "properties": {
+              "table_name": {
+                "type": "string",
+                "description": "The table name to load or save data to. It\noverwrites name in ``save_args`` and ``table_name``\nparameters in ``load_args``."
+              },
+              "credentials": {
+                "type": "object",
+                "description": "A dictionary with a ``SQLAlchemy`` connection string.\nUsers are supposed to provide the connection string 'con'\nthrough credentials.\nTo find all supported connection string formats, see here:\nhttps://docs.sqlalchemy.org/core/engines.html#database-urls\nAdditional parameters for the sqlalchemy engine can be provided\nalongside the 'con' parameter."
+              },
+              "load_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Provided to underlying pandas ``read_sql_table``\nfunction along with the connection string.\nTo find all supported arguments, see here:\nhttps://pandas.pydata.org/pandas-docs/stable/generated/pandas.read_sql_table.html\nTo find all supported connection string formats, see here:\nhttps://docs.sqlalchemy.org/core/engines.html#database-urls"
+              },
+              "save_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Provided to underlying pandas ``to_sql`` function along\nwith the connection string.\nTo find all supported arguments, see here:\nhttps://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.to_sql.html\nTo find all supported connection string formats, see here:\nhttps://docs.sqlalchemy.org/core/engines.html#database-urls\nIt has ``index=False`` in the default parameters."
+              },
+              "metadata": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Any arbitrary metadata.\nThis is ignored by Kedro, but may be consumed by users or external plugins."
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "pandas.XMLDataset"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "filepath"
+            ],
+            "properties": {
+              "filepath": {
+                "type": "string",
+                "description": "Filepath in POSIX format to a XML file prefixed with a protocol like `s3://`.\nIf prefix is not provided, `file` protocol (local filesystem) will be used.\nThe prefix should be any protocol supported by ``fsspec``.\nNote: `http(s)` doesn't support versioning.\nCan be a string or a PathLike object."
+              },
+              "load_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Pandas options for loading XML files.\nHere you can find all available arguments:\nhttps://pandas.pydata.org/docs/reference/api/pandas.read_xml.html\nAll defaults are preserved."
+              },
+              "save_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Pandas options for saving XML files.\nHere you can find all available arguments:\nhttps://pandas.pydata.org/docs/reference/api/pandas.DataFrame.to_xml.html\nAll defaults are preserved, but \"index\", which is set to False."
+              },
+              "version": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "If specified, should be an instance of\n``kedro.io.core.Version``. If its ``load`` attribute is\nNone, the latest version will be loaded. If its ``save``\nattribute is None, save version will be autogenerated."
+              },
+              "credentials": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Credentials required to get access to the underlying filesystem.\nE.g. for ``GCSFileSystem`` it should look like `{\"token\": None}`."
+              },
+              "fs_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Extra arguments to pass into underlying filesystem class constructor\n(e.g. `{\"project\": \"my-project\"}` for ``GCSFileSystem``).\nDefaults are preserved, apart from the `open_args_save` `mode` which is set to `wb`.\nNote that the save method requires bytes, so any save mode provided should include \"b\" for bytes."
+              },
+              "metadata": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Any arbitrary metadata.\nThis is ignored by Kedro, but may be consumed by users or external plugins."
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "partitions.IncrementalDataset"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "path",
+              "dataset"
+            ],
+            "properties": {
+              "path": {
+                "type": "string",
+                "description": "Path to the folder containing partitioned data.\nIf path starts with the protocol (e.g., ``s3://``) then the\ncorresponding ``fsspec`` concrete filesystem implementation will\nbe used. If protocol is not specified,\n``fsspec.implementations.local.LocalFileSystem`` will be used.\n**Note:** Some concrete implementations are bundled with ``fsspec``,\nwhile others (like ``s3`` or ``gcs``) must be installed separately\nprior to usage of the ``PartitionedDataset``."
+              },
+              "dataset": {
+                "pattern": ".*",
+                "description": "Underlying dataset definition. This is used to instantiate\nthe dataset for each file located inside the ``path``.\nAccepted formats are:\na) object of a class that inherits from ``AbstractDataset``\nb) a string representing a fully qualified class name to such class\nc) a dictionary with ``type`` key pointing to a string from b),\nother keys are passed to the Dataset initializer.\nCredentials for the dataset can be explicitly specified in\nthis configuration."
+              },
+              "checkpoint": {
+                "type": [
+                  "string",
+                  "object",
+                  "null"
+                ],
+                "description": "Optional checkpoint configuration. Accepts a dictionary\nwith the corresponding dataset definition including ``filepath``\n(unlike ``dataset`` argument). Checkpoint configuration is\ndescribed here:\nhttps://docs.kedro.org/en/stable/data/partitioned_and_incremental_datasets.html#checkpoint-configuration\nCredentials for the checkpoint can be explicitly specified\nin this configuration."
+              },
+              "filepath_arg": {
+                "type": "string",
+                "description": "Underlying dataset initializer argument that will\ncontain a path to each corresponding partition file.\nIf unspecified, defaults to \"filepath\"."
+              },
+              "filename_suffix": {
+                "type": "string",
+                "description": "If specified, only partitions that end with this\nstring will be processed."
+              },
+              "credentials": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Protocol-specific options that will be passed to\n``fsspec.filesystem``\nhttps://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.filesystem,\nthe dataset initializer and the checkpoint. If\nthe dataset or the checkpoint configuration contains explicit\ncredentials spec, then such spec will take precedence.\nAll possible credentials management scenarios are documented here:\nhttps://docs.kedro.org/en/stable/data/partitioned_and_incremental_datasets.html#partitioned-dataset-credentials"
+              },
+              "load_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Keyword arguments to be passed into ``find()`` method of\nthe filesystem implementation."
+              },
+              "fs_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Extra arguments to pass into underlying filesystem class constructor\n(e.g. `{\"project\": \"my-project\"}` for ``GCSFileSystem``)."
+              },
+              "metadata": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Any arbitrary metadata.\nThis is ignored by Kedro, but may be consumed by users or external plugins."
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "partitions.PartitionedDataset"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "path",
+              "dataset"
+            ],
+            "properties": {
+              "path": {
+                "type": "string",
+                "description": "Path to the folder containing partitioned data.\nIf path starts with the protocol (e.g., ``s3://``) then the\ncorresponding ``fsspec`` concrete filesystem implementation will\nbe used. If protocol is not specified,\n``fsspec.implementations.local.LocalFileSystem`` will be used.\n**Note:** Some concrete implementations are bundled with ``fsspec``,\nwhile others (like ``s3`` or ``gcs``) must be installed separately\nprior to usage of the ``PartitionedDataset``."
+              },
+              "dataset": {
+                "pattern": ".*",
+                "description": "Underlying dataset definition. This is used to instantiate\nthe dataset for each file located inside the ``path``.\nAccepted formats are:\na) object of a class that inherits from ``AbstractDataset``\nb) a string representing a fully qualified class name to such class\nc) a dictionary with ``type`` key pointing to a string from b),\nother keys are passed to the Dataset initializer.\nCredentials for the dataset can be explicitly specified in\nthis configuration."
+              },
+              "filepath_arg": {
+                "type": "string",
+                "description": "Underlying dataset initializer argument that will\ncontain a path to each corresponding partition file.\nIf unspecified, defaults to \"filepath\"."
+              },
+              "filename_suffix": {
+                "type": "string",
+                "description": "If specified, only partitions that end with this\nstring will be processed."
+              },
+              "credentials": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Protocol-specific options that will be passed to\n``fsspec.filesystem``\nhttps://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.filesystem\nand the dataset initializer. If the dataset config contains\nexplicit credentials spec, then such spec will take precedence.\nAll possible credentials management scenarios are documented here:\nhttps://docs.kedro.org/en/stable/data/partitioned_and_incremental_datasets.html#partitioned-dataset-credentials"
+              },
+              "load_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Keyword arguments to be passed into ``find()`` method of\nthe filesystem implementation."
+              },
+              "fs_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Extra arguments to pass into underlying filesystem class constructor\n(e.g. `{\"project\": \"my-project\"}` for ``GCSFileSystem``)."
+              },
+              "overwrite": {
+                "type": "boolean",
+                "description": "If True, any existing partitions will be removed."
+              },
+              "save_lazily": {
+                "type": "boolean",
+                "description": "Parameter to enable/disable lazy saving, the default is True. Meaning that if callable object\nis passed as data to save, the partition\u2019s data will not be materialised until it is time to write.\nLazy saving example:\nhttps://docs.kedro.org/en/stable/catalog-data/partitioned_and_incremental_datasets/#partitioned-dataset-lazy-saving"
+              },
+              "metadata": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Any arbitrary metadata.\nThis is ignored by Kedro, but may be consumed by users or external plugins."
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "pickle.PickleDataset"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "filepath"
+            ],
+            "properties": {
+              "filepath": {
+                "type": "string",
+                "description": "Filepath in POSIX format to a Pickle file prefixed with a protocol like\n`s3://`. If prefix is not provided, `file` protocol (local filesystem) will be used.\nThe prefix should be any protocol supported by ``fsspec``.\nNote: `http(s)` doesn't support versioning."
+              },
+              "backend": {
+                "type": "string",
+                "description": "Backend to use, must be an import path to a module which satisfies the\n``pickle`` interface. That is, contains a `load` and `dump` function.\nDefaults to 'pickle'."
+              },
+              "load_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Pickle options for loading pickle files.\nYou can pass in arguments that the backend load function specified accepts, e.g:\npickle.load: https://docs.python.org/3/library/pickle.html#pickle.load\njoblib.load: https://joblib.readthedocs.io/en/latest/generated/joblib.load.html\ndill.load: https://dill.readthedocs.io/en/latest/index.html#dill.load\ncompress_pickle.load:\nhttps://lucianopaz.github.io/compress_pickle/html/api/compress_pickle.html#compress_pickle.compress_pickle.load\ncloudpickle.load:\nhttps://github.com/cloudpipe/cloudpickle/blob/master/tests/cloudpickle_test.py\nAll defaults are preserved."
+              },
+              "save_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Pickle options for saving pickle files.\nYou can pass in arguments that the backend dump function specified accepts, e.g:\npickle.dump: https://docs.python.org/3/library/pickle.html#pickle.dump\njoblib.dump: https://joblib.readthedocs.io/en/latest/generated/joblib.dump.html\ndill.dump: https://dill.readthedocs.io/en/latest/index.html#dill.dump\ncompress_pickle.dump:\nhttps://lucianopaz.github.io/compress_pickle/html/api/compress_pickle.html#compress_pickle.compress_pickle.dump\ncloudpickle.dump:\nhttps://github.com/cloudpipe/cloudpickle/blob/master/tests/cloudpickle_test.py\nAll defaults are preserved."
+              },
+              "version": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "If specified, should be an instance of\n``kedro.io.core.Version``. If its ``load`` attribute is\nNone, the latest version will be loaded. If its ``save``\nattribute is None, save version will be autogenerated."
+              },
+              "credentials": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Credentials required to get access to the underlying filesystem.\nE.g. for ``GCSFileSystem`` it should look like `{\"token\": None}`."
+              },
+              "fs_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Extra arguments to pass into underlying filesystem class constructor\n(e.g. `{\"project\": \"my-project\"}` for ``GCSFileSystem``), as well as\nto pass to the filesystem's `open` method through nested keys\n`open_args_load` and `open_args_save`.\nHere you can find all available arguments for `open`:\nhttps://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.spec.AbstractFileSystem.open\nAll defaults are preserved, except `mode`, which is set to `wb` when saving."
+              },
+              "metadata": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Any arbitrary metadata.\nThis is ignored by Kedro, but may be consumed by users or external plugins."
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "pillow.ImageDataset"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "filepath"
+            ],
+            "properties": {
+              "filepath": {
+                "type": "string",
+                "description": "Filepath in POSIX format to an image file prefixed with a protocol like\n`s3://`. If prefix is not provided, `file` protocol (local filesystem) will be used.\nThe prefix should be any protocol supported by ``fsspec``.\nNote: `http(s)` doesn't support versioning.\nCan be a string or a PathLike object."
+              },
+              "save_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Pillow options for saving image files.\nHere you can find all available arguments:\nhttps://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.save\nAll defaults are preserved."
+              },
+              "version": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "If specified, should be an instance of\n``kedro.io.core.Version``. If its ``load`` attribute is\nNone, the latest version will be loaded. If its ``save``\nattribute is None, save version will be autogenerated."
+              },
+              "credentials": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Credentials required to get access to the underlying filesystem.\nE.g. for ``GCSFileSystem`` it should look like `{\"token\": None}`."
+              },
+              "fs_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Extra arguments to pass into underlying filesystem class constructor\n(e.g. `{\"project\": \"my-project\"}` for ``GCSFileSystem``), as well as\nto pass to the filesystem's `open` method through nested keys\n`open_args_load` and `open_args_save`.\nHere you can find all available arguments for `open`:\nhttps://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.spec.AbstractFileSystem.open\nAll defaults are preserved, except `mode`, which is set to `wb` when saving."
+              },
+              "metadata": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Any arbitrary metadata.\nThis is ignored by Kedro, but may be consumed by users or external plugins."
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "plotly.HTMLDataset"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "filepath"
+            ],
+            "properties": {
+              "filepath": {
+                "type": "string",
+                "description": "Filepath in POSIX format to an HTML file prefixed with a protocol like `s3://`.\nIf prefix is not provided `file` protocol (local filesystem) will be used.\nThe prefix should be any protocol supported by ``fsspec``.\nNote: `http(s)` doesn't support versioning."
+              },
+              "save_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Plotly options for saving HTML files.\nHere you can find all available arguments:\nhttps://plotly.com/python-api-reference/generated/plotly.io.write_html.html#plotly.io.write_html\nAll defaults are preserved."
+              },
+              "version": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "If specified, should be an instance of\n``kedro.io.core.Version``. If its ``load`` attribute is\nNone, the latest version will be loaded. If its ``save``\nattribute is None, save version will be autogenerated."
+              },
+              "credentials": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Credentials required to get access to the underlying filesystem.\nE.g. for ``GCSFileSystem`` it should look like `{'token': None}`."
+              },
+              "fs_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Extra arguments to pass into underlying filesystem class constructor\n(e.g. `{\"project\": \"my-project\"}` for ``GCSFileSystem``), as well as\nto pass to the filesystem's `open` method through nested keys\n`open_args_load` and `open_args_save`.\nHere you can find all available arguments for `open`:\nhttps://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.spec.AbstractFileSystem.open\nAll defaults are preserved, except `mode`, which is set to `w` when\nsaving."
+              },
+              "metadata": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Any arbitrary metadata.\nThis is ignored by Kedro, but may be consumed by users or external plugins."
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "plotly.JSONDataset"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "filepath"
+            ],
+            "properties": {
+              "filepath": {
+                "type": "string",
+                "description": "Filepath in POSIX format to a JSON file prefixed with a protocol like `s3://`.\nIf prefix is not provided `file` protocol (local filesystem) will be used.\nThe prefix should be any protocol supported by ``fsspec``.\nNote: `http(s)` doesn't support versioning."
+              },
+              "load_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Plotly options for loading JSON files.\nHere you can find all available arguments:\nhttps://plotly.com/python-api-reference/generated/plotly.io.from_json.html#plotly.io.from_json\nAll defaults are preserved."
+              },
+              "save_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Plotly options for saving JSON files.\nHere you can find all available arguments:\nhttps://plotly.com/python-api-reference/generated/plotly.io.write_json.html\nAll defaults are preserved."
+              },
+              "version": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "If specified, should be an instance of\n``kedro.io.core.Version``. If its ``load`` attribute is\nNone, the latest version will be loaded. If its ``save``\nattribute is None, save version will be autogenerated."
+              },
+              "credentials": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Credentials required to get access to the underlying filesystem.\nE.g. for ``GCSFileSystem`` it should look like `{'token': None}`."
+              },
+              "fs_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Extra arguments to pass into underlying filesystem class constructor\n(e.g. `{\"project\": \"my-project\"}` for ``GCSFileSystem``), as well as\nto pass to the filesystem's `open` method through nested keys\n`open_args_load` and `open_args_save`.\nHere you can find all available arguments for `open`:\nhttps://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.spec.AbstractFileSystem.open\nAll defaults are preserved, except `mode`, which is set to `w` when\nsaving."
+              },
+              "metadata": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Any arbitrary metadata.\nThis is ignored by Kedro, but may be consumed by users or external plugins."
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "plotly.PlotlyDataset"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "filepath",
+              "plotly_args"
+            ],
+            "properties": {
+              "filepath": {
+                "type": "string",
+                "description": "Filepath in POSIX format to a JSON file prefixed with a protocol like `s3://`.\nIf prefix is not provided `file` protocol (local filesystem) will be used.\nThe prefix should be any protocol supported by ``fsspec``.\nNote: `http(s)` doesn't support versioning."
+              },
+              "plotly_args": {
+                "type": "object",
+                "description": "Plotly configuration for generating a plotly figure from the\ndataframe. Keys are `type` (plotly express function, e.g. bar,\nline, scatter), `fig` (kwargs passed to the plotting function), theme\n(defaults to `plotly`), `layout`."
+              },
+              "load_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Plotly options for loading JSON files.\nHere you can find all available arguments:\nhttps://plotly.com/python-api-reference/generated/plotly.io.from_json.html#plotly.io.from_json\nAll defaults are preserved."
+              },
+              "save_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Plotly options for saving JSON files.\nHere you can find all available arguments:\nhttps://plotly.com/python-api-reference/generated/plotly.io.write_json.html\nAll defaults are preserved."
+              },
+              "version": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "If specified, should be an instance of\n``kedro.io.core.Version``. If its ``load`` attribute is\nNone, the latest version will be loaded. If its ``save``\nattribute is None, save version will be autogenerated."
+              },
+              "credentials": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Credentials required to get access to the underlying filesystem.\nE.g. for ``GCSFileSystem`` it should look like `{'token': None}`."
+              },
+              "fs_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Extra arguments to pass into underlying filesystem class constructor\n(e.g. `{\"project\": \"my-project\"}` for ``GCSFileSystem``), as well as\nto pass to the filesystem's `open` method through nested keys\n`open_args_load` and `open_args_save`.\nHere you can find all available arguments for `open`:\nhttps://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.spec.AbstractFileSystem.open\nAll defaults are preserved, except `mode`, which is set to `w` when saving."
+              },
+              "metadata": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Any arbitrary metadata.\nThis is ignored by Kedro, but may be consumed by users or external plugins."
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "polars.CSVDataset"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "filepath"
+            ],
+            "properties": {
+              "filepath": {
+                "type": "string",
+                "description": "Filepath as a string or path-like object in POSIX format to a CSV file prefixed with a protocol\n`s3://`.\nIf prefix is not provided, `file` protocol (local filesystem)\nwill be used.\nThe prefix should be any protocol supported by ``fsspec``.\nNote: `http(s)` doesn't support versioning."
+              },
+              "load_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Polars options for loading CSV files.\nHere you can find all available arguments:\nhttps://pola-rs.github.io/polars/py-polars/html/reference/api/polars.read_csv.html#polars.read_csv\nAll defaults are preserved, but we explicitly use `rechunk=True` for `seaborn`\ncompatibility."
+              },
+              "save_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Polars options for saving CSV files.\nHere you can find all available arguments:\nhttps://pola-rs.github.io/polars/py-polars/html/reference/api/polars.DataFrame.write_csv.html\nAll defaults are preserved."
+              },
+              "version": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "If specified, should be an instance of\n``kedro.io.core.Version``. If its ``load`` attribute is\nNone, the latest version will be loaded. If its ``save``\nattribute is None, save version will be autogenerated."
+              },
+              "credentials": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Credentials required to get access to the underlying filesystem.\nE.g. for ``GCSFileSystem`` it should look like `{\"token\": None}`."
+              },
+              "fs_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Extra arguments to pass into underlying filesystem class constructor\n(e.g. `{\"project\": \"my-project\"}` for ``GCSFileSystem``).\nDefaults are preserved, apart from the `open_args_save` `mode` which is set to `w`."
+              },
+              "metadata": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Any arbitrary metadata.\nThis is ignored by Kedro, but may be consumed by users or external plugins."
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "polars.EagerPolarsDataset"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "filepath",
+              "file_format"
+            ],
+            "properties": {
+              "filepath": {
+                "type": "string",
+                "description": "Filepath as a string or path-like object in POSIX format to a file prefixed with a protocol like\n`s3://`.\nIf prefix is not provided, `file` protocol (local filesystem)\nwill be used.\nThe prefix should be any protocol supported by ``fsspec``.\nKey assumption: The first argument of either load/save method points to\na filepath/buffer/io type location. There are some read/write targets such\nas 'clipboard' or 'records' that will fail since they do not take a filepath\nlike argument."
+              },
+              "file_format": {
+                "type": "string",
+                "description": "String which is used to match the appropriate load/save method on a\nbest effort basis. For example if 'csv' is passed, the `polars.read_csv` and\n`polars.DataFrame.write_csv` methods will be identified. An error will\nbe raised unless there is at least one matching `read_<file_format>`\nor `write_<file_format>`."
+              },
+              "load_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Polars options for loading CSV files.\nHere you can find all available arguments:\nhttps://pola-rs.github.io/polars/py-polars/html/reference/io.html\nAll defaults are preserved."
+              },
+              "save_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Polars options for saving files.\nHere you can find all available arguments:\nhttps://pola-rs.github.io/polars/py-polars/html/reference/io.html\nAll defaults are preserved."
+              },
+              "version": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "If specified, should be an instance of\n``kedro.io.core.Version``. If its ``load`` attribute is\nNone, the latest version will be loaded. If its ``save``\nattribute is None, save version will be autogenerated."
+              },
+              "credentials": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Credentials required to get access to the underlying filesystem.\nE.g. for ``GCSFileSystem`` it should look like `{\"token\": None}`."
+              },
+              "fs_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Extra arguments to pass into underlying filesystem class constructor\n(e.g. `{\"project\": \"my-project\"}` for ``GCSFileSystem``)."
+              },
+              "metadata": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Any arbitrary metadata.\nThis is ignored by Kedro, but may be consumed by users or external plugins."
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "polars.LazyPolarsDataset"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "filepath",
+              "file_format"
+            ],
+            "properties": {
+              "filepath": {
+                "type": "string",
+                "description": "Filepath as a string or path-like object in POSIX format to a file prefixed with a protocol like\n`s3://`.\nIf prefix is not provided, `file` protocol (local filesystem)\nwill be used.\nThe prefix should be any protocol supported by ``fsspec``.\nKey assumption: The first argument of either load/save method points to\na filepath/buffer/io type location. There are some read/write targets\nsuch as 'clipboard' or 'records' that will fail since they do not take a\nfilepath like argument."
+              },
+              "file_format": {
+                "type": "string",
+                "description": "String which is used to match the appropriate load/save method\non a best effort basis. For example if 'csv' is passed the\n`polars.read_csv` and\n`polars.DataFrame.write_csv` methods will be identified. An error will\nbe raised unless\nat least one matching `read_{file_format}` or `write_{file_format}`."
+              },
+              "load_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "polars options for loading files.\nHere you can find all available arguments:\nhttps://pola-rs.github.io/polars/py-polars/html/reference/io.html\nAll defaults are preserved."
+              },
+              "save_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Polars options for saving files.\nHere you can find all available arguments:\nhttps://pola-rs.github.io/polars/py-polars/html/reference/io.html\nAll defaults are preserved."
+              },
+              "version": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "If specified, should be an instance of\n``kedro.io.core.Version``. If its ``load`` attribute is\nNone, the latest version will be loaded. If its ``save``\nattribute is None, save version will be autogenerated."
+              },
+              "credentials": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Credentials required to get access to the underlying filesystem.\nE.g. for ``GCSFileSystem`` it should look like `{\"token\": None}`."
+              },
+              "fs_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Extra arguments to pass into underlying filesystem class constructor\n(e.g. `{\"project\": \"my-project\"}` for ``GCSFileSystem``), as well as\nto pass to the filesystem's `open` method through nested keys\n`open_args_load` and `open_args_save`.\nHere you can find all available arguments for `open`:\nhttps://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.spec.AbstractFileSystem.open\nAll defaults are preserved, except `mode`, which is set to `wb` when saving."
+              },
+              "metadata": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Any arbitrary metadata.\nThis is ignored by Kedro, but may be consumed by users or external plugins."
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "redis.PickleDataset"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "key"
+            ],
+            "properties": {
+              "key": {
+                "type": "string",
+                "description": "The key to use for saving/loading object to Redis."
+              },
+              "backend": {
+                "type": "string",
+                "description": "Backend to use, must be an import path to a module which satisfies the\n``pickle`` interface. That is, contains a `loads` and `dumps` function.\nDefaults to 'pickle'."
+              },
+              "load_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Pickle options for loading pickle files.\nYou can pass in arguments that the backend load function specified accepts, e.g:\npickle.loads: https://docs.python.org/3/library/pickle.html#pickle.loads\ndill.loads: https://dill.readthedocs.io/en/latest/index.html#dill.loads\ncompress_pickle.loads:\nhttps://lucianopaz.github.io/compress_pickle/html/api/compress_pickle.html#compress_pickle.compress_pickle.loads\ncloudpickle.loads:\nhttps://github.com/cloudpipe/cloudpickle/blob/master/tests/cloudpickle_test.py\nAll defaults are preserved."
+              },
+              "save_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Pickle options for saving pickle files.\nYou can pass in arguments that the backend dump function specified accepts, e.g:\npickle.dumps: https://docs.python.org/3/library/pickle.html#pickle.dump\ndill.dumps: https://dill.readthedocs.io/en/latest/index.html#dill.dumps\ncompress_pickle.dumps:\nhttps://lucianopaz.github.io/compress_pickle/html/api/compress_pickle.html#compress_pickle.compress_pickle.dumps\ncloudpickle.dumps:\nhttps://github.com/cloudpipe/cloudpickle/blob/master/tests/cloudpickle_test.py\nAll defaults are preserved."
+              },
+              "credentials": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Credentials required to get access to the redis server.\nE.g. `{\"password\": None}`."
+              },
+              "redis_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Extra arguments to pass into the redis client constructor\n``redis.StrictRedis.from_url``. (e.g. `{\"socket_timeout\": 10}`), as well as to pass\nto the ``redis.StrictRedis.set`` through nested keys `from_url_args` and `set_args`.\nHere you can find all available arguments for `from_url`:\nhttps://redis-py.readthedocs.io/en/stable/connections.html?highlight=from_url#redis.Redis.from_url\nAll defaults are preserved, except `url`, which is set to `redis://127.0.0.1:6379`.\nYou could also specify the url through the env variable ``REDIS_URL``."
+              },
+              "metadata": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Any arbitrary metadata.\nThis is ignored by Kedro, but may be consumed by users or external plugins."
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "snowflake.SnowparkTableDataset"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "table_name"
+            ],
+            "properties": {
+              "table_name": {
+                "type": "string",
+                "description": "The table name to load or save data to."
+              },
+              "schema": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Name of the schema where ``table_name`` is.\nOptional as can be provided as part of ``credentials``\ndictionary. Argument value takes priority over one provided\nin ``credentials`` if any."
+              },
+              "database": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Name of the database where ``schema`` is.\nOptional as can be provided as part of ``credentials``\ndictionary. Argument value takes priority over one provided\nin ``credentials`` if any."
+              },
+              "load_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Currently not used"
+              },
+              "save_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Provided to underlying snowpark ``save_as_table``\nTo find all supported arguments, see here:\nhttps://docs.snowflake.com/en/developer-guide/snowpark/reference/python/api/snowflake.snowpark.DataFrameWriter.saveAsTable.html"
+              },
+              "credentials": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "A dictionary with a snowpark connection string.\nTo find all supported arguments, see here:\nhttps://docs.snowflake.com/en/user-guide/python-connector-api.html#connect"
+              },
+              "session": {
+                "pattern": ".*"
+              },
+              "metadata": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Any arbitrary metadata.\nThis is ignored by Kedro, but may be consumed by users or external plugins."
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "spark.DeltaTableDataset"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "filepath"
+            ],
+            "properties": {
+              "filepath": {
+                "type": "string",
+                "description": "Filepath in POSIX format to a Spark dataframe. This can be a\nstring or an ``os.PathLike`` object. When using Databricks\nand working with data written to mount path points,\nspecify ``filepath``s for (versioned) ``SparkDataset``s\nstarting with ``/dbfs/mnt``."
+              },
+              "metadata": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Any arbitrary metadata.\nThis is ignored by Kedro, but may be consumed by users or external plugins."
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "spark.GBQQueryDataset"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "materialization_dataset"
+            ],
+            "properties": {
+              "materialization_dataset": {
+                "type": "string",
+                "description": "The name of the dataset to materialize the query results."
+              },
+              "sql": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "The SQL query to execute"
+              },
+              "filepath": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "A path to a file with a sql query statement."
+              },
+              "materialization_project": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "The name of the project to materialize the query results.\nOptional (defaults to the project id set by the credentials)."
+              },
+              "load_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Load args passed to Spark DataFrameReader load method.\nIt is dependent on the selected file format. You can find\na list of read options for each supported format\nin Spark DataFrame read documentation:\nhttps://spark.apache.org/docs/latest/api/python/getting_started/quickstart_df.html"
+              },
+              "fs_args": {
+                "type": [
+                  "object",
+                  "null"
+                ]
+              },
+              "bq_credentials": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Credentials to authenticate spark session with google bigquery.\nDictionary with key specifying the type of credentials ('base64', 'file', 'json').\nAlternatively, you can pass the credentials in load_args as follows:\nWhen passing as `base64`:\n`load_args={\"credentials\": \"your_credentials\"}`\nWhen passing as a `file`:\n`load_args={\"credentialsFile\": \"/path/to/your/credentials.json\"}`\nWhen passing as a json object:\nThis is not supported when passed directly in load_args. You can pass the json object (as a python dictionary) in the credentials\nby specifying the key as `json`.\nRead more here:\nhttps://github.com/GoogleCloudDataproc/spark-bigquery-connector?tab=readme-ov-file#how-do-i-authenticate-outside-gce--dataproc"
+              },
+              "fs_credentials": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Credentials to authenticate with the filesystem.\nThe keyword args would be directly passed to fsspec.filesystem constructor."
+              },
+              "metadata": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Any arbitrary metadata.\nThis is ignored by Kedro, but may be consumed by users or external plugins."
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "spark.SparkDataset"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "filepath"
+            ],
+            "properties": {
+              "filepath": {
+                "type": "string",
+                "description": "Filepath in POSIX format to a Spark dataframe. This can be a\nstring or an ``os.PathLike`` object. When using Databricks\nspecify ``filepath``s starting with ``/dbfs/``."
+              },
+              "file_format": {
+                "type": "string",
+                "description": "File format used during load and save\noperations. These are formats supported by the running\nSparkContext include parquet, csv, delta. For a list of supported\nformats please refer to Apache Spark documentation at\nhttps://spark.apache.org/docs/latest/sql-programming-guide.html"
+              },
+              "load_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Load args passed to Spark DataFrameReader load method.\nIt is dependent on the selected file format. You can find\na list of read options for each supported format\nin Spark DataFrame read documentation:\nhttps://spark.apache.org/docs/latest/api/python/getting_started/quickstart_df.html"
+              },
+              "save_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Save args passed to Spark DataFrame write options.\nSimilar to load_args this is dependent on the selected file\nformat. You can pass ``mode`` and ``partitionBy`` to specify\nyour overwrite mode and partitioning respectively. You can find\na list of options for each format in Spark DataFrame\nwrite documentation:\nhttps://spark.apache.org/docs/latest/api/python/getting_started/quickstart_df.html"
+              },
+              "version": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "If specified, should be an instance of\n``kedro.io.core.Version``. If its ``load`` attribute is\nNone, the latest version will be loaded. If its ``save``\nattribute is None, save version will be autogenerated."
+              },
+              "credentials": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Credentials to access the S3 bucket, such as\n``key``, ``secret``, if ``filepath`` prefix is ``s3a://`` or ``s3n://``.\nOptional keyword arguments passed to ``hdfs.client.InsecureClient``\nif ``filepath`` prefix is ``hdfs://``. Ignored otherwise."
+              },
+              "metadata": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Any arbitrary metadata.\nThis is ignored by Kedro, but may be consumed by users or external plugins."
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "spark.SparkHiveDataset"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "database",
+              "table"
+            ],
+            "properties": {
+              "database": {
+                "type": "string",
+                "description": "The name of the hive database."
+              },
+              "table": {
+                "type": "string",
+                "description": "The name of the table within the database."
+              },
+              "write_mode": {
+                "type": "string",
+                "description": "``insert``, ``upsert`` or ``overwrite`` are supported."
+              },
+              "table_pk": {
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "description": "If performing an upsert, this identifies the primary key columns used to\nresolve preexisting data. Is required for ``write_mode=\"upsert\"``."
+              },
+              "save_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Optional mapping of any options,\npassed to the `DataFrameWriter.saveAsTable` as kwargs.\nKey example of this is `partitionBy` which allows data partitioning\non a list of column names.\nOther `HiveOptions` can be found here:\nhttps://spark.apache.org/docs/latest/sql-data-sources-hive-tables.html#specifying-storage-format-for-hive-tables"
+              },
+              "metadata": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Any arbitrary metadata.\nThis is ignored by Kedro, but may be consumed by users or external plugins."
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "spark.SparkJDBCDataset"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "url",
+              "table"
+            ],
+            "properties": {
+              "url": {
+                "type": "string",
+                "description": "A JDBC URL of the form ``jdbc:subprotocol:subname``."
+              },
+              "table": {
+                "type": "string",
+                "description": "The name of the table to load or save data to."
+              },
+              "credentials": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "A dictionary of JDBC database connection arguments.\nNormally at least properties ``user`` and ``password`` with\ntheir corresponding values.  It updates ``properties``\nparameter in ``load_args`` and ``save_args`` in case it is\nprovided."
+              },
+              "load_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Provided to underlying PySpark ``jdbc`` function along\nwith the JDBC URL and the name of the table. To find all\nsupported arguments, see here:\nhttps://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.DataFrameWriter.jdbc.html"
+              },
+              "save_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Provided to underlying PySpark ``jdbc`` function along\nwith the JDBC URL and the name of the table. To find all\nsupported arguments, see here:\nhttps://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.DataFrameWriter.jdbc.html"
+              },
+              "metadata": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Any arbitrary metadata.\nThis is ignored by Kedro, but may be consumed by users or external plugins."
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "spark.SparkStreamingDataset"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "filepath": {
+                "type": "string",
+                "description": "Filepath in POSIX format to a Spark dataframe. This can be a\nstring or an ``os.PathLike`` object. When using Databricks\nspecify ``filepath``s starting with ``/dbfs/``. For message brokers such as\nKafka and all filepath is not required."
+              },
+              "file_format": {
+                "type": "string",
+                "description": "File format used during load and save operations.\nThese are formats supported by the running SparkContext including parquet,\ncsv, and delta. For a list of supported formats please refer to the Apache\nSpark documentation at\nhttps://spark.apache.org/docs/latest/structured-streaming-programming-guide.html"
+              },
+              "save_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Save args passed to Spark DataFrameReader write options.\nSimilar to load_args, this is dependent on the selected file format. You can pass\n``mode`` and ``partitionBy`` to specify your overwrite mode and partitioning\nrespectively. You can find a list of options for each selected format in\nSpark DataFrame write documentation, see\nhttps://spark.apache.org/docs/latest/structured-streaming-programming-guide.html"
+              },
+              "load_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Load args passed to Spark DataFrameReader load method.\nIt is dependent on the selected file format. You can find a list of read options\nfor each selected format in Spark DataFrame read documentation, see\nhttps://spark.apache.org/docs/latest/structured-streaming-programming-guide.html.\nPlease note that a schema is mandatory for a streaming DataFrame\nif ``schemaInference`` is not True."
+              },
+              "metadata": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Any arbitrary metadata.\nThis is ignored by Kedro, but may be consumed by users or external plugins."
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "svmlight.SVMLightDataset"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "filepath"
+            ],
+            "properties": {
+              "filepath": {
+                "type": "string",
+                "description": "Filepath in POSIX format to a text file prefixed with a protocol like `s3://`.\nIf prefix is not provided, `file` protocol (local filesystem) will be used.\nThe prefix should be any protocol supported by ``fsspec``."
+              },
+              "load_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Arguments passed on to ``load_svmlight_file``.\nSee the details in\nhttps://scikit-learn.org/stable/modules/generated/sklearn.datasets.load_svmlight_file.html"
+              },
+              "save_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Arguments passed on to ``dump_svmlight_file``.\nSee the details in\nhttps://scikit-learn.org/stable/modules/generated/sklearn.datasets.dump_svmlight_file.html"
+              },
+              "version": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "If specified, should be an instance of\n``kedro.io.core.Version``. If its ``load`` attribute is\nNone, the latest version will be loaded. If its ``save``\nattribute is None, save version will be autogenerated."
+              },
+              "credentials": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Credentials required to get access to the underlying filesystem.\nE.g. for ``GCSFileSystem`` it should look like `{\"token\": None}`."
+              },
+              "fs_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Extra arguments to pass into underlying filesystem class constructor\n(e.g. `{\"project\": \"my-project\"}` for ``GCSFileSystem``).\nAll defaults are preserved, except `mode`, which is set to `rb` when loading\nand to `wb` when saving."
+              },
+              "metadata": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Any arbitrary metadata.\nThis is ignored by Kedro, but may be consumed by users or external plugins."
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "tensorflow.TensorFlowModelDataset"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "filepath"
+            ],
+            "properties": {
+              "filepath": {
+                "type": "string",
+                "description": "Filepath in POSIX format to a TensorFlow model directory prefixed with a\nprotocol like `s3://`. If prefix is not provided `file` protocol (local filesystem)\nwill be used. The prefix should be any protocol supported by ``fsspec``.\nNote: `http(s)` doesn't support versioning."
+              },
+              "load_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "TensorFlow options for loading models.\nHere you can find all available arguments:\nhttps://www.tensorflow.org/api_docs/python/tf/keras/models/load_model\nAll defaults are preserved, except for \"safe_mode\", which is set to True.\nSet ``safe_mode: false`` to load models containing custom objects from\ntrusted sources. A special key ``tf_device`` can be used to specify the\ndevice context for loading."
+              },
+              "save_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "TensorFlow options for saving models.\nHere you can find all available arguments:\nhttps://www.tensorflow.org/api_docs/python/tf/keras/models/save_model\nAll defaults are preserved, except for \"save_format\", which is set to \"tf\"."
+              },
+              "version": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "If specified, should be an instance of\n``kedro.io.core.Version``. If its ``load`` attribute is\nNone, the latest version will be loaded. If its ``save``\nattribute is None, save version will be autogenerated."
+              },
+              "credentials": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Credentials required to get access to the underlying filesystem.\nE.g. for ``GCSFileSystem`` it should look like `{'token': None}`."
+              },
+              "fs_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Extra arguments to pass into underlying filesystem class constructor\n(e.g. `{\"project\": \"my-project\"}` for ``GCSFileSystem``)."
+              },
+              "metadata": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Any arbitrary metadata.\nThis is ignored by Kedro, but may be consumed by users or external plugins."
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "text.TextDataset"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "filepath"
+            ],
+            "properties": {
+              "filepath": {
+                "type": "string",
+                "description": "Filepath in POSIX format to a text file prefixed with a protocol like `s3://`.\nIf prefix is not provided, `file` protocol (local filesystem) will be used.\nThe prefix should be any protocol supported by ``fsspec``.\nNote: `http(s)` doesn't support versioning."
+              },
+              "version": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "If specified, should be an instance of\n``kedro.io.core.Version``. If its ``load`` attribute is\nNone, the latest version will be loaded. If its ``save``\nattribute is None, save version will be autogenerated."
+              },
+              "credentials": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Credentials required to get access to the underlying filesystem.\nE.g. for ``GCSFileSystem`` it should look like `{\"token\": None}`."
+              },
+              "fs_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Extra arguments to pass into underlying filesystem class constructor\n(e.g. `{\"project\": \"my-project\"}` for ``GCSFileSystem``), as well as\nto pass to the filesystem's `open` method through nested keys\n`open_args_load` and `open_args_save`.\nHere you can find all available arguments for `open`:\nhttps://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.spec.AbstractFileSystem.open\nAll defaults are preserved, except `mode`, which is set to `r` when loading\nand to `w` when saving."
+              },
+              "metadata": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Any arbitrary metadata.\nThis is ignored by Kedro, but may be consumed by users or external plugins."
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "yaml.YAMLDataset"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "filepath"
+            ],
+            "properties": {
+              "filepath": {
+                "type": "string",
+                "description": "Filepath in POSIX format to a YAML file prefixed with a protocol like `s3://`.\nIf prefix is not provided, `file` protocol (local filesystem) will be used.\nThe prefix should be any protocol supported by ``fsspec``.\nNote: `http(s)` doesn't support versioning."
+              },
+              "save_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "PyYAML options for saving YAML files (arguments passed\ninto ```yaml.dump``). Here you can find all available arguments:\nhttps://pyyaml.org/wiki/PyYAMLDocumentation\nAll defaults are preserved, but \"default_flow_style\", which is set to False."
+              },
+              "version": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "If specified, should be an instance of\n``kedro.io.core.Version``. If its ``load`` attribute is\nNone, the latest version will be loaded. If its ``save``\nattribute is None, save version will be autogenerated."
+              },
+              "credentials": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Credentials required to get access to the underlying filesystem.\nE.g. for ``GCSFileSystem`` it should look like `{\"token\": None}`."
+              },
+              "fs_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Extra arguments to pass into underlying filesystem class constructor\n(e.g. `{\"project\": \"my-project\"}` for ``GCSFileSystem``), as well as\nto pass to the filesystem's `open` method through nested keys\n`open_args_load` and `open_args_save`.\nHere you can find all available arguments for `open`:\nhttps://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.spec.AbstractFileSystem.open\nAll defaults are preserved, except `mode`, which is set to `w` when saving."
+              },
+              "metadata": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Any arbitrary metadata.\nThis is ignored by Kedro, but may be consumed by users or external plugins."
+              }
+            }
+          }
+        }
+      ]
     }
   }
+}

--- a/kedro-datasets/static/jsonschema/kedro-catalog-1.0.0.json
+++ b/kedro-datasets/static/jsonschema/kedro-catalog-1.0.0.json
@@ -567,7 +567,64 @@
             }
           },
           "then": {
-            "properties": {}
+            "properties": {
+              "path": {
+                "type": "string",
+                "description": "Path to a file or directory for persisting Hugging Face datasets. Supports local paths, ``os.PathLike`` objects, and remote URIs (e.g. ``s3://bucket/data``)."
+              },
+              "version": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Optional versioning configuration (see :class:`~kedro.io.core.Version`)."
+              },
+              "data_files": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Mapping of split name to filename for loading and saving a ``DatasetDict`` from a directory (e.g. ``{\"train\": \"train.csv\"}``). The keys must match the split names of the ``DatasetDict`` being saved, and the filenames must use the correct extension for the format (e.g. ``.csv`` for ``CSVDataset``)."
+              },
+              "load_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Additional keyword arguments passed to the underlying load function. This cannot include ``data_files``; use the top-level ``data_files`` argument instead."
+              },
+              "save_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Additional keyword arguments passed to the underlying save function. This cannot include ``data_files``; use the top-level ``data_files`` argument instead."
+              },
+              "credentials": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Credentials for the underlying filesystem (e.g. ``key``/``secret`` for S3). Passed to the ``storage_options`` parameter in the underlying ``datasets`` implementation."
+              },
+              "fs_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Extra arguments passed to the ``fsspec`` filesystem initialiser. Passed to the ``storage_options`` parameter in the underlying ``datasets`` implementation."
+              },
+              "metadata": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Any arbitrary metadata. This is ignored by Kedro but may be consumed by users or external plugins."
+              }
+            },
+            "required": [
+              "path"
+            ]
           }
         },
         {
@@ -579,7 +636,64 @@
             }
           },
           "then": {
-            "properties": {}
+            "properties": {
+              "path": {
+                "type": "string",
+                "description": "Path to a file or directory for persisting Hugging Face datasets. Supports local paths, ``os.PathLike`` objects, and remote URIs (e.g. ``s3://bucket/data``)."
+              },
+              "version": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Optional versioning configuration (see :class:`~kedro.io.core.Version`)."
+              },
+              "data_files": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Mapping of split name to filename for loading and saving a ``DatasetDict`` from a directory (e.g. ``{\"train\": \"train.csv\"}``). The keys must match the split names of the ``DatasetDict`` being saved, and the filenames must use the correct extension for the format (e.g. ``.csv`` for ``CSVDataset``)."
+              },
+              "load_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Additional keyword arguments passed to the underlying load function. This cannot include ``data_files``; use the top-level ``data_files`` argument instead."
+              },
+              "save_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Additional keyword arguments passed to the underlying save function. This cannot include ``data_files``; use the top-level ``data_files`` argument instead."
+              },
+              "credentials": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Credentials for the underlying filesystem (e.g. ``key``/``secret`` for S3). Passed to the ``storage_options`` parameter in the underlying ``datasets`` implementation."
+              },
+              "fs_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Extra arguments passed to the ``fsspec`` filesystem initialiser. Passed to the ``storage_options`` parameter in the underlying ``datasets`` implementation."
+              },
+              "metadata": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Any arbitrary metadata. This is ignored by Kedro but may be consumed by users or external plugins."
+              }
+            },
+            "required": [
+              "path"
+            ]
           }
         },
         {
@@ -659,7 +773,64 @@
             }
           },
           "then": {
-            "properties": {}
+            "properties": {
+              "path": {
+                "type": "string",
+                "description": "Path to a file or directory for persisting Hugging Face datasets. Supports local paths, ``os.PathLike`` objects, and remote URIs (e.g. ``s3://bucket/data``)."
+              },
+              "version": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Optional versioning configuration (see :class:`~kedro.io.core.Version`)."
+              },
+              "data_files": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Mapping of split name to filename for loading and saving a ``DatasetDict`` from a directory (e.g. ``{\"train\": \"train.csv\"}``). The keys must match the split names of the ``DatasetDict`` being saved, and the filenames must use the correct extension for the format (e.g. ``.csv`` for ``CSVDataset``)."
+              },
+              "load_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Additional keyword arguments passed to the underlying load function. This cannot include ``data_files``; use the top-level ``data_files`` argument instead."
+              },
+              "save_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Additional keyword arguments passed to the underlying save function. This cannot include ``data_files``; use the top-level ``data_files`` argument instead."
+              },
+              "credentials": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Credentials for the underlying filesystem (e.g. ``key``/``secret`` for S3). Passed to the ``storage_options`` parameter in the underlying ``datasets`` implementation."
+              },
+              "fs_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Extra arguments passed to the ``fsspec`` filesystem initialiser. Passed to the ``storage_options`` parameter in the underlying ``datasets`` implementation."
+              },
+              "metadata": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Any arbitrary metadata. This is ignored by Kedro but may be consumed by users or external plugins."
+              }
+            },
+            "required": [
+              "path"
+            ]
           }
         },
         {
@@ -671,7 +842,64 @@
             }
           },
           "then": {
-            "properties": {}
+            "properties": {
+              "path": {
+                "type": "string",
+                "description": "Path to a file or directory for persisting Hugging Face datasets. Supports local paths, ``os.PathLike`` objects, and remote URIs (e.g. ``s3://bucket/data``)."
+              },
+              "version": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Optional versioning configuration (see :class:`~kedro.io.core.Version`)."
+              },
+              "data_files": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Mapping of split name to filename for loading and saving a ``DatasetDict`` from a directory (e.g. ``{\"train\": \"train.csv\"}``). The keys must match the split names of the ``DatasetDict`` being saved, and the filenames must use the correct extension for the format (e.g. ``.csv`` for ``CSVDataset``)."
+              },
+              "load_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Additional keyword arguments passed to the underlying load function. This cannot include ``data_files``; use the top-level ``data_files`` argument instead."
+              },
+              "save_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Additional keyword arguments passed to the underlying save function. This cannot include ``data_files``; use the top-level ``data_files`` argument instead."
+              },
+              "credentials": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Credentials for the underlying filesystem (e.g. ``key``/``secret`` for S3). Passed to the ``storage_options`` parameter in the underlying ``datasets`` implementation."
+              },
+              "fs_args": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Extra arguments passed to the ``fsspec`` filesystem initialiser. Passed to the ``storage_options`` parameter in the underlying ``datasets`` implementation."
+              },
+              "metadata": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Any arbitrary metadata. This is ignored by Kedro but may be consumed by users or external plugins."
+              }
+            },
+            "required": [
+              "path"
+            ]
           }
         },
         {

--- a/kedro-datasets/tests/test_generate_catalog_schema.py
+++ b/kedro-datasets/tests/test_generate_catalog_schema.py
@@ -1,0 +1,348 @@
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from kedro_datasets import _generate_catalog_schema as generator
+
+
+class SampleDataset:
+    def __init__(
+        self,
+        filepath: str,
+        *args: Any,
+        options: dict[str, Any] | None = None,
+        value=None,
+        **kwargs: Any,
+    ) -> None:
+        """Create a sample dataset.
+
+        Args:
+            filepath: The file path.
+            options: Optional arguments.
+                Continued detail.
+            value: Untyped value.
+        """
+
+
+SAMPLE_SPEC = generator.DatasetSpec(
+    type_id="sample.SampleDataset",
+    parameters=[
+        generator.DatasetParameter("filepath", "str", True),
+        generator.DatasetParameter("options", "dict[str, Any] | None", False),
+        generator.DatasetParameter("value", inspect.Parameter.empty, False),
+    ],
+    docstring=inspect.getdoc(SampleDataset.__init__),
+)
+
+
+def test_json_type_for_known_nullable_and_unknown_annotations():
+    class Version:
+        pass
+
+    assert generator._json_type_for(str) == "string"
+    assert generator._json_type_for(Path) == "string"
+    assert generator._json_type_for(Version) == "object"
+    assert generator._json_type_for(dict[str, Any] | None) == ["object", "null"]
+    assert generator._json_type_for(str | dict[str, Any]) == ["string", "object"]
+    assert generator._json_type_for(str | Any) is generator._UNKNOWN
+    assert generator._json_type_for("str | UnknownType") is generator._UNKNOWN
+    assert generator._json_type_for(inspect.Parameter.empty) is generator._UNKNOWN
+    assert generator._json_type_for(None) is generator._UNKNOWN
+    assert generator._json_type_for("Version") == "object"
+    assert generator._json_type_for("str | os.PathLike") == "string"
+
+
+def test_json_type_for_handles_empty_and_invalid_type_map_entries(monkeypatch):
+    class Unmapped:
+        pass
+
+    monkeypatch.setattr(generator, "get_args", lambda annotation: ())
+    assert generator._json_type_for_union(object()) is generator._UNKNOWN
+
+    monkeypatch.setitem(generator._TYPE_MAP, "not-a-type", "string")
+    assert generator._json_type_for_concrete(Unmapped) is generator._UNKNOWN
+
+
+def test_property_schema_renders_unknown_as_pattern():
+    assert generator._property_schema(Any, None) == {"pattern": ".*"}
+    assert generator._property_schema(str, "A value.") == {
+        "type": "string",
+        "description": "A value.",
+    }
+
+
+def test_parse_docstring_args_handles_missing_and_wrapped_descriptions():
+    assert generator._parse_docstring_args(None) == {}
+    assert generator._parse_docstring_args("No args here.") == {}
+
+    doc = """Create a dataset.
+
+    Args:
+        filepath: The file path.
+            Continued detail.
+        load_args (dict): Load options.
+
+    Raises:
+        ValueError: Bad value.
+    """
+
+    assert generator._parse_docstring_args(doc) == {
+        "filepath": "The file path.\nContinued detail.",
+        "load_args": "Load options.",
+    }
+
+
+def test_iter_subpackages_filters_private_and_excluded_packages(tmp_path, monkeypatch):
+    package_path = tmp_path / "kedro_datasets"
+    package_path.mkdir()
+    for name in ["api", "_private", "langchain"]:
+        (package_path / name).mkdir()
+        (package_path / name / "__init__.py").touch()
+    (package_path / "not_a_package.py").touch()
+
+    monkeypatch.setattr(generator.kedro_datasets, "__path__", [str(package_path)])
+
+    assert generator._iter_subpackages() == ["api"]
+
+
+def test_submodule_attrs_for_reads_lazy_exports(tmp_path, monkeypatch):
+    package_path = tmp_path / "kedro_datasets"
+    subpackage_path = package_path / "sample"
+    subpackage_path.mkdir(parents=True)
+    (package_path / "__init__.py").touch()
+    (subpackage_path / "__init__.py").write_text(
+        "import lazy_loader as lazy\n"
+        "lazy.attach(__name__, submodules=[])\n"
+        "__getattr__, __dir__, __all__ = lazy.attach(\n"
+        "    __name__,\n"
+        "    submod_attrs={'sample_dataset': ['SampleDataset']},\n"
+        ")\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        generator.kedro_datasets, "__file__", str(package_path / "__init__.py")
+    )
+
+    assert generator._submodule_attrs_for("sample") == {
+        "SampleDataset": "sample_dataset"
+    }
+
+
+def test_submodule_attrs_for_aborts_without_lazy_exports(tmp_path, monkeypatch):
+    package_path = tmp_path / "kedro_datasets"
+    subpackage_path = package_path / "sample"
+    subpackage_path.mkdir(parents=True)
+    (package_path / "__init__.py").touch()
+    (subpackage_path / "__init__.py").write_text("", encoding="utf-8")
+    monkeypatch.setattr(
+        generator.kedro_datasets, "__file__", str(package_path / "__init__.py")
+    )
+
+    with pytest.raises(SystemExit, match="Cannot find lazy exports"):
+        generator._submodule_attrs_for("sample")
+
+
+def test_dataset_spec_from_source_extracts_init_parameters(tmp_path, monkeypatch):
+    package_path = tmp_path / "kedro_datasets"
+    subpackage_path = package_path / "sample"
+    subpackage_path.mkdir(parents=True)
+    (package_path / "__init__.py").touch()
+    (subpackage_path / "sample_dataset.py").write_text(
+        "from __future__ import annotations\n"
+        "from typing import Any\n\n"
+        "class SampleDataset:\n"
+        "    def __init__(self, filepath: str, *, options: dict[str, Any] | None = None, value=None) -> None:\n"
+        "        '''Create a sample.\n\n"
+        "        Args:\n"
+        "            filepath: The file path.\n"
+        "            options: Optional arguments.\n"
+        "            value: Untyped value.\n"
+        "        '''\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        generator.kedro_datasets, "__file__", str(package_path / "__init__.py")
+    )
+
+    assert generator._dataset_spec_from_source(
+        "sample", "sample_dataset", "SampleDataset"
+    ) == generator.DatasetSpec(
+        type_id="sample.SampleDataset",
+        parameters=[
+            generator.DatasetParameter("filepath", "str", True),
+            generator.DatasetParameter("options", "dict[str, Any] | None", False),
+            generator.DatasetParameter("value", inspect.Parameter.empty, False),
+        ],
+        docstring=(
+            "Create a sample.\n\n"
+            "Args:\n"
+            "    filepath: The file path.\n"
+            "    options: Optional arguments.\n"
+            "    value: Untyped value."
+        ),
+    )
+
+
+def test_dataset_spec_from_source_handles_missing_init(tmp_path, monkeypatch):
+    package_path = tmp_path / "kedro_datasets"
+    subpackage_path = package_path / "sample"
+    subpackage_path.mkdir(parents=True)
+    (package_path / "__init__.py").touch()
+    (subpackage_path / "sample_dataset.py").write_text(
+        "class SampleDataset:\n" "    pass\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        generator.kedro_datasets, "__file__", str(package_path / "__init__.py")
+    )
+
+    assert generator._dataset_spec_from_source(
+        "sample", "sample_dataset", "SampleDataset"
+    ) == generator.DatasetSpec("sample.SampleDataset", [], None)
+
+
+def test_dataset_spec_from_source_aborts_when_class_is_missing(tmp_path, monkeypatch):
+    package_path = tmp_path / "kedro_datasets"
+    subpackage_path = package_path / "sample"
+    subpackage_path.mkdir(parents=True)
+    (package_path / "__init__.py").touch()
+    (subpackage_path / "sample_dataset.py").write_text("", encoding="utf-8")
+    monkeypatch.setattr(
+        generator.kedro_datasets, "__file__", str(package_path / "__init__.py")
+    )
+
+    with pytest.raises(SystemExit, match="Cannot find SampleDataset"):
+        generator._dataset_spec_from_source("sample", "sample_dataset", "SampleDataset")
+
+
+def test_iter_dataset_specs_uses_lazy_export_order(monkeypatch):
+    monkeypatch.setattr(generator, "_iter_subpackages", lambda: ["sample"])
+    monkeypatch.setattr(
+        generator,
+        "_submodule_attrs_for",
+        lambda subpackage: {"BDataset": "b_dataset", "ADataset": "a_dataset"},
+    )
+    monkeypatch.setattr(
+        generator,
+        "_dataset_spec_from_source",
+        lambda subpackage, module_name, class_name: generator.DatasetSpec(
+            f"{subpackage}.{class_name}", [], None
+        ),
+    )
+
+    assert generator._iter_dataset_specs() == [
+        generator.DatasetSpec("sample.ADataset", [], None),
+        generator.DatasetSpec("sample.BDataset", [], None),
+    ]
+
+
+def test_deep_merge_merges_nested_dicts_and_replaces_values():
+    base = {"properties": {"filepath": {"type": "string"}}, "required": ["filepath"]}
+    override = {"properties": {"filepath": {"description": "Path."}}, "required": []}
+
+    assert generator._deep_merge(base, override) == {
+        "properties": {"filepath": {"type": "string", "description": "Path."}},
+        "required": [],
+    }
+
+
+def test_resolved_type_hints_falls_back_for_unresolved_annotations():
+    namespace: dict[str, Any] = {}
+    exec(  # noqa: S102
+        "from __future__ import annotations\n"
+        "def unresolved(value: MissingType) -> None:\n"
+        "    pass\n",
+        namespace,
+    )
+
+    assert generator._resolved_type_hints(namespace["unresolved"]) == {}
+
+
+def test_dataset_then_schema_uses_signature_docstring_and_overrides(monkeypatch):
+    monkeypatch.setitem(
+        generator.SCHEMA_OVERRIDES,
+        "sample.SampleDataset",
+        {"properties": {"filepath": {"description": "Overridden."}}},
+    )
+
+    assert generator._dataset_then_schema(SAMPLE_SPEC) == {
+        "required": ["filepath"],
+        "properties": {
+            "filepath": {"type": "string", "description": "Overridden."},
+            "options": {
+                "type": ["object", "null"],
+                "description": "Optional arguments.\nContinued detail.",
+            },
+            "value": {"pattern": ".*", "description": "Untyped value."},
+        },
+    }
+
+
+def test_build_schema_uses_dataset_classes(monkeypatch):
+    monkeypatch.setattr(
+        generator,
+        "_iter_dataset_specs",
+        lambda: [SAMPLE_SPEC],
+    )
+
+    assert generator.build_schema() == {
+        "type": "object",
+        "patternProperties": {
+            "^[a-z0-9-_]+$": {
+                "required": ["type"],
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "enum": ["sample.SampleDataset"],
+                    }
+                },
+                "allOf": [
+                    {
+                        "if": {
+                            "properties": {"type": {"const": "sample.SampleDataset"}}
+                        },
+                        "then": generator._dataset_then_schema(SAMPLE_SPEC),
+                    }
+                ],
+            }
+        },
+    }
+
+
+def test_schema_io_paths(monkeypatch, tmp_path):
+    schema_path = tmp_path / generator.SCHEMA_FILENAME
+    schema = {"type": "object"}
+    monkeypatch.setattr(generator, "_schema_path", lambda: schema_path)
+    monkeypatch.setattr(generator, "build_schema", lambda: schema)
+
+    assert generator.check_schema() is False
+    generator.write_schema()
+    assert schema_path.read_text(encoding="utf-8") == '{\n  "type": "object"\n}\n'
+    assert generator.check_schema() is True
+
+
+def test_schema_path_points_to_static_schema_file():
+    assert generator._schema_path().name == generator.SCHEMA_FILENAME
+    assert generator._schema_path().parent.name == "jsonschema"
+
+
+def test_main_writes_or_checks_schema(monkeypatch, tmp_path, capsys):
+    schema_path = tmp_path / generator.SCHEMA_FILENAME
+    calls = []
+
+    monkeypatch.setattr(generator, "_schema_path", lambda: schema_path)
+    monkeypatch.setattr(generator, "write_schema", lambda: calls.append("write"))
+    monkeypatch.setattr(generator, "check_schema", lambda: True)
+
+    assert generator.main([]) == 0
+    assert calls == ["write"]
+    assert generator.main(["--check"]) == 0
+
+    monkeypatch.setattr(generator, "check_schema", lambda: False)
+
+    assert generator.main(["--check"]) == 1
+    assert "is not up to date" in capsys.readouterr().err

--- a/kedro-datasets/tests/test_generate_catalog_schema.py
+++ b/kedro-datasets/tests/test_generate_catalog_schema.py
@@ -174,22 +174,44 @@ def test_dataset_spec_from_source_extracts_init_parameters(tmp_path, monkeypatch
     )
 
 
-def test_dataset_spec_from_source_handles_missing_init(tmp_path, monkeypatch):
+def test_dataset_spec_from_source_handles_missing_init_with_override(
+    tmp_path, monkeypatch
+):
     package_path = tmp_path / "kedro_datasets"
     subpackage_path = package_path / "sample"
     subpackage_path.mkdir(parents=True)
     (package_path / "__init__.py").touch()
     (subpackage_path / "sample_dataset.py").write_text(
-        "class SampleDataset:\n" "    pass\n",
+        "class SampleDataset:\n    pass\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        generator.kedro_datasets, "__file__", str(package_path / "__init__.py")
+    )
+    monkeypatch.setitem(generator.SCHEMA_OVERRIDES, "sample.SampleDataset", {})
+
+    assert generator._dataset_spec_from_source(
+        "sample", "sample_dataset", "SampleDataset"
+    ) == generator.DatasetSpec("sample.SampleDataset", [], None)
+
+
+def test_dataset_spec_from_source_aborts_on_missing_init_without_override(
+    tmp_path, monkeypatch
+):
+    package_path = tmp_path / "kedro_datasets"
+    subpackage_path = package_path / "sample"
+    subpackage_path.mkdir(parents=True)
+    (package_path / "__init__.py").touch()
+    (subpackage_path / "sample_dataset.py").write_text(
+        "class SampleDataset:\n    pass\n",
         encoding="utf-8",
     )
     monkeypatch.setattr(
         generator.kedro_datasets, "__file__", str(package_path / "__init__.py")
     )
 
-    assert generator._dataset_spec_from_source(
-        "sample", "sample_dataset", "SampleDataset"
-    ) == generator.DatasetSpec("sample.SampleDataset", [], None)
+    with pytest.raises(ValueError, match="defines no __init__ method"):
+        generator._dataset_spec_from_source("sample", "sample_dataset", "SampleDataset")
 
 
 def test_dataset_spec_from_source_aborts_when_class_is_missing(tmp_path, monkeypatch):

--- a/kedro-datasets/tests/test_generate_catalog_schema.py
+++ b/kedro-datasets/tests/test_generate_catalog_schema.py
@@ -251,15 +251,12 @@ def test_deep_merge_merges_nested_dicts_and_replaces_values():
 
 
 def test_resolved_type_hints_falls_back_for_unresolved_annotations():
-    namespace: dict[str, Any] = {}
-    exec(  # noqa: S102
-        "from __future__ import annotations\n"
-        "def unresolved(value: MissingType) -> None:\n"
-        "    pass\n",
-        namespace,
-    )
+    def unresolved(value) -> None:
+        pass
 
-    assert generator._resolved_type_hints(namespace["unresolved"]) == {}
+    unresolved.__annotations__ = {"value": "MissingType", "return": None}
+
+    assert generator._resolved_type_hints(unresolved) == {}
 
 
 def test_dataset_then_schema_uses_signature_docstring_and_overrides(monkeypatch):

--- a/kedro-datasets/tests/test_generate_catalog_schema.py
+++ b/kedro-datasets/tests/test_generate_catalog_schema.py
@@ -40,36 +40,22 @@ SAMPLE_SPEC = generator.DatasetSpec(
 
 
 def test_json_type_for_known_nullable_and_unknown_annotations():
-    class Version:
-        pass
-
-    assert generator._json_type_for(str) == "string"
-    assert generator._json_type_for(Path) == "string"
-    assert generator._json_type_for(Version) == "object"
-    assert generator._json_type_for(dict[str, Any] | None) == ["object", "null"]
-    assert generator._json_type_for(str | dict[str, Any]) == ["string", "object"]
+    assert generator._json_type_for("str") == "string"
+    assert generator._json_type_for("pathlib.Path") == "string"
+    assert generator._json_type_for("Version") == "object"
+    assert generator._json_type_for("dict[str, Any] | None") == ["object", "null"]
+    assert generator._json_type_for("str | dict[str, Any]") == ["string", "object"]
     assert generator._json_type_for(str | Any) is generator._UNKNOWN
     assert generator._json_type_for("str | UnknownType") is generator._UNKNOWN
     assert generator._json_type_for(inspect.Parameter.empty) is generator._UNKNOWN
     assert generator._json_type_for(None) is generator._UNKNOWN
-    assert generator._json_type_for("Version") == "object"
     assert generator._json_type_for("str | os.PathLike") == "string"
-
-
-def test_json_type_for_handles_empty_and_invalid_type_map_entries(monkeypatch):
-    class Unmapped:
-        pass
-
-    monkeypatch.setattr(generator, "get_args", lambda annotation: ())
-    assert generator._json_type_for_union(object()) is generator._UNKNOWN
-
-    monkeypatch.setitem(generator._TYPE_MAP, "not-a-type", "string")
-    assert generator._json_type_for_concrete(Unmapped) is generator._UNKNOWN
+    assert generator._json_type_for(Path) is generator._UNKNOWN
 
 
 def test_property_schema_renders_unknown_as_pattern():
     assert generator._property_schema(Any, None) == {"pattern": ".*"}
-    assert generator._property_schema(str, "A value.") == {
+    assert generator._property_schema("str", "A value.") == {
         "type": "string",
         "description": "A value.",
     }
@@ -248,15 +234,6 @@ def test_deep_merge_merges_nested_dicts_and_replaces_values():
         "properties": {"filepath": {"type": "string", "description": "Path."}},
         "required": [],
     }
-
-
-def test_resolved_type_hints_falls_back_for_unresolved_annotations():
-    def unresolved(value) -> None:
-        pass
-
-    unresolved.__annotations__ = {"value": "MissingType", "return": None}
-
-    assert generator._resolved_type_hints(unresolved) == {}
 
 
 def test_dataset_then_schema_uses_signature_docstring_and_overrides(monkeypatch):


### PR DESCRIPTION
## Description

Closes #964.

This PR adds an automated workflow for generating the Kedro catalog JSON schema, replacing the previous manual maintenance process for `kedro-catalog-1.0.0.json`.

## Development notes

- Added `kedro_datasets._generate_catalog_schema`, which generates the latest catalog schema from dataset source files.
- Added `kedro_datasets._schema_overrides` for schema facts that cannot be inferred from constructor signatures or docstrings.
- Regenerated `static/jsonschema/kedro-catalog-1.0.0.json` from the generator.
- Added a manual pre-commit hook to regenerate the catalog schema.
- Removed the PR checklist item asking contributors to manually update catalog JSON schema files.
- Added tests covering the generator, override merge behavior, source-level dataset discovery, annotation mapping, CLI behavior, and schema write/check behavior.

Tested with:

```bash
python -m ruff check kedro_datasets\_generate_catalog_schema.py kedro_datasets\_schema_overrides.py tests\test_generate_catalog_schema.py
python -m pytest tests\test_generate_catalog_schema.py -q --no-cov
python -m pytest tests\test_generate_catalog_schema.py -q --cov-reset --cov=kedro_datasets._generate_catalog_schema --cov=kedro_datasets._schema_overrides --cov-report=term-missing --no-cov-on-fail
python -m kedro_datasets._generate_catalog_schema --check
python -m json.tool static\jsonschema\kedro-catalog-1.0.0.json
```

## Developer Certificate of Origin

 All commits were signed off by including a `Signed-off-by` line in the commit message. [[See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/)](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).


## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [x] Added tests to cover my changes
- [ ] Received approvals from at least half of the TSC (required for adding a new, non-experimental dataset)