### PR TITLE
build(datasets): fix redirected links and speed up lychee CI check

### DIFF
--- a/.github/workflows/kedro-datasets.yml
+++ b/.github/workflows/kedro-datasets.yml
@@ -77,7 +77,7 @@ jobs:
         with:
           fail: false
           args: >
-            --extensions py,yml,md
+            --extensions py,yml,md,html
             --exclude-path 'site/'
             --exclude-path '(^|/)tests/'
             .

--- a/.github/workflows/kedro-datasets.yml
+++ b/.github/workflows/kedro-datasets.yml
@@ -76,7 +76,11 @@ jobs:
         uses: lycheeverse/lychee-action@v2
         with:
           fail: false
-          args: --exclude "@.lycheeignore" --exclude-path '\.md$' site/
+          args: >
+            --extensions py,yml,md
+            --exclude-path 'site/'
+            --exclude-path '(^|/)tests/'
+            .
           workingDirectory: kedro-datasets
 
   detect-secrets:

--- a/.github/workflows/kedro-datasets.yml
+++ b/.github/workflows/kedro-datasets.yml
@@ -76,7 +76,7 @@ jobs:
         uses: lycheeverse/lychee-action@v2
         with:
           fail: false
-          args: --max-concurrency 32 --exclude "@.lycheeignore" site/
+          args: --exclude "@.lycheeignore" --exclude-path '\.md$' site/
           workingDirectory: kedro-datasets
 
   detect-secrets:

