### PR TITLE
feat(datasets): add os.PathLike support for Ibis FileDataset

### DIFF
--- a/kedro-datasets/kedro_datasets/ibis/file_dataset.py
+++ b/kedro-datasets/kedro_datasets/ibis/file_dataset.py
@@ -1,6 +1,7 @@
 """Provide file loading and saving functionality for Ibis's backends."""
 from __future__ import annotations
 
+import os
 from copy import deepcopy
 from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING, Any, ClassVar
@@ -77,7 +78,7 @@ class FileDataset(ConnectionMixin, AbstractVersionedDataset[ir.Table, ir.Table])
 
     def __init__(  # noqa: PLR0913
         self,
-        filepath: str,
+        filepath: str | os.PathLike,
         file_format: str = "parquet",
         *,
         table_name: str | None = None,
@@ -106,9 +107,10 @@ class FileDataset(ConnectionMixin, AbstractVersionedDataset[ir.Table, ir.Table])
         link to the underlying file exists past ``FileDataset.load()``.
 
         Args:
-            filepath: Path to a file to register as a table. Most useful
-                for loading data into your data warehouse (for testing).
-                On save, the backend exports data to the specified path.
+            filepath: Filepath (``str`` or ``os.PathLike``) to a file to
+                register as a table. Most useful for loading data into your
+                data warehouse (for testing). On save, the backend exports
+                data to the specified path.
             file_format: String specifying the file format for the file.
                 Defaults to writing execution results to a Parquet file.
             table_name: The name to use for the created table (on load).

--- a/kedro-datasets/tests/ibis/test_file_dataset.py
+++ b/kedro-datasets/tests/ibis/test_file_dataset.py
@@ -82,6 +82,18 @@ class TestFileDataset:
         reloaded = file_dataset.load()
         assert_frame_equal(dummy_table.execute(), reloaded.execute())
 
+    def test_pathlike_filepath(self, tmp_path, connection_config, dummy_table):
+        """Test that os.PathLike filepaths are supported."""
+        filepath = tmp_path / "test.csv"
+        dataset = FileDataset(
+            filepath=filepath,
+            file_format="csv",
+            connection=connection_config,
+        )
+        dataset.save(dummy_table)
+        reloaded = dataset.load()
+        assert_frame_equal(dummy_table.execute(), reloaded.execute())
+
     def test_save_and_load_parquet(
         self, filepath_parquet, connection_config, dummy_table
     ):


### PR DESCRIPTION
## Description
Closes part of #1316 and #1317 (Ibis).

Ensures that `os.PathLike` objects work for `ibis.FileDataset` by:
- updating the `filepath` type hint from `str` to `str | os.PathLike`
- clarifying the docstring to document PathLike support
- adding a `test_pathlike_filepath` regression test that passes a `pathlib.Path` (without `.as_posix()`) and verifies a save/load round-trip

## Development notes
`split_filepath` already accepts `str | os.PathLike` and converts via `str(filepath)`, and load/save already pass string paths to the Ibis backend. No changes to core I/O logic were required — only the public type hint, docstring, and test coverage, consistent with #1324 and other PathLike PRs in this series.

Rebased onto latest `main` (includes #1490 / pytest-xdist >=3.0). Removed the temporary `py>=1.11.0` pin as requested.

## Developer Certificate of Origin
- [x] I certify that this contribution is in accordance with the Developer Certificate of Origin. All commits include a `Signed-off-by` line.

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Updated `jsonschema/kedro-catalog-X.XX.json` if necessary
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [x] Added tests to cover my changes
- [ ] Received approvals from at least half of the TSC (required for adding a new, non-experimental dataset)