### PR TITLE
feat(datasets): add os.PathLike support for GeoPandas GenericDataset

### DIFF
--- a/kedro-datasets/RELEASE.md
+++ b/kedro-datasets/RELEASE.md
@@ -5,6 +5,7 @@
 ## Breaking changes to experimental datasets
 ## Bug fixes and other changes
 ## Community contributions
+- [Tanmay Singh](https://github.com/tannnmayy)
 
 # Release 9.6.0
 

--- a/kedro-datasets/tests/geopandas/test_generic_dataset.py
+++ b/kedro-datasets/tests/geopandas/test_generic_dataset.py
@@ -153,6 +153,14 @@ class TestGenericDataset:
         assert geojson_dataset._fs_open_args_load == {}
         assert geojson_dataset._fs_open_args_save == {"mode": "wb"}
 
+    def test_pathlike_filepath(self, tmp_path, dummy_dataframe):
+        """Test that os.PathLike filepaths are supported."""
+        filepath = tmp_path / "test.geojson"
+        dataset = GenericDataset(filepath=filepath)
+        dataset.save(dummy_dataframe)
+        reloaded_df = dataset.load()
+        assert_frame_equal(reloaded_df, dummy_dataframe)
+
     @pytest.mark.parametrize("geojson_dataset", [{"index": False}], indirect=True)
     def test_load_missing_file(self, geojson_dataset):
         """Check the error while trying to load from missing source."""


### PR DESCRIPTION
## Description
Closes part of #1316 (Geopandas).

Ensures that `os.PathLike` objects work for `geopandas.GenericDataset` by adding a `test_pathlike_filepath` regression test that passes a `pathlib.Path` filepath (without `.as_posix()`) and verifies a save/load round-trip.

The public `filepath` type hint is already `str | os.PathLike`; this PR only adds test coverage, consistent with other PathLike PRs in this series (e.g. #1478, #1479).

Rebased onto latest `main` (includes #1490 / pytest-xdist >=3.0). Removed the temporary `py>=1.11.0` pin as requested.

## Developer Certificate of Origin
- [x] I certify that this contribution is in accordance with the Developer Certificate of Origin. All commits include a `Signed-off-by` line.

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Updated `jsonschema/kedro-catalog-X.XX.json` if necessary
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [x] Added tests to cover my changes
- [ ] Received approvals from at least half of the TSC (required for adding a new, non-experimental dataset)