### PR TITLE
feat(datasets): add os.PathLike support for MatlabDataset

### DIFF
--- a/kedro-datasets/kedro_datasets/matlab/matlab_dataset.py
+++ b/kedro-datasets/kedro_datasets/matlab/matlab_dataset.py
@@ -5,6 +5,7 @@ supports all allowed options for loading and saving matlab files.
 """
 from __future__ import annotations
 
+import os
 from copy import deepcopy
 from pathlib import PurePosixPath
 from typing import Any
@@ -61,7 +62,7 @@ class MatlabDataset(AbstractVersionedDataset[np.ndarray, np.ndarray]):
 
     def __init__(  # noqa = PLR0913
         self,
-        filepath: str,
+        filepath: str | os.PathLike,
         save_args: dict[str, Any] | None = None,
         version: Version | None = None,
         credentials: dict[str, Any] | None = None,

--- a/kedro-datasets/tests/matlab/test_matlab_dataset.py
+++ b/kedro-datasets/tests/matlab/test_matlab_dataset.py
@@ -43,6 +43,14 @@ class TestMatlabDataset:
         assert matlab_dataset._fs_open_args_load == {}
         assert matlab_dataset._fs_open_args_save == {"mode": "wb"}
 
+    def test_pathlike_filepath(self, tmp_path, dummy_data):
+        """Test that os.PathLike filepaths are supported."""
+        filepath = tmp_path / "test.mat"
+        dataset = MatlabDataset(filepath=filepath)
+        dataset.save(dummy_data)
+        reloaded = dataset.load()
+        assert (dummy_data == reloaded["data"]).all()
+
     def test_exists(self, matlab_dataset, dummy_data):
         """Test `exists` method invocation for both existing and
         nonexistent dataset."""


### PR DESCRIPTION
## Description
Closes part of #1316 (Matlab).

Ensures that \os.PathLike\ objects work for \MatlabDataset\ by updating the \ilepath\ type hint to \str | os.PathLike\ and adding a regression test covering a \pathlib.Path\ filepath.

## Developer Certificate of Origin
- [x] I certify that this contribution is in accordance with the Developer Certificate of Origin as set out in [CONTRIBUTING.md](https://github.com/kedro-org/kedro-plugins/blob/main/CONTRIBUTING.md).