### PR TITLE
feat(datasets): add os.PathLike support for EmailMessageDataset

### DIFF
--- a/kedro-datasets/tests/email/test_message_dataset.py
+++ b/kedro-datasets/tests/email/test_message_dataset.py
@@ -57,6 +57,14 @@ class TestEmailMessageDataset:
         assert message_dataset._fs_open_args_load == {"mode": "r"}
         assert message_dataset._fs_open_args_save == {"mode": "w"}
 
+    def test_pathlike_filepath(self, tmp_path, dummy_msg):
+        """Test that os.PathLike filepaths are supported."""
+        filepath = tmp_path / "test"
+        dataset = EmailMessageDataset(filepath=filepath)
+        dataset.save(dummy_msg)
+        reloaded = dataset.load()
+        assert dummy_msg.__dict__ == reloaded.__dict__
+
     def test_exists(self, message_dataset, dummy_msg):
         """Test `exists` method invocation for both existing and
         nonexistent dataset."""


### PR DESCRIPTION
## Description
Closes part of #1316 (Email).

Ensures that `os.PathLike` objects work for `EmailMessageDataset` by adding a `test_pathlike_filepath` regression test that passes a `pathlib.Path` filepath (without `.as_posix()`) and verifies a save/load round-trip.

The public `filepath` type hint is already `str | os.PathLike`; this PR only adds test coverage, consistent with other PathLike PRs in this series (e.g. #1478, #1479).

Rebased onto latest `main` (includes #1490 / pytest-xdist >=3.0). Removed the temporary `py>=1.11.0` pin as requested.

## Developer Certificate of Origin
- [x] I certify that this contribution is in accordance with the Developer Certificate of Origin. All commits include a `Signed-off-by` line.

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Updated `jsonschema/kedro-catalog-X.XX.json` if necessary
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [x] Added tests to cover my changes
- [ ] Received approvals from at least half of the TSC (required for adding a new, non-experimental dataset)