### PR TITLE
build: bump pytest-xdist to >=3.0 to fix flaky `py.log` collection error

### DIFF
--- a/kedro-datasets/pyproject.toml
+++ b/kedro-datasets/pyproject.toml
@@ -331,7 +331,7 @@ test = [
     "pyspark>=4.0, <4.1; python_version >= '3.12'",  # Temporary pin till delta-spark is compatible
     "pytest-cov>=7.0,<8.0",
     "pytest-mock>=1.7.1, <2.0",
-    "pytest-xdist[psutil]~=2.2.1",
+    "pytest-xdist[psutil]>=3.0,<4.0",
     "pytest~=7.2",
     "python-docx",
     "python-pptx",
@@ -435,7 +435,7 @@ experimental_test = [
     "pyspark>=4.0; python_version >= '3.12'",
     "pytest-cov>=7.0,<8.0",
     "pytest-mock>=1.7.1, <2.0",
-    "pytest-xdist[psutil]~=2.2.1",
+    "pytest-xdist[psutil]>=3.0,<4.0",
     "pytest~=7.2",
     "u8darts[all]",
     "numpy<2.5",  # numba (pulled in via darts -> shap) does not support numpy 2.5 yet

--- a/kedro-docker/pyproject.toml
+++ b/kedro-docker/pyproject.toml
@@ -31,7 +31,7 @@ test = [
     "pytest",
     "pytest-cov",
     "pytest-mock",
-    "pytest-xdist[psutil]~=2.2.1",
+    "pytest-xdist[psutil]>=3.0,<4.0",
     "PyYAML>=5.1, <7.0",
     "wheel==0.32.2",
 ]

--- a/kedro-telemetry/pyproject.toml
+++ b/kedro-telemetry/pyproject.toml
@@ -29,7 +29,7 @@ test = [
     "pytest",
     "pytest-cov",
     "pytest-mock",
-    "pytest-xdist[psutil]~=2.2.1",
+    "pytest-xdist[psutil]>=3.0,<4.0",
     "PyYAML==5.3.1", # Temporary fix, to be removed
     "wheel",
 ]


### PR DESCRIPTION
## Description

Builds fail intermittently at collection time with:

```
INTERNALERROR>   File ".../xdist/scheduler/each.py", line 1, in <module>
INTERNALERROR>     from py.log import Producer
INTERNALERROR> ModuleNotFoundError: No module named 'py.log'; 'py' is not a package
```

`pytest-xdist` was pinned to `~=2.2.1`, which imports `py.log` and therefore needs the real, separately-installed `py` package. Since pytest 7.2, pytest vendors `py.path`/`py.error` into `_pytest._py`, ships its own top-level `py.py` *module* shim, and no longer depends on `py`. That shim is not a package, so `import py.log` fails. Nothing else in the dev dependencies pulls in real `py` any more either (`pytest-forked` dropped its `py` dependency in 1.6.0).

It only fails intermittently because whether the real `py` package ends up in the environment — shadowing pytest's `py.py` shim — depends on transitive resolution and install ordering, not on anything we declare.

## Development notes

- Bumped `pytest-xdist[psutil]` from `~=2.2.1` to `>=3.0,<4.0` in `kedro-datasets` (both test extras), `kedro-docker` and `kedro-telemetry`. 
- `kedro-airflow` is already unpinned and unaffected. 
- xdist 3.x drops both the `py` and `pytest-forked` dependencies and requires `pytest>=7.0`, so it is compatible with the existing `pytest~=7.2` pin.

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Updated `jsonschema/kedro-catalog-X.XX.json` if necessary
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
- [ ] Received approvals from at least half of the TSC (required for adding a new, non-experimental dataset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
