### PR TITLE
feat(telemetry): Count validator declarations in project statistics

### DIFF
--- a/kedro-telemetry/RELEASE.md
+++ b/kedro-telemetry/RELEASE.md
@@ -1,4 +1,5 @@
 # Upcoming release
+* Added validator declaration counts to the project statistics event: `number_of_validated_datasets` and per-library `validator_type_count.*`, with user-defined validators reported as `custom`.
 * Added `kedro_telemetry.api.send_telemetry_event`, a public helper other Kedro plugins can call to send usage events through the standard consent flow — opt-out settings (`DO_NOT_TRACK`, `KEDRO_DISABLE_TELEMETRY`, `.telemetry`) apply to these events exactly as they do to built-in ones.
 * Added support for `kedro skills` usage events sent by the [`kedro-skills`](https://github.com/kedro-org/kedro-skills) plugin via the new helper: `kedro_skills_install` (skill id, target IDEs, `--all` flag, success), `kedro_skills_update` (number of skills updated, drift detected, success) and `kedro_skills_uninstall` (skill id).
 

--- a/kedro-telemetry/kedro_telemetry/plugin.py
+++ b/kedro-telemetry/kedro_telemetry/plugin.py
@@ -57,6 +57,12 @@ PYPROJECT_CONFIG_NAME = "pyproject.toml"
 UNDEFINED_PACKAGE_NAME = "undefined_package_name"
 MISSING_USER_IDENTITY = "missing_user_identity"
 
+# Validator class paths from these top-level packages are public library names;
+# anything else is user-defined and reported as "custom".
+_PUBLIC_VALIDATOR_NAMESPACES = frozenset(
+    {"pandera", "pydantic", "great_expectations", "kedro", "kedro_datasets"}
+)
+
 logger = logging.getLogger(__name__)
 
 
@@ -368,6 +374,21 @@ def _format_project_statistics_data(
     # can be aggregated/grouped in Heap dashboards.
     for type_name, count in dataset_type_counts.items():
         properties[f"dataset_type_count.{type_name}"] = count
+
+    # Validator declarations, exposed by the public `validator_specs` property
+    # on `kedro >= 1.6` catalogs. Only public library names are reported;
+    # user-defined validators are bucketed as "custom".
+    validator_specs = getattr(catalog, "validator_specs", None)
+    if validator_specs:
+        properties["number_of_validated_datasets"] = len(validator_specs)
+        validator_type_counts: dict[str, int] = {}
+        for spec in validator_specs.values():
+            class_path = getattr(spec, "class_path", "") or ""
+            top_level = class_path.split(".")[0]
+            key = top_level if top_level in _PUBLIC_VALIDATOR_NAMESPACES else "custom"
+            validator_type_counts[key] = validator_type_counts.get(key, 0) + 1
+        for type_name, count in validator_type_counts.items():
+            properties[f"validator_type_count.{type_name}"] = count
     return properties
 
 

--- a/kedro-telemetry/tests/test_plugin.py
+++ b/kedro-telemetry/tests/test_plugin.py
@@ -770,6 +770,51 @@ class TestKedroTelemetryHook:
         # dataset_type_count.* properties should be emitted at all.
         assert not any(k.startswith("dataset_type_count.") for k in result)
 
+    def test_validator_specs_counted_with_pii_bucketing(
+        self, pipeline_fixture, project_pipelines
+    ):
+        class Spec:
+            def __init__(self, class_path):
+                self.class_path = class_path
+
+        catalog = MagicMock()
+        catalog.keys.return_value = ["datasetA", "datasetB", "datasetC"]
+        catalog.get_type.side_effect = (
+            lambda ds_name: "kedro.io.memory_dataset.MemoryDataset"
+        )
+        catalog.validator_specs = {
+            "datasetA": Spec("pandera.pandas.DataFrameModel"),
+            "datasetB": Spec("my_project.schemas.CompaniesSchema"),
+            "datasetC": Spec("my_project.validators.check_rows"),
+        }
+
+        result = _format_project_statistics_data(
+            catalog, pipeline_fixture, project_pipelines
+        )
+
+        validated_cnt, pandera_cnt, custom_cnt = 3, 1, 2
+        assert result["number_of_validated_datasets"] == validated_cnt
+        assert result["validator_type_count.pandera"] == pandera_cnt
+        assert result["validator_type_count.custom"] == custom_cnt
+        assert not any("my_project" in key for key in result)
+
+    def test_catalog_without_validator_support_emits_no_validator_fields(
+        self, pipeline_fixture, project_pipelines
+    ):
+        catalog = MagicMock()
+        catalog.keys.return_value = ["datasetA"]
+        catalog.get_type.side_effect = (
+            lambda ds_name: "kedro.io.memory_dataset.MemoryDataset"
+        )
+        del catalog.validator_specs
+
+        result = _format_project_statistics_data(
+            catalog, pipeline_fixture, project_pipelines
+        )
+
+        assert "number_of_validated_datasets" not in result
+        assert not any(k.startswith("validator_type_count.") for k in result)
+
     def test_new_catalog_with_keys_method(self, pipeline_fixture, project_pipelines):
         # catalog.list() was replaces with catalog.keys() in `kedro >= 1.0`
         catalog = MagicMock()


### PR DESCRIPTION
## Description
Kedro's next release adds dataset validation (kedro-org/kedro#5677): datasets can declare a validator in the catalog. This adds usage counts for that feature to the existing "Kedro Project Statistics" event so we can track adoption from the first release.

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [ ] Updated `jsonschema/kedro-catalog-X.XX.json` if necessary
- [x] Added a description of this change in the relevant `RELEASE.md` file
- [x] Added tests to cover my changes
- [ ] Received approvals from at least half of the TSC (required for adding a new, non-experimental dataset)
