### PR TITLE
feat(datasets): add os.PathLike support for partition datasets

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -294,14 +294,14 @@
         "filename": "kedro-datasets/tests/partitions/test_incremental_dataset.py",
         "hashed_secret": "727d8ff68b6b550f2cf6e737b3cad5149c65fe5b",
         "is_verified": false,
-        "line_number": 440
+        "line_number": 446
       },
       {
         "type": "Secret Keyword",
         "filename": "kedro-datasets/tests/partitions/test_incremental_dataset.py",
         "hashed_secret": "adb5fabe51f5b45e83fdd91b71c92156fec4a63e",
         "is_verified": false,
-        "line_number": 460
+        "line_number": 466
       }
     ],
     "kedro-datasets/tests/partitions/test_partitioned_dataset.py": [
@@ -310,35 +310,35 @@
         "filename": "kedro-datasets/tests/partitions/test_partitioned_dataset.py",
         "hashed_secret": "76f747de912e8682e29a23cb506dd5bf0de080d2",
         "is_verified": false,
-        "line_number": 606
+        "line_number": 605
       },
       {
         "type": "Secret Keyword",
         "filename": "kedro-datasets/tests/partitions/test_partitioned_dataset.py",
         "hashed_secret": "9027cc5a2c1321de60a2d71ccde6229d1152d6d3",
         "is_verified": false,
-        "line_number": 607
+        "line_number": 606
       },
       {
         "type": "Secret Keyword",
         "filename": "kedro-datasets/tests/partitions/test_partitioned_dataset.py",
         "hashed_secret": "5dcbdf371f181b9b7a41a4be7be70f8cbee67da7",
         "is_verified": false,
-        "line_number": 643
+        "line_number": 642
       },
       {
         "type": "Secret Keyword",
         "filename": "kedro-datasets/tests/partitions/test_partitioned_dataset.py",
         "hashed_secret": "727d8ff68b6b550f2cf6e737b3cad5149c65fe5b",
         "is_verified": false,
-        "line_number": 694
+        "line_number": 693
       },
       {
         "type": "Secret Keyword",
         "filename": "kedro-datasets/tests/partitions/test_partitioned_dataset.py",
         "hashed_secret": "adb5fabe51f5b45e83fdd91b71c92156fec4a63e",
         "is_verified": false,
-        "line_number": 714
+        "line_number": 713
       }
     ],
     "kedro-datasets/tests/plotly/test_html_dataset.py": [
@@ -460,5 +460,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-11T15:35:48Z"
+  "generated_at": "2026-08-12T15:14:07Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -310,35 +310,35 @@
         "filename": "kedro-datasets/tests/partitions/test_partitioned_dataset.py",
         "hashed_secret": "76f747de912e8682e29a23cb506dd5bf0de080d2",
         "is_verified": false,
-        "line_number": 599
+        "line_number": 606
       },
       {
         "type": "Secret Keyword",
         "filename": "kedro-datasets/tests/partitions/test_partitioned_dataset.py",
         "hashed_secret": "9027cc5a2c1321de60a2d71ccde6229d1152d6d3",
         "is_verified": false,
-        "line_number": 600
+        "line_number": 607
       },
       {
         "type": "Secret Keyword",
         "filename": "kedro-datasets/tests/partitions/test_partitioned_dataset.py",
         "hashed_secret": "5dcbdf371f181b9b7a41a4be7be70f8cbee67da7",
         "is_verified": false,
-        "line_number": 636
+        "line_number": 643
       },
       {
         "type": "Secret Keyword",
         "filename": "kedro-datasets/tests/partitions/test_partitioned_dataset.py",
         "hashed_secret": "727d8ff68b6b550f2cf6e737b3cad5149c65fe5b",
         "is_verified": false,
-        "line_number": 687
+        "line_number": 694
       },
       {
         "type": "Secret Keyword",
         "filename": "kedro-datasets/tests/partitions/test_partitioned_dataset.py",
         "hashed_secret": "adb5fabe51f5b45e83fdd91b71c92156fec4a63e",
         "is_verified": false,
-        "line_number": 707
+        "line_number": 714
       }
     ],
     "kedro-datasets/tests/plotly/test_html_dataset.py": [
@@ -460,5 +460,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-14T13:15:43Z"
+  "generated_at": "2026-08-11T15:35:48Z"
 }

