### PR TITLE
feat(datasets): add os.PathLike support for TensorFlowModelDataset

### DIFF
--- a/kedro-datasets/kedro_datasets/tensorflow/tensorflow_model_dataset.py
+++ b/kedro-datasets/kedro_datasets/tensorflow/tensorflow_model_dataset.py
@@ -4,6 +4,7 @@ TensorFlow models.
 from __future__ import annotations
 
 import copy
+import os
 import tempfile
 from pathlib import PurePath, PurePosixPath
 from typing import Any
@@ -77,7 +78,7 @@ class TensorFlowModelDataset(AbstractVersionedDataset[tf.keras.Model, tf.keras.M
     def __init__(  # noqa: PLR0913
         self,
         *,
-        filepath: str,
+        filepath: str | os.PathLike,
         load_args: dict[str, Any] | None = None,
         save_args: dict[str, Any] | None = None,
         version: Version | None = None,

--- a/kedro-datasets/tests/tensorflow/test_tensorflow_model_dataset.py
+++ b/kedro-datasets/tests/tensorflow/test_tensorflow_model_dataset.py
@@ -159,6 +159,19 @@ class TestTensorFlowModelDataset:
         assert tf_model_dataset._load_args == {"safe_mode": True}
         assert tf_model_dataset._save_args == {}
 
+    def test_pathlike_filepath(
+        self, tmp_path, dummy_tf_base_model, dummy_x_test, tensorflow_model_dataset
+    ):
+        """Test that os.PathLike filepaths are supported."""
+        filepath = tmp_path / "test_tf.h5"
+        dataset = tensorflow_model_dataset(filepath=filepath)
+        dataset.save(dummy_tf_base_model)
+
+        reloaded = dataset.load()
+        new_predictions = reloaded.predict(dummy_x_test)
+        predictions = dummy_tf_base_model.predict(dummy_x_test)
+        np.testing.assert_allclose(predictions, new_predictions, rtol=1e-6, atol=1e-6)
+
     def test_load_missing_model(self, tf_model_dataset):
         """Test error message when trying to load missing model."""
         pattern = r"Failed while loading data from dataset kedro_datasets.tensorflow.tensorflow_model_dataset.TensorFlowModelDataset\(.*\)"


### PR DESCRIPTION
## Description
Closes part of #1316 (TensorFlow).

Ensures that \os.PathLike\ objects work for \TensorFlowModelDataset\ by updating the \ilepath\ type hint to \str | os.PathLike\ and adding a regression test covering a \pathlib.Path\ filepath.

## Developer Certificate of Origin
- [x] I certify that this contribution is in accordance with the Developer Certificate of Origin as set out in [CONTRIBUTING.md](https://github.com/kedro-org/kedro-plugins/blob/main/CONTRIBUTING.md).