### PR TITLE
feat(datasets): add PathLike support for Redis keys

### DIFF
--- a/kedro-datasets/RELEASE.md
+++ b/kedro-datasets/RELEASE.md
@@ -4,7 +4,9 @@
 ## Breaking changes
 ## Breaking changes to experimental datasets
 ## Bug fixes and other changes
+- Added `os.PathLike` support for `redis.PickleDataset` keys.
 ## Community contributions
+- [akira-in-tech](https://github.com/akira-in-tech)
 
 # Release 9.6.0
 

--- a/kedro-datasets/kedro_datasets/redis/redis_dataset.py
+++ b/kedro-datasets/kedro_datasets/redis/redis_dataset.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import importlib
 import os
 from copy import deepcopy
+from pathlib import PurePath
 from typing import Any
 
 import redis
@@ -143,7 +144,7 @@ class PickleDataset(AbstractDataset[Any, Any]):
 
         self._backend = backend
 
-        self._key = os.fspath(key) if isinstance(key, os.PathLike) else key
+        self._key = PurePath(key).as_posix() if isinstance(key, os.PathLike) else key
 
         self.metadata = metadata
 

--- a/kedro-datasets/kedro_datasets/redis/redis_dataset.py
+++ b/kedro-datasets/kedro_datasets/redis/redis_dataset.py
@@ -64,7 +64,7 @@ class PickleDataset(AbstractDataset[Any, Any]):
     def __init__(  # noqa: PLR0913
         self,
         *,
-        key: str,
+        key: str | os.PathLike,
         backend: str = "pickle",
         load_args: dict[str, Any] | None = None,
         save_args: dict[str, Any] | None = None,
@@ -86,7 +86,8 @@ class PickleDataset(AbstractDataset[Any, Any]):
             * `torch`
 
         Args:
-            key: The key to use for saving/loading object to Redis.
+            key: The key to use for saving/loading object to Redis. Can be a
+                string or a PathLike object.
             backend: Backend to use, must be an import path to a module which satisfies the
                 ``pickle`` interface. That is, contains a `loads` and `dumps` function.
                 Defaults to 'pickle'.
@@ -142,7 +143,7 @@ class PickleDataset(AbstractDataset[Any, Any]):
 
         self._backend = backend
 
-        self._key = key
+        self._key = os.fspath(key) if isinstance(key, os.PathLike) else key
 
         self.metadata = metadata
 

--- a/kedro-datasets/tests/redis/test_redis_dataset.py
+++ b/kedro-datasets/tests/redis/test_redis_dataset.py
@@ -2,6 +2,7 @@
 
 import importlib
 import pickle
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
@@ -59,6 +60,31 @@ def pickle_dataset(mocker, key, backend, load_args, save_args, redis_args):
 
 
 class TestPickleDataset:
+    def test_pathlike_key(
+        self,
+        mocker,
+        backend,
+        dummy_object,
+        serialised_dummy_object,
+    ):
+        """Test that os.PathLike keys are normalized for Redis operations."""
+        key = Path("namespace") / "key"
+        redis_db = mocker.MagicMock()
+        redis_db.exists.return_value = True
+        redis_db.get.return_value = serialised_dummy_object
+        mocker.patch("redis.StrictRedis.from_url", return_value=redis_db)
+
+        dataset = PickleDataset(key=key, backend=backend)
+        dataset.save(dummy_object)
+        loaded = dataset.load()
+
+        redis_key = str(key)
+        redis_db.set.assert_called_once_with(redis_key, serialised_dummy_object)
+        redis_db.exists.assert_called_once_with(redis_key)
+        redis_db.get.assert_called_once_with(redis_key)
+        assert_frame_equal(loaded, dummy_object)
+        assert dataset._describe()["key"] == redis_key
+
     @pytest.mark.parametrize(
         "key,backend,load_args,save_args",
         [

--- a/kedro-datasets/tests/redis/test_redis_dataset.py
+++ b/kedro-datasets/tests/redis/test_redis_dataset.py
@@ -2,7 +2,7 @@
 
 import importlib
 import pickle
-from pathlib import Path
+from pathlib import PureWindowsPath
 
 import numpy as np
 import pandas as pd
@@ -68,7 +68,7 @@ class TestPickleDataset:
         serialised_dummy_object,
     ):
         """Test that os.PathLike keys are normalized for Redis operations."""
-        key = Path("namespace") / "key"
+        key = PureWindowsPath("namespace") / "key"
         redis_db = mocker.MagicMock()
         redis_db.exists.return_value = True
         redis_db.get.return_value = serialised_dummy_object
@@ -78,7 +78,7 @@ class TestPickleDataset:
         dataset.save(dummy_object)
         loaded = dataset.load()
 
-        redis_key = str(key)
+        redis_key = "namespace/key"
         redis_db.set.assert_called_once_with(redis_key, serialised_dummy_object)
         redis_db.exists.assert_called_once_with(redis_key)
         redis_db.get.assert_called_once_with(redis_key)


### PR DESCRIPTION
## Description

Adds `os.PathLike` support for `redis.PickleDataset` keys, covering the Redis dataset slice of #1316 and #1317.

`redis-py` does not encode `PathLike` objects directly, so the dataset now normalizes them with `PurePath.as_posix()` at its input boundary. This keeps Redis keys consistent across operating systems while preserving existing string key behavior.

## Development notes

- Expands the public `key` annotation and docstring to accept `str | os.PathLike`.
- Normalizes path-like keys once during dataset initialization using POSIX separators.
- Adds regression coverage for `save`, `load`, `exists`, and `_describe` with a `PureWindowsPath` key.
- Adds the change and contributor entry to the upcoming release notes.

Verified with:

```text
python -m pytest -q tests/redis/test_redis_dataset.py --no-cov
14 passed

python -m ruff check kedro_datasets/redis/redis_dataset.py tests/redis/test_redis_dataset.py
All checks passed!

python -m black --check kedro_datasets/redis/redis_dataset.py tests/redis/test_redis_dataset.py
2 files would be left unchanged.

python -m mypy kedro_datasets/redis/redis_dataset.py --ignore-missing-imports
Success: no issues found in 1 source file
```

## Developer Certificate of Origin

All commits include the required `Signed-off-by` trailer.

## Checklist

- [x] Opened this PR as a draft for maintainer review
- [x] Updated the documentation to reflect the code changes
- [x] No catalog JSON schema change is required
- [x] Added a description of this change in `kedro-datasets/RELEASE.md`
- [x] Added tests to cover the changes
- [x] TSC approval for a new dataset is not required because this updates an existing dataset