--- a/kedro-datasets/kedro_datasets/partitions/incremental_dataset.py
+++ b/kedro-datasets/kedro_datasets/partitions/incremental_dataset.py
@@ -67,7 +67,7 @@ class IncrementalDataset(PartitionedDataset):
     def __init__(  # noqa: PLR0913
         self,
         *,
-        path: str,
+        path: str | os.PathLike,
         dataset: str | type[AbstractDataset] | dict[str, Any],
         checkpoint: str | dict[str, Any] | None = None,
         filepath_arg: str = "filepath",
@@ -80,7 +80,8 @@ class IncrementalDataset(PartitionedDataset):
         """Creates a new instance of ``IncrementalDataset``.
 
         Args:
-            path: Path to the folder containing partitioned data.
+            path: Path to the folder containing partitioned data. Accepts strings
+                and ``os.PathLike`` objects.
                 If path starts with the protocol (e.g., ``s3://``) then the
                 corresponding ``fsspec`` concrete filesystem implementation will
                 be used. If protocol is not specified,

--- a/kedro-datasets/kedro_datasets/partitions/partitioned_dataset.py
+++ b/kedro-datasets/kedro_datasets/partitions/partitioned_dataset.py
@@ -4,6 +4,7 @@ underlying dataset definition. It also uses `fsspec` for filesystem level operat
 
 from __future__ import annotations
 
+import os
 from collections.abc import Callable
 from copy import deepcopy
 from pathlib import PurePosixPath
@@ -137,7 +138,7 @@ class PartitionedDataset(AbstractDataset[dict[str, Any], dict[str, Callable[[], 
     def __init__(  # noqa: PLR0913
         self,
         *,
-        path: str,
+        path: str | os.PathLike,
         dataset: str | type[AbstractDataset] | dict[str, Any],
         filepath_arg: str = "filepath",
         filename_suffix: str = "",
@@ -151,7 +152,8 @@ class PartitionedDataset(AbstractDataset[dict[str, Any], dict[str, Callable[[], 
         """Creates a new instance of ``PartitionedDataset``.
 
         Args:
-            path: Path to the folder containing partitioned data.
+            path: Path to the folder containing partitioned data. Accepts strings
+                and ``os.PathLike`` objects.
                 If path starts with the protocol (e.g., ``s3://``) then the
                 corresponding ``fsspec`` concrete filesystem implementation will
                 be used. If protocol is not specified,
@@ -200,7 +202,7 @@ class PartitionedDataset(AbstractDataset[dict[str, Any], dict[str, Callable[[], 
 
         super().__init__()
 
-        self._path = path
+        self._path = os.fspath(path)
         self._filename_suffix = filename_suffix
         self._overwrite = overwrite
         self._protocol = infer_storage_options(self._path)["protocol"]

--- a/kedro-datasets/tests/partitions/test_incremental_dataset.py
+++ b/kedro-datasets/tests/partitions/test_incremental_dataset.py
@@ -65,6 +65,12 @@ def dummy_lt_func(value1: str, value2: str):
 
 
 class TestIncrementalDatasetLocal:
+    def test_pathlike_path(self, local_csvs):
+        dataset = IncrementalDataset(path=local_csvs, dataset=DATASET)
+
+        assert dataset._path == os.fspath(local_csvs)
+        assert len(dataset.load()) == 5
+
     def test_load_and_confirm(self, local_csvs, partitioned_data_pandas):
         """Test the standard flow for loading, confirming and reloading
         an IncrementalDataset"""

--- a/kedro-datasets/tests/partitions/test_partitioned_dataset.py
+++ b/kedro-datasets/tests/partitions/test_partitioned_dataset.py
@@ -13,7 +13,7 @@ from moto import mock_aws
 from pandas.testing import assert_frame_equal
 
 from kedro_datasets.pandas import CSVDataset, ParquetDataset
-from kedro_datasets.partitions import PartitionedDataset
+from kedro_datasets.partitions import IncrementalDataset, PartitionedDataset
 from kedro_datasets.partitions.partitioned_dataset import KEY_PROPAGATION_WARNING
 
 
@@ -61,6 +61,13 @@ class FakeDataset:  # pylint: disable=too-few-public-methods
 
 
 class TestPartitionedDatasetLocal:
+    @pytest.mark.parametrize("dataset_cls", [PartitionedDataset, IncrementalDataset])
+    def test_pathlike_path(self, dataset_cls, local_csvs):
+        dataset = dataset_cls(path=local_csvs, dataset="pandas.CSVDataset")
+
+        assert dataset._path == os.fspath(local_csvs)
+        assert len(dataset.load()) == 5
+
     @pytest.mark.parametrize("dataset", ["pandas.ParquetDataset", ParquetDataset])
     def test_repr(self, dataset):
         pds = PartitionedDataset(path="", dataset=dataset)

--- a/kedro-datasets/tests/partitions/test_partitioned_dataset.py
+++ b/kedro-datasets/tests/partitions/test_partitioned_dataset.py
@@ -13,7 +13,7 @@ from moto import mock_aws
 from pandas.testing import assert_frame_equal
 
 from kedro_datasets.pandas import CSVDataset, ParquetDataset
-from kedro_datasets.partitions import IncrementalDataset, PartitionedDataset
+from kedro_datasets.partitions import PartitionedDataset
 from kedro_datasets.partitions.partitioned_dataset import KEY_PROPAGATION_WARNING
 
 
@@ -61,9 +61,8 @@ class FakeDataset:  # pylint: disable=too-few-public-methods
 
 
 class TestPartitionedDatasetLocal:
-    @pytest.mark.parametrize("dataset_cls", [PartitionedDataset, IncrementalDataset])
-    def test_pathlike_path(self, dataset_cls, local_csvs):
-        dataset = dataset_cls(path=local_csvs, dataset="pandas.CSVDataset")
+    def test_pathlike_path(self, local_csvs):
+        dataset = PartitionedDataset(path=local_csvs, dataset="pandas.CSVDataset")
 
         assert dataset._path == os.fspath(local_csvs)
         assert len(dataset.load()) == 5


### PR DESCRIPTION
## Description

Closes the Partitions subtask of #1316 and #1317.

`PartitionedDataset` and `IncrementalDataset` now accept `os.PathLike` paths in their public annotations and documentation. The shared partition path is normalized with `os.fspath()`, so both dataset types can safely use `pathlib.Path` values throughout their existing string-based path handling.

## Development notes

Added a regression test that exercises both partition dataset classes with a `pathlib.Path`, verifies the normalized path, and loads all five fixture partitions.

Validation:

- `../.venv/bin/python -m pytest tests/partitions/test_partitioned_dataset.py tests/partitions/test_incremental_dataset.py -q --no-cov` — 192 passed
- `.venv/bin/ruff check kedro-datasets/kedro_datasets/partitions/partitioned_dataset.py kedro-datasets/kedro_datasets/partitions/incremental_dataset.py kedro-datasets/tests/partitions/test_partitioned_dataset.py` — passed
- `.venv/bin/ruff format --check kedro-datasets/kedro_datasets/partitions/partitioned_dataset.py kedro-datasets/kedro_datasets/partitions/incremental_dataset.py kedro-datasets/tests/partitions/test_partitioned_dataset.py` — passed
- `.venv/bin/black --check kedro-datasets/kedro_datasets/partitions/partitioned_dataset.py kedro-datasets/kedro_datasets/partitions/incremental_dataset.py kedro-datasets/tests/partitions/test_partitioned_dataset.py` — passed
- `../.venv/bin/mypy kedro_datasets/partitions/partitioned_dataset.py kedro_datasets/partitions/incremental_dataset.py --ignore-missing-imports` — passed

## Developer Certificate of Origin

- [x] I certify that this contribution is in accordance with the Developer Certificate of Origin. The commit includes a `Signed-off-by` line.

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress — N/A; this is ready for review.
- [x] Updated the documentation to reflect the code changes
- [ ] Updated `jsonschema/kedro-catalog-X.XX.json` if necessary — N/A; no catalog schema changes.
- [ ] Added a description of this change in the relevant `RELEASE.md` file — N/A for this narrowly scoped dataset subtask.
- [x] Added tests to cover my changes
- [ ] Received approvals from at least half of the TSC (required for adding a new, non-experimental dataset) — N/A; no dataset was added.
