### PR TITLE
fix(datasets): avoid Polars filename warning in EagerPolarsDataset

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -397,7 +397,7 @@
         "filename": "kedro-datasets/tests/polars/test_eager_polars_dataset.py",
         "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
         "is_verified": false,
-        "line_number": 127
+        "line_number": 128
       }
     ],
     "kedro-datasets/tests/polars/test_lazy_polars_dataset.py": [
@@ -460,5 +460,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-14T13:15:43Z"
+  "generated_at": "2026-08-11T02:19:07Z"
 }

--- a/kedro-datasets/RELEASE.md
+++ b/kedro-datasets/RELEASE.md
@@ -4,7 +4,10 @@
 ## Breaking changes
 ## Breaking changes to experimental datasets
 ## Bug fixes and other changes
+- Fixed `polars.EagerPolarsDataset` local loads to pass a path string to Polars instead of an fsspec file object, avoiding the "Polars found a filename" `UserWarning` and aligning with `LazyPolarsDataset` / `polars.CSVDataset` (#789).
 ## Community contributions
+- [Tanmay Singh](https://github.com/tannnmayy)
+
 
 # Release 9.6.0
 

--- a/kedro-datasets/kedro_datasets/polars/eager_polars_dataset.py
+++ b/kedro-datasets/kedro_datasets/polars/eager_polars_dataset.py
@@ -159,6 +159,14 @@ class EagerPolarsDataset(AbstractVersionedDataset[pl.DataFrame, pl.DataFrame]):
                 " API"
                 " https://pola-rs.github.io/polars/py-polars/html/reference/io.html"
             )
+
+        # Prefer path-based I/O for local files when no custom open args are needed.
+        # Passing a Python file object can trigger Polars' "found a filename"
+        # UserWarning and prevents path-aware optimisations (see #789). This matches
+        # LazyPolarsDataset / polars.CSVDataset local load behaviour.
+        if self._protocol == "file" and not self._fs_open_args_load:
+            return load_method(load_path, **self._load_args)
+
         with self._fs.open(load_path, **self._fs_open_args_load) as fs_file:
             return load_method(fs_file, **self._load_args)
 

--- a/kedro-datasets/tests/polars/test_eager_polars_dataset.py
+++ b/kedro-datasets/tests/polars/test_eager_polars_dataset.py
@@ -1,4 +1,5 @@
 import inspect
+import warnings
 from pathlib import Path, PurePosixPath
 from time import sleep
 
@@ -205,6 +206,59 @@ class TestEagerExcelDataset:
         dataset = EagerPolarsDataset(filepath=filepath, file_format="parquet")
         dataset.save(dummy_dataframe)
         assert_frame_equal(dataset.load(), dummy_dataframe)
+
+
+class TestEagerPolarsDatasetLocalLoad:
+    """Regression coverage for #789: local loads should use path-based I/O."""
+
+    @pytest.mark.parametrize("file_format", ["csv", "parquet"])
+    def test_local_load_uses_path_not_file_object(
+        self, tmp_path, dummy_dataframe, file_format, mocker
+    ):
+        """Local loads must pass a path string to Polars, not an fsspec file object.
+
+        Opening via ``fs.open`` and handing Polars a file-like with a ``.name`` can
+        emit ``UserWarning: Polars found a filename`` and blocks path-aware features.
+        """
+        filepath = tmp_path / f"test.{file_format}"
+        dataset = EagerPolarsDataset(
+            filepath=filepath.as_posix(),
+            file_format=file_format,
+        )
+        dataset.save(dummy_dataframe)
+
+        open_spy = mocker.spy(dataset._fs, "open")
+        with warnings.catch_warnings(record=True) as recorded:
+            warnings.simplefilter("always")
+            reloaded = dataset.load()
+
+        open_spy.assert_not_called()
+        filename_warnings = [
+            w
+            for w in recorded
+            if issubclass(w.category, UserWarning)
+            and "filename" in str(w.message).lower()
+        ]
+        assert filename_warnings == []
+        assert_frame_equal(dummy_dataframe, reloaded)
+
+    def test_custom_open_args_load_still_uses_filesystem(
+        self, tmp_path, dummy_dataframe, mocker
+    ):
+        """Custom ``fs_args.open_args_load`` must keep fsspec ``open`` behaviour."""
+        filepath = tmp_path / "test.csv"
+        dataset = EagerPolarsDataset(
+            filepath=filepath.as_posix(),
+            file_format="csv",
+            fs_args={"open_args_load": {"mode": "rb"}},
+        )
+        dataset.save(dummy_dataframe)
+
+        open_spy = mocker.spy(dataset._fs, "open")
+        reloaded = dataset.load()
+
+        open_spy.assert_called()
+        assert_frame_equal(dummy_dataframe, reloaded)
 
 
 class TestEagerParquetDatasetVersioned:


### PR DESCRIPTION
## Description
Closes #789.

`EagerPolarsDataset.load()` always opened the target via `fsspec` and passed a Python file object into `polars.read_*`. Polars can then emit a filename-related `UserWarning` and cannot use path-aware optimisations (see also discussion on #625 / #590).

## Development notes
For **local** (`file`) loads with no custom `fs_args.open_args_load`, call `polars.read_{format}(path, **load_args)` directly — the same pattern used by:

- `LazyPolarsDataset` (local `scan_*`)
- `polars.CSVDataset` (local `read_csv`)

Still use `fsspec.open` when:

- the protocol is remote (versioning / multi-cloud still go through the filesystem), or
- the user set custom `open_args_load` (explicit open kwargs)

Remote I/O is intentionally unchanged in this PR to keep the fix scoped; a fuller "less fsspec" rewrite remains #625.

## How tested
```text
pytest tests/polars/test_eager_polars_dataset.py::TestEagerPolarsDatasetLocalLoad -v
# 3 passed (csv + parquet path load, custom open_args_load regression)
```

## Developer Certificate of Origin
- [x] I certify that this contribution is in accordance with the Developer Certificate of Origin. All commits include a `Signed-off-by` line.

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [x] Added a description of this change in the relevant `RELEASE.md` file
- [x] Added tests to cover my changes
- [ ] Received approvals from at least half of the TSC (required for adding a new, non-experimental dataset)