--- a/kedro-datasets/CONTRIBUTING.md
+++ b/kedro-datasets/CONTRIBUTING.md
@@ -25,7 +25,7 @@ If you have new ideas for Kedro-Datasets then please open a [GitHub issue](https
 ## Contribute a new dataset
 
 If you're unsure where to begin contributing to Kedro-Datasets, please start by looking through the `good first issue` and `help wanted` on [GitHub](https://github.com/kedro-org/kedro-plugins/issues).
-If you want to contribute a new dataset, read the [tutorial to create and contribute a custom dataset](https://docs.kedro.org/en/stable/data/how_to_create_a_custom_dataset.html) in the Kedro documentation.
+If you want to contribute a new dataset, read the [tutorial to create and contribute a custom dataset](https://docs.kedro.org/en/stable/extend/how_to_create_a_custom_dataset/) in the Kedro documentation.
 Make sure to add the necessary files for the new dataset so that it shows up in the API documentation:
 
 1. Ensure the dataset's docstring is markdown-parseable.
@@ -39,7 +39,7 @@ Below is a guide to help you understand the process of contributing a new datase
 
 #### Core datasets
 
-Core datasets are maintained by the [Kedro Technical Steering Committee (TSC)](https://docs.kedro.org/en/stable/contribution/technical_steering_committee.html) and adhere to specific standards. These datasets adhere to the following requirements:
+Core datasets are maintained by the [Kedro Technical Steering Committee (TSC)](https://docs.kedro.org/en/stable/about/technical_steering_committee/) and adhere to specific standards. These datasets adhere to the following requirements:
 
 1. Must be something that the Kedro TSC is willing to maintain.
 2. Must be fully documented.
@@ -82,15 +82,15 @@ Working on your first pull request? You can learn how from these resources:
 ### Guidelines
 
 - Aim for cross-platform compatibility on Windows, macOS and Linux
-- We use [Anaconda](https://www.anaconda.com/distribution/) as a preferred virtual environment
+- We use [Anaconda](https://www.anaconda.com/download) as a preferred virtual environment
 - We use [SemVer](https://semver.org/) for versioning
 - We use [mkdocs](https://www.mkdocs.org/) for our documentation
 
 Our code is designed to be compatible with Python 3.6 onwards and our style guidelines are (in cascading order):
 
-- [PEP 8 conventions](https://www.python.org/dev/peps/pep-0008/) for all Python code
+- [PEP 8 conventions](https://peps.python.org/pep-0008/) for all Python code
 - [Google docstrings](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings) for code comments
-- [PEP 484 type hints](https://www.python.org/dev/peps/pep-0484/) for all user-facing functions / class methods e.g.
+- [PEP 484 type hints](https://peps.python.org/pep-0484/) for all user-facing functions / class methods e.g.
 
 ```
 def count_truthy(elements: List[Any]) -> int:

--- a/kedro-datasets/README.md
+++ b/kedro-datasets/README.md
@@ -5,7 +5,7 @@
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://github.com/kedro-org/kedro-plugins/blob/main/LICENSE.md)
 [![Python Version](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue.svg)](https://pypi.org/project/kedro-datasets/)
 [![PyPI Version](https://badge.fury.io/py/kedro-datasets.svg)](https://pypi.org/project/kedro-datasets/)
-[![Code Style: Black](https://img.shields.io/badge/code%20style-black-black.svg)](https://github.com/ambv/black)
+[![Code Style: Black](https://img.shields.io/badge/code%20style-black-black.svg)](https://github.com/psf/black)
 
 Welcome to `kedro_datasets`, the home of Kedro's data connectors. Here you will find `AbstractDataset` implementations powering Kedro's DataCatalog created by QuantumBlack and external contributors.
 
@@ -47,12 +47,12 @@ We support a range of data connectors, including CSV, Excel, Parquet, Feather, H
 
 These data connectors are supported with the APIs of `pandas`, `spark`, `networkx`, `matplotlib`, `yaml` and more.
 
-[The Data Catalog](https://docs.kedro.org/en/stable/data/data_catalog.html) allows you to work with a range of file formats on local file systems, network file systems, cloud object stores, and Hadoop.
+[The Data Catalog](https://docs.kedro.org/en/stable/catalog-data/data_catalog/) allows you to work with a range of file formats on local file systems, network file systems, cloud object stores, and Hadoop.
 
-Here is a full list of [supported data connectors and APIs](https://docs.kedro.org/projects/kedro-datasets/en/stable/api/kedro_datasets.html).
+Here is a full list of [supported data connectors and APIs](https://docs.kedro.org/projects/kedro-datasets/).
 
 ## How can I create my own `AbstractDataset` implementation?
-Take a look at our [instructions on how to create your own `AbstractDataset` implementation](https://docs.kedro.org/en/stable/data/how_to_create_a_custom_dataset.html).
+Take a look at our [instructions on how to create your own `AbstractDataset` implementation](https://docs.kedro.org/en/stable/extend/how_to_create_a_custom_dataset/).
 
 ## Can I contribute?
 

--- a/kedro-datasets/RELEASE.md
+++ b/kedro-datasets/RELEASE.md
@@ -578,7 +578,7 @@ Many thanks to the following Kedroids for contributing PRs to this release:
 
 - Removed Dataset classes ending with "DataSet", use the "Dataset" spelling instead.
 - Removed support for Python 3.7 and 3.8.
-- Added [databricks-connect>=13.0](https://docs.databricks.com/en/dev-tools/databricks-connect-ref.html) support for Spark- and Databricks-based datasets.
+- Added [databricks-connect>=13.0](https://docs.databricks.com/aws/en/dev-tools/databricks-connect) support for Spark- and Databricks-based datasets.
 - Bumped `s3fs` to latest calendar-versioned release.
 - `PartitionedDataset` and `IncrementalDataset` now both support versioning of the underlying dataset.
 
@@ -605,7 +605,7 @@ Many thanks to the following Kedroids for contributing PRs to this release:
 
 | Type                       | Description                                                            | Location                |
 | -------------------------- | ---------------------------------------------------------------------- | ----------------------- |
-| `polars.LazyPolarsDataset` | A `LazyPolarsDataset` using [polars](https://www.pola.rs/)'s Lazy API. | `kedro_datasets.polars` |
+| `polars.LazyPolarsDataset` | A `LazyPolarsDataset` using [polars](https://pola.rs/)'s Lazy API. | `kedro_datasets.polars` |
 
 - Moved `PartitionedDataSet` and `IncrementalDataSet` from the core Kedro repo to `kedro-datasets` and renamed to `PartitionedDataset` and `IncrementalDataset`.
 - Renamed `polars.GenericDataSet` to `polars.EagerPolarsDataset` to better reflect the difference between the two dataset classes.
@@ -644,7 +644,7 @@ Many thanks to the following Kedroids for contributing PRs to this release:
 
 | Type                    | Description                                                                                                                | Location                |
 | ----------------------- | -------------------------------------------------------------------------------------------------------------------------- | ----------------------- |
-| `polars.GenericDataSet` | A `GenericDataSet` backed by [polars](https://www.pola.rs/), a lightning fast dataframe package built entirely using Rust. | `kedro_datasets.polars` |
+| `polars.GenericDataSet` | A `GenericDataSet` backed by [polars](https://pola.rs/), a lightning fast dataframe package built entirely using Rust. | `kedro_datasets.polars` |
 
 ## Bug fixes and other changes
 
@@ -797,8 +797,8 @@ Many thanks to the following Kedroids for contributing PRs to this release:
 
 | Type                             | Description                                                                                                           | Location                   |
 | -------------------------------- | --------------------------------------------------------------------------------------------------------------------- | -------------------------- |
-| `polars.CSVDataSet`              | A `CSVDataSet` backed by [polars](https://www.pola.rs/), a lighting fast dataframe package built entirely using Rust. | `kedro_datasets.polars`    |
-| `snowflake.SnowparkTableDataSet` | Work with [Snowpark](https://www.snowflake.com/en/data-cloud/snowpark/) DataFrames from tables in Snowflake.          | `kedro_datasets.snowflake` |
+| `polars.CSVDataSet`              | A `CSVDataSet` backed by [polars](https://pola.rs/), a lighting fast dataframe package built entirely using Rust. | `kedro_datasets.polars`    |
+| `snowflake.SnowparkTableDataSet` | Work with [Snowpark](https://www.snowflake.com/en/product/features/snowpark/) DataFrames from tables in Snowflake.          | `kedro_datasets.snowflake` |
 
 ## Bug fixes and other changes
 
@@ -823,7 +823,7 @@ Many thanks to the following Kedroids for contributing PRs to this release:
 
 First official release of Kedro-Datasets.
 
-Datasets are Kedro’s way of dealing with input and output in a data and machine-learning pipeline. [Kedro supports numerous datasets](https://kedro.readthedocs.io/en/stable/kedro.extras.datasets.html) out of the box to allow you to process different data formats including Pandas, Plotly, Spark and more.
+Datasets are Kedro’s way of dealing with input and output in a data and machine-learning pipeline. [Kedro supports numerous datasets](https://docs.kedro.org/projects/kedro-datasets/) out of the box to allow you to process different data formats including Pandas, Plotly, Spark and more.
 
 The datasets have always been part of the core Kedro Framework project inside `kedro.extras`. In Kedro `0.19.0`, we will remove datasets from Kedro to reduce breaking changes associated with dataset dependencies. Instead, users will need to use the datasets from the `kedro-datasets` repository instead.
 

--- a/kedro-datasets/kedro_datasets/README.md
+++ b/kedro-datasets/kedro_datasets/README.md
@@ -8,11 +8,11 @@ We support a range of data descriptions, including CSV, Excel, Parquet, Feather,
 
 These data descriptions are supported with the APIs of `pandas`, `spark`, `networkx`, `matplotlib`, `yaml` and more.
 
-[The Data Catalog](https://docs.kedro.org/en/stable/data/data_catalog.html) allows you to work with a range of file formats on local file systems, network file systems, cloud object stores, and Hadoop.
+[The Data Catalog](https://docs.kedro.org/en/stable/catalog-data/data_catalog/) allows you to work with a range of file formats on local file systems, network file systems, cloud object stores, and Hadoop.
 
 Here is a full list of [supported data descriptions and APIs](https://docs.kedro.org/en/stable/kedro_datasets.html).
 
 ## How can I create my own `AbstractDataset` implementation?
 
 
-Take a look at our [instructions on how to create your own `AbstractDataset` implementation](https://docs.kedro.org/en/stable/data/how_to_create_a_custom_dataset.html).
+Take a look at our [instructions on how to create your own `AbstractDataset` implementation](https://docs.kedro.org/en/stable/extend/how_to_create_a_custom_dataset/).

--- a/kedro-datasets/kedro_datasets/spark/README.md
+++ b/kedro-datasets/kedro_datasets/spark/README.md
@@ -5,7 +5,7 @@ See [Spark Structured Streaming](https://spark.apache.org/docs/latest/structured
 
 To work with multiple streaming nodes, 2 hooks are required for:
 
-- Integrating PySpark, see [Build a Kedro pipeline with PySpark](https://docs.kedro.org/en/stable/integrations/pyspark_integration.html) for details
+- Integrating PySpark, see [Build a Kedro pipeline with PySpark](https://docs.kedro.org/en/stable/integrations-and-plugins/pyspark_integration/) for details
 - Running streaming query without termination unless exception
 
 #### Supported file formats

--- a/kedro-datasets/kedro_datasets_benchmarks/README.md
+++ b/kedro-datasets/kedro_datasets_benchmarks/README.md
@@ -1,6 +1,6 @@
 # Kedro-Datasets Benchmarks
 
-This directory contains performance benchmarks for `kedro-datasets` using [airspeed velocity (asv)](https://asv.readthedocs.io/).
+This directory contains performance benchmarks for `kedro-datasets` using [airspeed velocity (asv)](https://asv.readthedocs.io/en/latest/).
 
 ## Running Benchmarks in the Monorepo
 

--- a/kedro-datasets/kedro_datasets_experimental/langfuse/README.md
+++ b/kedro-datasets/kedro_datasets_experimental/langfuse/README.md
@@ -469,7 +469,7 @@ DatasetError: Remote sync policy specified but no remote prompt exists
 
 ## TraceDataset
 
-A Kedro dataset for managing [Langfuse tracing](https://langfuse.com/docs/tracing) clients and callbacks. It provides the appropriate tracing object based on a configurable mode, enabling seamless integration with LangChain, OpenAI, AutoGen, or direct Langfuse SDK usage. Environment variables are automatically configured during initialization.
+A Kedro dataset for managing [Langfuse tracing](https://langfuse.com/docs/observability/overview) clients and callbacks. It provides the appropriate tracing object based on a configurable mode, enabling seamless integration with LangChain, OpenAI, AutoGen, or direct Langfuse SDK usage. Environment variables are automatically configured during initialization.
 
 ### Quick Start
 
@@ -1085,6 +1085,6 @@ DatasetError: Langfuse API error while fetching dataset '...': 401 Unauthorized
 
 ## Related Resources
 - **Kedro Academy**: [Agentic Workflows](https://github.com/kedro-org/kedro-academy/tree/main/kedro-agentic-workflows)
-- **Langfuse Tracing**: [Tracing overview](https://langfuse.com/docs/tracing)
+- **Langfuse Tracing**: [Tracing overview](https://langfuse.com/docs/observability/overview)
 - **Langfuse Evaluation**: [Dataset experiments](https://langfuse.com/docs/evaluation/experiments/datasets)
-- **Langfuse Prompts**: [Prompt management](https://langfuse.com/docs/prompt-management)
+- **Langfuse Prompts**: [Prompt management](https://langfuse.com/docs/prompt-management/overview)

--- a/kedro-datasets/kedro_datasets_experimental/mlrun/README.md
+++ b/kedro-datasets/kedro_datasets_experimental/mlrun/README.md
@@ -286,5 +286,5 @@ FileNotFoundError: Model artifact not found
 
 - [MLRun Documentation](https://docs.mlrun.org/en/latest/?badge=latest) — check your MLRun version for supported `load_args`/`save_args`
 - [MLRun execution API (MLClientCtx)](https://docs.mlrun.org/en/latest/api/mlrun.execution/index.html) — `log_artifact`, `log_model`, `log_result`, `get_artifact`
-- [Kedro Documentation](https://docs.kedro.org/en/stable/)
+- [Kedro Documentation](https://docs.kedro.org/)
 - [MLRun GitHub](https://github.com/mlrun/mlrun)

--- a/kedro-datasets/kedro_datasets_experimental/mlrun/README.md
+++ b/kedro-datasets/kedro_datasets_experimental/mlrun/README.md
@@ -286,5 +286,5 @@ FileNotFoundError: Model artifact not found
 
 - [MLRun Documentation](https://docs.mlrun.org/en/latest/?badge=latest) — check your MLRun version for supported `load_args`/`save_args`
 - [MLRun execution API (MLClientCtx)](https://docs.mlrun.org/en/latest/api/mlrun.execution/index.html) — `log_artifact`, `log_model`, `log_result`, `get_artifact`
-- [Kedro Documentation](https://docs.kedro.org/)
+- [Kedro Documentation](https://docs.kedro.org/en/stable/)
 - [MLRun GitHub](https://github.com/mlrun/mlrun)

--- a/kedro-datasets/kedro_datasets_experimental/opik/README.md
+++ b/kedro-datasets/kedro_datasets_experimental/opik/README.md
@@ -1066,5 +1066,5 @@ def my_task(dataset_item: dict) -> dict:
 - **Opik Documentation**: [Opik Platform](https://www.comet.com/docs/opik/)
 - **Opik Tracing**: [Tracing overview](https://www.comet.com/docs/opik/tracing/advanced/log_traces)
 - **Opik Evaluation**: [Evaluation overview](https://www.comet.com/docs/opik/evaluation/overview)
-- **Kedro Documentation**: [Kedro Datasets](https://docs.kedro.org/en/stable/)
+- **Kedro Documentation**: [Kedro Datasets](https://docs.kedro.org/)
 - **Kedro Academy**: [Agentic Workflows](https://github.com/kedro-org/kedro-academy/tree/main/kedro-agentic-workflows)

--- a/kedro-datasets/kedro_datasets_experimental/opik/README.md
+++ b/kedro-datasets/kedro_datasets_experimental/opik/README.md
@@ -432,7 +432,7 @@ DatasetError: Remote sync policy specified but no remote prompt exists in Opik
 
 ## TraceDataset
 
-A Kedro dataset for managing [Opik tracing](https://www.comet.com/docs/opik/tracing/log_traces) clients and callbacks. It provides the appropriate tracing object based on a configurable mode, enabling seamless integration with LangChain, OpenAI, AutoGen, or direct Opik SDK usage. Opik credentials are automatically configured during initialization.
+A Kedro dataset for managing [Opik tracing](https://www.comet.com/docs/opik/tracing/advanced/log_traces) clients and callbacks. It provides the appropriate tracing object based on a configurable mode, enabling seamless integration with LangChain, OpenAI, AutoGen, or direct Opik SDK usage. Opik credentials are automatically configured during initialization.
 
 ### Quick Start
 
@@ -1064,7 +1064,7 @@ def my_task(dataset_item: dict) -> dict:
 
 ## Related Resources
 - **Opik Documentation**: [Opik Platform](https://www.comet.com/docs/opik/)
-- **Opik Tracing**: [Tracing overview](https://www.comet.com/docs/opik/tracing/log_traces)
+- **Opik Tracing**: [Tracing overview](https://www.comet.com/docs/opik/tracing/advanced/log_traces)
 - **Opik Evaluation**: [Evaluation overview](https://www.comet.com/docs/opik/evaluation/overview)
-- **Kedro Documentation**: [Kedro Datasets](https://docs.kedro.org/)
+- **Kedro Documentation**: [Kedro Datasets](https://docs.kedro.org/en/stable/)
 - **Kedro Academy**: [Agentic Workflows](https://github.com/kedro-org/kedro-academy/tree/main/kedro-agentic-workflows)

--- a/kedro-datasets/lychee.toml
+++ b/kedro-datasets/lychee.toml
@@ -1,0 +1,25 @@
+# Config for the `lychee` link checker used in CI (see .github/workflows/kedro-datasets.yml).
+# Picked up automatically since lychee's default --config value is "lychee.toml".
+
+# Overall cap on concurrent network requests.
+max_concurrency = 12
+
+# Cap on simultaneous requests to any single host, plus a minimum gap between
+# them. Documentation sites like docs.kedro.org and readthedocs.io are linked
+# from nearly every dataset's docstring, so without this they get hit with
+# dozens of concurrent requests and start rate-limiting (HTTP 429) almost
+# immediately, which is the main reason link checks used to be slow.
+host_concurrency = 4
+host_request_interval = "250ms"
+
+# Treat 429 as an accepted response: it means "you're being throttled", not
+# "this link is broken". Accepting it outright avoids lychee's retry/backoff
+# logic, which otherwise re-requests each rate-limited link multiple times
+# and waits between attempts.
+accept = ["100..=103", "200..=299", "429"]
+
+# docs.kedro.org accounts for the vast majority of rate-limit responses, so
+# throttle it further still.
+[hosts."docs.kedro.org"]
+concurrency = 2
+request_interval = "500ms"

--- a/kedro-datasets/lychee.toml
+++ b/kedro-datasets/lychee.toml
@@ -18,6 +18,16 @@ host_request_interval = "250ms"
 # and waits between attempts.
 accept = ["100..=103", "200..=299", "429"]
 
+# We scan raw .py source, so placeholder/example values inside docstring code
+# samples (credentials snippets, etc.) get picked up as if they were real
+# links. Skip loopback addresses (localhost:*, 127.0.0.1:*) and known fake
+# hostnames used in examples.
+exclude_loopback = true
+exclude = [
+    '^https?://custom\.langfuse\.com',
+    '^https?://[\w-]+\.weaviate\.network',
+]
+
 # docs.kedro.org accounts for the vast majority of rate-limit responses, so
 # throttle it further still.
 [hosts."docs.kedro.org"]

--- a/kedro-datasets/lychee.toml
+++ b/kedro-datasets/lychee.toml
@@ -1,17 +1,6 @@
 # Config for the `lychee` link checker used in CI (see .github/workflows/kedro-datasets.yml).
 # Picked up automatically since lychee's default --config value is "lychee.toml".
 
-# Overall cap on concurrent network requests.
-max_concurrency = 12
-
-# Cap on simultaneous requests to any single host, plus a minimum gap between
-# them. Documentation sites like docs.kedro.org and readthedocs.io are linked
-# from nearly every dataset's docstring, so without this they get hit with
-# dozens of concurrent requests and start rate-limiting (HTTP 429) almost
-# immediately, which is the main reason link checks used to be slow.
-host_concurrency = 4
-host_request_interval = "250ms"
-
 # Treat 429 as an accepted response: it means "you're being throttled", not
 # "this link is broken". Accepting it outright avoids lychee's retry/backoff
 # logic, which otherwise re-requests each rate-limited link multiple times
@@ -27,9 +16,3 @@ exclude = [
     '^https?://custom\.langfuse\.com',
     '^https?://[\w-]+\.weaviate\.network',
 ]
-
-# docs.kedro.org accounts for the vast majority of rate-limit responses, so
-# throttle it further still.
-[hosts."docs.kedro.org"]
-concurrency = 2
-request_interval = "500ms"


### PR DESCRIPTION
**TL;DR:** lychee now checks links by scanning source files (`.py`/`.yml`/`.md`/`.html`) directly instead of crawling the built docs `site/`, which is what makes it faster — not because fewer links are covered.

### Description
Fixed lychee redirects where it makes sense, and reworked the `check-docs` lychee setup so it doesn't take ~50 mins to run (original slow run: https://github.com/kedro-org/kedro-plugins/actions/runs/31106737864/job/92633738389?pr=1477).

### Changes
- Updated links in `kedro-datasets` Markdown files that resolved via one or more HTTP redirects to point at their final destination instead.
- Reworked the `check-docs` lychee step: it now scans source `.py`/`.yml`/`.md` files directly instead of the built `site/`. The built site duplicates every docstring link across an `.html` and `.md` page per dataset, plus repeats it again on every page's shared nav/footer — scanning source checks each link once instead of once per generated page.
- Excludes `tests/` (fixture code uses `file:///tmp/...` paths that aren't real links).
- Added `kedro-datasets/lychee.toml`: accepts `429` as a valid status instead of retrying it, and excludes loopback addresses and known placeholder hostnames used in docstring example credentials (`localhost:*`, `custom.langfuse.com`, `*.weaviate.network`) that source-scanning surfaces but the old HTML-based scan didn't (lychee skips links inside code blocks by default). Earlier iterations also added per-host concurrency throttling for the old, much higher-volume site scan; removed once the source-scan switch made it unnecessary (confirmed via a real run: 0 rate-limit responses at the new, much lower link volume).
- Also added `.html` to the scanned extensions, so the hardcoded social links in `docs/overrides/*.html` (rendered on every page's footer) stay covered — they'd otherwise have been silently dropped by the switch to source-scanning.

### Result
The latest run took 1 min and summary is as follows compared to the one that took 50 mins:
| Status | Original (~50 min) | Latest (1m 41s) |
|---|---|---|
| 🔍 Total | 18168 | 834 |
| 🔗 Unique | 2074 | 422 |
| ✅ Successful | 16526 | 745 |
| 🔀 Redirected | 167 | 41 |
| 🚫 Errors | 1166 | 22 |
| ⏳ Timeouts | 0 | 1 |
| 👻 Excluded | 1 | 20 |
