### PR TITLE
fix(datasets): bypass s3fs listing cache when globbing in SparkDatasetV2

### DIFF
--- a/kedro-datasets/RELEASE.md
+++ b/kedro-datasets/RELEASE.md
@@ -4,6 +4,8 @@
 ## Breaking changes
 ## Breaking changes to experimental datasets
 ## Bug fixes and other changes
+- Fixed `spark.SparkDatasetV2` resolving a stale version for versioned S3 datasets by bypassing the `s3fs` listing cache when globbing (`s3://`, `s3a://`, `s3n://`).
+
 ## Community contributions
 
 # Release 9.6.0

--- a/kedro-datasets/kedro_datasets/spark/spark_dataset_v2.py
+++ b/kedro-datasets/kedro_datasets/spark/spark_dataset_v2.py
@@ -363,6 +363,12 @@ class SparkDatasetV2(AbstractVersionedDataset):
 
         # Regular fsspec for everything else
         fs = get_spark_filesystem(protocol, credentials)
+
+        if protocol in ("s3", "s3a", "s3n"):
+            # Bypass the s3fs listing cache so versioned datasets resolve the
+            # latest version rather than a stale directory listing.
+            return fs.exists, partial(fs.glob, refresh=True)
+
         return fs.exists, fs.glob
 
     def _handle_delta_format(self) -> None:

--- a/kedro-datasets/tests/spark/test_spark_dataset_v2.py
+++ b/kedro-datasets/tests/spark/test_spark_dataset_v2.py
@@ -545,6 +545,31 @@ class TestSparkDatasetV2CloudStorage:
         # Verify s3a:// normalization
         assert dataset._spark_path.startswith("s3a://")
 
+    @pytest.mark.parametrize("protocol", ["s3", "s3a", "s3n"])
+    def test_s3_glob_bypasses_listing_cache(self, mock_s3_filesystem, protocol):
+        """Test that S3 globbing refreshes the listing cache.
+
+        Without ``refresh=True``, a versioned dataset can resolve a stale
+        version from the s3fs directory listing cache.
+        """
+        dataset = SparkDatasetV2(
+            filepath=f"{protocol}://bucket/data.parquet", version=Version(None, None)
+        )
+
+        dataset._glob_function("bucket/data.parquet/*/data.parquet")
+
+        mock_s3_filesystem.glob.assert_called_once_with(
+            "bucket/data.parquet/*/data.parquet", refresh=True
+        )
+
+    def test_non_s3_glob_does_not_pass_refresh(self, mock_s3_filesystem):
+        """Test that ``refresh`` is not passed to filesystems that reject it."""
+        dataset = SparkDatasetV2(filepath="gs://bucket/data.parquet")
+
+        dataset._glob_function("bucket/data.parquet")
+
+        mock_s3_filesystem.glob.assert_called_once_with("bucket/data.parquet")
+
     def test_gcs_handling(self, mock_s3_filesystem):
         """Test GCS handling."""
         dataset = SparkDatasetV2(


### PR DESCRIPTION
## Description

Follow-up to #736. While checking whether that issue is still relevant, I found that `SparkDatasetV2` handles all S3 protocols correctly (`s3://`, `s3a://`, `s3n://` all normalise to `s3a://` for Spark), but it dropped a deliberate behaviour that `SparkDataset` v1 had: bypassing the `s3fs` directory listing cache when globbing.

v1 does this at `spark_dataset.py:217`:

```python
# Ensure cache is not used so latest version is retrieved correctly.
glob_function = partial(_s3.glob, refresh=True)
```

`SparkDatasetV2._get_filesystem_ops` returned a bare `fs.glob`, so a versioned S3 dataset could resolve a stale version from the cached listing instead of the latest one.

## Development notes

- `_get_filesystem_ops` now wraps `fs.glob` in `partial(..., refresh=True)` for the `s3`, `s3a` and `s3n` protocols. 
- Added a parametrised test asserting `refresh=True` is passed for all three S3 protocols, plus a test that non-S3 filesystems (`gs://`) still get a plain `glob` call.

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Updated `jsonschema/kedro-catalog-X.XX.json` if necessary
- [x] Added a description of this change in the relevant `RELEASE.md` file
- [x] Added tests to cover my changes
- [ ] Received approvals from at least half of the TSC (required for adding a new, non-experimental dataset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)