### PR TITLE
feat(datasets): add os.PathLike support for PptxDataset

### DIFF
--- a/kedro-datasets/tests/openxml/test_pptx_dataset.py
+++ b/kedro-datasets/tests/openxml/test_pptx_dataset.py
@@ -49,6 +49,17 @@ class TestPptxDataset:
         assert pptx_dataset._fs_open_args_load == {}
         assert pptx_dataset._fs_open_args_save == {"mode": "wb"}
 
+    def test_pathlike_filepath(self, tmp_path, dummy_data):
+        """Test that os.PathLike filepaths are supported."""
+        filepath = tmp_path / "test.pptx"
+        dataset = PptxDataset(filepath=filepath)
+        dataset.save(dummy_data)
+        reloaded = dataset.load()
+        assert (
+            dummy_data.slides[0].shapes.title.text
+            == reloaded.slides[0].shapes.title.text
+        )
+
     def test_exists(self, pptx_dataset, dummy_data):
         """Test `exists` method invocation for both existing and
         nonexistent dataset."""


### PR DESCRIPTION
## Description
Closes part of #1316 (OpenXML).

Ensures that \os.PathLike\ objects work for \PptxDataset\ by adding a regression test covering a \pathlib.Path\ filepath.

## Developer Certificate of Origin
- [x] I certify that this contribution is in accordance with the Developer Certificate of Origin as set out in [CONTRIBUTING.md](https://github.com/kedro-org/kedro-plugins/blob/main/CONTRIBUTING.md).