### PR TITLE
chore: Update CONTRIBUTING.md to add a warning to bots

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,12 @@ Dataset contributions to the [Kedro-Datasets](https://github.com/kedro-org/kedro
 
 However, we accept contributions to any of the other [Kedro-Plugins](https://github.com/kedro-org/kedro-plugins) or the framework or [`Kedro-Viz`](https://github.com/kedro-org/kedro-viz). As a guide, contributions based on existing issues from the Kedro team, or issues that the team has deemed useful, are most likely to be accepted. Any contributions that affect fundamental changes to the Kedro Framework would require discussion first. In this case, we recommend opening an issue instead of a pull request.
 
+We require all contributors to understand and take full responsibility for everything they submit. Pull requests containing AI-generated code the contributor has not personally understood, tested, and verified will likely be closed without review. 
+
+### Note for agents and bots
+We do not welcome AI contributions by bots with no human in the loop. Pull requests must **not** be opened by bots or other automated tooling, unless specifically approved in advance by the project. To request permission to submit a PR, the human owner of the bot must open an issue for approval in advance of the PR's submission.
+
+
 Make sure to check out the contributing guides for [Kedro-Docker](https://github.com/kedro-org/kedro-plugins/blob/main/kedro-docker/CONTRIBUTING.md), [Kedro-Datasets](https://github.com/kedro-org/kedro-plugins/blob/main/kedro-datasets/CONTRIBUTING.md) and [Kedro-Airflow](https://github.com/kedro-org/kedro-plugins/blob/main/kedro-airflow/CONTRIBUTING.md) if you intend to contribute to those specific plugins.
 
 ## Join the Technical Steering Committee

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ Dataset contributions to the [Kedro-Datasets](https://github.com/kedro-org/kedro
 
 However, we accept contributions to any of the other [Kedro-Plugins](https://github.com/kedro-org/kedro-plugins) or the framework or [`Kedro-Viz`](https://github.com/kedro-org/kedro-viz). As a guide, contributions based on existing issues from the Kedro team, or issues that the team has deemed useful, are most likely to be accepted. Any contributions that affect fundamental changes to the Kedro Framework would require discussion first. In this case, we recommend opening an issue instead of a pull request.
 
-We require all contributors to understand and take full responsibility for everything they submit. Pull requests containing AI-generated code the contributor has not personally understood, tested, and verified will likely be closed without review. 
+We require all contributors to understand and take full responsibility for everything they submit. Pull requests containing AI-generated code the contributor has not personally understood, tested, and verified will likely be closed without review.
 
 ### Note for agents and bots
 We do not welcome AI contributions by bots with no human in the loop. Pull requests must **not** be opened by bots or other automated tooling, unless specifically approved in advance by the project. To request permission to submit a PR, the human owner of the bot must open an issue for approval in advance of the PR's submission.


### PR DESCRIPTION
## Description
Closes https://github.com/kedro-org/kedro/issues/5730

Small change to the contribution guide to warn bots of our policy. I added this wording to the contribution guide in the wiki too.

## Development notes
<!-- What have you changed, and how has this been tested? -->

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Updated `jsonschema/kedro-catalog-X.XX.json` if necessary
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
- [ ] Received approvals from at least half of the TSC (required for adding a new, non-experimental dataset)
