### PR TITLE
feat(datasets): add os.PathLike support for DocxDataset

### DIFF
--- a/kedro-datasets/tests/openxml/test_docx_dataset.py
+++ b/kedro-datasets/tests/openxml/test_docx_dataset.py
@@ -44,6 +44,14 @@ class TestDocxDataset:
         assert docx_dataset._fs_open_args_load == {}
         assert docx_dataset._fs_open_args_save == {"mode": "wb"}
 
+    def test_pathlike_filepath(self, tmp_path, dummy_data):
+        """Test that os.PathLike filepaths are supported."""
+        filepath = tmp_path / "test.docx"
+        dataset = DocxDataset(filepath=filepath)
+        dataset.save(dummy_data)
+        reloaded = dataset.load()
+        assert dummy_data.paragraphs[0].text == reloaded.paragraphs[0].text
+
     def test_exists(self, docx_dataset, dummy_data):
         """Test `exists` method invocation for both existing and
         nonexistent dataset."""


### PR DESCRIPTION
## Description
Closes part of #1316 (OpenXML).

Ensures that \os.PathLike\ objects work for \DocxDataset\ by adding a regression test covering a \pathlib.Path\ filepath.

## Developer Certificate of Origin
- [x] I certify that this contribution is in accordance with the Developer Certificate of Origin as set out in [CONTRIBUTING.md](https://github.com/kedro-org/kedro-plugins/blob/main/CONTRIBUTING.md).